### PR TITLE
Make install.py's compiler detection cascade and Lmod-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,16 +50,39 @@ the identical compiler/BLAS/LAPACK configuration resolved in phase 1.
 `pybind11` is a hard requirement (auto-installed via `pip` into the
 current interpreter if missing, since the pybind11 extension is the only
 DMRG backend besides ED). The compiler is auto-detected rather than
-defaulting to plain `g++`:
-`installtk/cppversion.py::find_conda_compiler()` looks for a
-conda-provided compiler (e.g. the `gxx_linux-64` package) next to the
-running interpreter when it's a conda Python, and uses that same compiler
-for *both* the ITensor build and the pybind extension link (`--gpp`
-overrides this). This matters because the extension is loaded into the
-same process as conda's own numpy/scipy, which bundle their own
-libstdc++ -- building against the system compiler instead has
-reproducibly segfaulted in the past (see the long comment in
-`mpscpp2/Makefile`). `installtk/blaslapack.py::find_working_config()`
+defaulting to plain `g++`, via a cascade of candidates rather than a
+single guess: `installtk/requirements.py::_compiler_candidates()` yields
+a conda-provided compiler first when running under a conda Python
+(`installtk/cppversion.py::find_conda_compiler()` looks for one, e.g. the
+`gxx_linux-64` package, next to the running interpreter -- preferred
+because the extension is loaded into the same process as conda's own
+numpy/scipy, which bundle their own libstdc++, and building against the
+system compiler instead has reproducibly segfaulted in the past, see the
+long comment in `mpscpp2/Makefile`), then falls back to the system
+`g++`/`c++` on PATH if that candidate doesn't actually work (`--gpp`
+overrides the whole cascade with a single hard choice). Each candidate is
+verified for real, not just checked for existence: besides an actual
+trial compile+link (`cppversion.trial_compile()`),
+`cppversion.backend_missing()` proactively asks the driver
+(`gpp -print-prog-name=cc1plus`) whether it can even locate its own
+compilation backend, since `--version`/`shutil.which()` both pass for a
+compiler binary that's present but incomplete. This isn't hypothetical:
+confirmed directly on Aalto's Triton cluster, whose `scicomp-python-env`
+module ships a conda-style Python distribution with exactly such a
+broken `x86_64-conda-linux-gnu-g++` wrapper (no matching `cc1plus`
+installed) -- the cascade transparently falls back to Triton's login-node
+system compiler in that case and prints a note about it.
+`installtk/cppversion.py::lmod_state()` detects environment-module
+systems (Lmod, via `$LMOD_CMD`/`$MODULEPATH`) so failure messages can
+suggest `module load ...` instead of the sudo-based apt-get/brew hints
+that are meaningless (no sudo) or simply wrong on a cluster; `check()`
+also prints a reminder to reload the same modules/conda environment used
+at install time in any later session that imports `dmrgpy`, since the
+compiled extension depends on them being present again at import time.
+`install.py --doctor` runs only this requirement-checking phase and
+exits, without starting the multi-minute ITensor build -- useful for
+diagnosing a cluster environment or reporting a bug.
+`installtk/blaslapack.py::find_working_config()`
 similarly tries several LAPACK/BLAS candidates (conda's own libs, system
 `-lblas -llapack`, OpenBLAS, and a Debian/Ubuntu-multiarch workaround that
 asks the system compiler where it actually finds `libblas.so`/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,33 @@ If LAPACK/BLAS can't be found automatically, point the script at OpenBLAS explic
 python install.py --openblas --openblas_libdir=/path/to/openblas/lib --openblas_includedir=/path/to/openblas/include
 ```
 
+To check what the script would use (compiler, BLAS/LAPACK) without
+actually running the several-minutes-long ITensor build, use
+
+```bash
+python install.py --doctor
+```
+
+### HPC clusters with environment modules (e.g. Aalto's Triton) ###
+
+On clusters using Lmod/environment modules, no C++ compiler may be on
+PATH at all until a module is loaded, e.g. on Triton:
+
+```bash
+module load <stack> gcc/<version>   # e.g. triton/2024.1-gcc gcc/12.3.0
+python install.py
+```
+
+If you're using a module-provided Python distribution (e.g. Triton's
+`scicomp-python-env`), its bundled conda-style compiler wrapper can
+sometimes be present but broken (missing its `cc1plus` backend) -- if so,
+`install.py` automatically falls back to the system/module-loaded
+compiler and prints a note about it. Whichever compiler ends up being
+used, and whichever modules/conda environment were loaded at install
+time, must be loaded/activated again in every later session (including
+job scripts) that imports `dmrgpy` -- the compiled extension depends on
+them.
+
 Alternatively, in case you just want to use the Julia version,
 execute the script 
 

--- a/install.py
+++ b/install.py
@@ -40,12 +40,24 @@ parser.add_argument("--itensor-version", "--itensor_version",
              "(mpscpp3, itensor_version=3), both = compile both, "
              "one after the other (default: %(default)s, matching the "
              "default backend in Python).")
+parser.add_argument("--doctor", "--check-only", dest="doctor",
+        action="store_true", default=False,
+        help="Only run the requirement checks (compiler, LAPACK/BLAS, "
+             "pybind11) and report what would be used, without compiling "
+             "anything. Useful for diagnosing a broken environment (e.g. "
+             "an HPC cluster) before committing to the "
+             "several-minutes-long ITensor build.")
 args = parser.parse_args()
 
 versions = [2, 3] if args.itensor_version == "both" else [int(args.itensor_version)]
 
 from installtk import requirements
 config = requirements.check(args) # phase 1: check everything first
+
+if args.doctor:
+    print("### --doctor: requirements OK, stopping before compilation ###")
+    import sys
+    sys.exit(0)
 
 from installtk import install2
 for version in versions:

--- a/installtk/cppversion.py
+++ b/installtk/cppversion.py
@@ -74,6 +74,46 @@ def find_conda_compiler(python_exe=None):
     return None
 
 
+def backend_missing(gpp, prog="cc1plus"):
+    """True if `gpp`'s own driver can't locate its compilation backend
+    (`cc1plus`, the actual C++ compiler -- `gpp` itself is just a driver
+    that execs it). Uses `gpp -print-prog-name=`, the same lookup gcc/clang
+    use internally, so this is a real check, not a guess -- and it's much
+    cheaper and more specific than waiting for a full trial_compile() to
+    fail with a raw "posix_spawnp: No such file or directory".
+
+    This exists because `--version` and `shutil.which()` both pass for a
+    compiler that's just a driver front-end with no matching backend
+    package installed -- confirmed on Aalto's Triton cluster, where the
+    `scicomp-python-env` module's bundled conda-style
+    `x86_64-conda-linux-gnu-g++` wrapper resolves and runs `--version`
+    fine but has no `cc1plus` behind it.
+    """
+    try:
+        out = subprocess.run([gpp, "-print-prog-name="+prog],
+                capture_output=True, text=True, timeout=15).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if not out or out == prog:
+        # gcc/clang echo the bare program name back unchanged when they
+        # can't resolve it to a path at all
+        return True
+    return not os.path.isfile(out)
+
+
+def lmod_state():
+    """Return (lmod_present, loaded_module_names) using the environment
+    variables Lmod itself sets ($LMOD_CMD/$MODULEPATH, $LOADEDMODULES).
+    Many HPC clusters (e.g. Aalto's Triton) provide no compiler at all on
+    PATH until a module is loaded -- detecting this lets error messages
+    point at 'module load ...' instead of the apt-get/brew hints that are
+    meaningless (no sudo) or simply wrong on a cluster."""
+    present = bool(os.environ.get("LMOD_CMD")) or \
+            bool(os.environ.get("MODULEPATH"))
+    loaded = [m for m in os.environ.get("LOADEDMODULES", "").split(":") if m]
+    return present, loaded
+
+
 def trial_compile(gpp, extra_flags=(), link_flags=(), source=None):
     """Try to compile (and link) a small C++ program with `gpp`, using
     `extra_flags` for compilation and `link_flags` for linking. Returns

--- a/installtk/requirements.py
+++ b/installtk/requirements.py
@@ -50,55 +50,118 @@ def _check_make():
               "  Mac:           xcode-select --install")
 
 
-def _resolve_compiler(gpp_arg, check_gpp, is_conda, python_exe):
+def _compiler_candidates(gpp_arg, is_conda, python_exe):
+    """Yield (label, path) compiler candidates to try, in priority order.
+    An explicit --gpp is a hard override, not a suggestion to cascade past,
+    so it's the only candidate yielded when given.
+
+    Otherwise a conda-provided compiler (if any) is tried first -- to keep
+    a single, consistent libstdc++/BLAS ABI with conda's own numpy/scipy,
+    see find_conda_compiler()'s docstring -- but the system compiler on
+    PATH is *also* offered as a fallback candidate, since a conda-adjacent
+    compiler can itself be broken: e.g. Aalto Triton's `scicomp-python-env`
+    module ships a conda-style Python distribution whose bundled
+    `x86_64-conda-linux-gnu-g++` wrapper can't find its own `cc1plus`
+    (confirmed directly), while plain system `g++` on that same login node
+    works fine without any module."""
     if gpp_arg is not None:
-        gpp = gpp_arg
-    else:
-        conda_gpp = cppversion.find_conda_compiler(python_exe) if is_conda \
-                else None
-        if conda_gpp is not None:
-            gpp = conda_gpp
-        elif is_conda:
-            print("Detected a conda Python ("+python_exe+") but no "
-                  "conda-provided C++ compiler was found next to it.")
-            print("This risks a crash once the compiled extension is "
-                  "loaded alongside conda's own numpy/scipy (they bundle "
-                  "their own libstdc++). Recommended fix:")
-            print("  conda install -c conda-forge gxx_linux-64   "
-                  "# Linux")
-            print("  conda install -c conda-forge clangxx_osx-64 "
-                  "# Mac")
-            print("Falling back to the system compiler for now.\n")
-            gpp = "g++"
-        else:
-            gpp = "g++"
+        yield "explicit --gpp", gpp_arg
+        return
+    conda_gpp = cppversion.find_conda_compiler(python_exe) if is_conda \
+            else None
+    if conda_gpp is not None:
+        yield "conda-provided compiler", conda_gpp
+    for name in ("g++", "c++"):
+        path = shutil.which(name)
+        if path:
+            yield "system "+name, path
+            break
 
+
+def _try_compiler(gpp, check_gpp):
+    """Check a single compiler candidate without exiting on failure, so
+    the caller can cascade to the next one. Returns (ok, reason)."""
     if not shutil.which(gpp) and not os.path.isfile(gpp):
-        _fail("C++ compiler '"+gpp+"' was not found.\n"
-              "Install a GNU C++ compiler (version 6 or higher), e.g.:\n"
-              "  Ubuntu/Debian: sudo apt-get install g++\n"
-              "  Mac:           xcode-select --install\n"
-              "  conda:         conda install -c conda-forge gxx_linux-64\n"
-              "then rerun with 'python install.py --gpp=<compiler>' if "
-              "needed.")
+        return False, "not found"
+    if not check_gpp:
+        return True, None
+    version = cppversion.compiler_version(gpp)
+    if version is None or not cppversion.correct_version(gpp):
+        return False, ("could not be used or is too old (found version "
+                +str(version)+", need >= 6)")
+    if cppversion.backend_missing(gpp):
+        return False, ("the compiler driver can't locate its own cc1plus "
+                "backend -- a partial/broken toolchain, not a version or "
+                "PATH problem (common for module-provided Python "
+                "distributions that bundle a compiler wrapper without the "
+                "matching backend package)")
+    ok, out = cppversion.trial_compile(gpp)
+    if not ok:
+        return False, "failed to compile a trivial test program:\n"+out
+    return True, None
 
-    if check_gpp:
-        version = cppversion.compiler_version(gpp)
-        if version is None or not cppversion.correct_version(gpp):
-            _fail("C++ compiler '"+gpp+"' could not be used or is too old "
-                  "(found version "+str(version)+", need >= 6).\n"
-                  "Install a newer GNU C++ compiler, e.g.:\n"
-                  "  Ubuntu/Debian: sudo add-apt-repository "
-                  "ppa:ubuntu-toolchain-r/test -y && sudo apt-get update -y "
-                  "&& sudo apt-get install g++-11 -y\n"
-                  "  conda:         conda install -c conda-forge "
-                  "gxx_linux-64\n"
-                  "then rerun with 'python install.py --gpp=<compiler>'.")
-        ok, out = cppversion.trial_compile(gpp)
-        if not ok:
-            _fail("C++ compiler '"+gpp+"' failed to compile a trivial "
-                  "test program:\n"+out)
-    return gpp
+
+def _environment_hints(is_conda, python_exe):
+    lmod_present, loaded = cppversion.lmod_state()
+    hints = []
+    if lmod_present:
+        hint = ("This looks like an HPC cluster using environment modules "
+                "(Lmod). No usable C++ compiler may be on PATH until one "
+                "is loaded, e.g. on Aalto's Triton:\n"
+                "  module avail gcc\n"
+                "  module load <stack> gcc/<version>   "
+                "# e.g. triton/2024.1-gcc gcc/12.3.0\n"
+                "then rerun this script in the same shell (or pass "
+                "--gpp=$(which g++) once one is loaded).")
+        if loaded:
+            hint += "\nCurrently loaded modules: "+", ".join(loaded)
+        hints.append(hint)
+    if is_conda:
+        conda_prefix = os.environ.get("CONDA_PREFIX")
+        writable = bool(conda_prefix) and os.access(conda_prefix, os.W_OK)
+        if writable:
+            hints.append("Your conda environment can install its own "
+                    "compiler:\n"
+                    "  conda install -c conda-forge gxx_linux-64   "
+                    "# Linux\n"
+                    "  conda install -c conda-forge clangxx_osx-64 "
+                    "# Mac")
+        else:
+            hints.append("Note: "+python_exe+" comes from a read-only or "
+                    "centrally-managed environment (e.g. an HPC module), "
+                    "so 'conda install' won't work here -- use --gpp to "
+                    "point at a working compiler instead (a module-loaded "
+                    "one, or the system compiler).")
+    if not lmod_present and not is_conda:
+        hints.append("  Ubuntu/Debian: sudo apt-get install g++\n"
+                "  Mac:           xcode-select --install")
+    return "\n".join(hints)
+
+
+def _resolve_compiler(gpp_arg, check_gpp, is_conda, python_exe):
+    candidates = list(_compiler_candidates(gpp_arg, is_conda, python_exe))
+    if not candidates:
+        _fail("No C++ compiler was found on PATH.\n"
+              +_environment_hints(is_conda, python_exe)
+              +"\nOr rerun with 'python install.py --gpp=<compiler>'.")
+
+    tried = []
+    for label, gpp in candidates:
+        ok, reason = _try_compiler(gpp, check_gpp)
+        if ok:
+            if tried:
+                print("Note: "+tried[-1][0]+" ("+tried[-1][1]+") did not "
+                      "work, falling back to "+label+" ("+gpp+").")
+            return gpp
+        tried.append((label, gpp, reason))
+
+    msg = "No working C++ compiler found. Tried:\n"
+    for label, gpp, reason in tried:
+        msg += "  - "+label+" ("+gpp+"): "+reason+"\n"
+    msg += "\n"+_environment_hints(is_conda, python_exe)
+    msg += "\nOr rerun with 'python install.py --gpp=<compiler>' once " \
+            "you have a working one."
+    _fail(msg)
 
 
 def _resolve_blas(gpp, openblas, openblas_libdir, openblas_includedir):
@@ -106,7 +169,7 @@ def _resolve_blas(gpp, openblas, openblas_libdir, openblas_includedir):
             openblas_libdir=openblas_libdir,
             openblas_includedir=openblas_includedir)
     if cfg is None:
-        _fail("Could not find a working LAPACK/BLAS installation "
+        msg = ("Could not find a working LAPACK/BLAS installation "
               "(tried system LAPACK/BLAS, conda's own libs, OpenBLAS in "
               "common locations, and the compiler's own multiarch lib "
               "dir).\nInstall LAPACK/BLAS, e.g.:\n"
@@ -119,6 +182,17 @@ def _resolve_blas(gpp, openblas, openblas_libdir, openblas_includedir):
               "libblas\n"
               "or pass --openblas_libdir/--openblas_includedir explicitly "
               "if it's installed in a non-standard location.")
+        lmod_present, _ = cppversion.lmod_state()
+        if lmod_present:
+            msg += ("\nOn an HPC cluster, LAPACK/BLAS is usually provided "
+                  "by a module too, e.g.:\n"
+                  "  module avail openblas\n"
+                  "  module load <stack> openblas/<version>\n"
+                  "then pass its lib/include dirs explicitly with "
+                  "--openblas --openblas_libdir=... "
+                  "--openblas_includedir=... (module-provided libraries "
+                  "usually aren't on the default linker search path).")
+        _fail(msg)
     print("Using "+cfg["description"])
     return cfg
 
@@ -189,6 +263,17 @@ def check(args):
 
     _check_pybind11(python_exe)
     print("pybind11: found")
+
+    lmod_present, loaded = cppversion.lmod_state()
+    if lmod_present and loaded:
+        print("Loaded modules: "+", ".join(loaded))
+        print("Remember to load these same modules whenever you use "
+              "dmrgpy later (e.g. in job scripts) -- the compiled "
+              "extension depends on them being present at import time too.")
+    if is_conda:
+        print("Conda/mamba environment: "+(conda_prefix or python_exe))
+        print("Remember to activate this same environment whenever you "
+              "use dmrgpy later.")
 
     print("### All requirements satisfied, proceeding to compilation ###\n")
 


### PR DESCRIPTION
## Summary
- Fixes the reported `cc1plus not found` failure on Aalto's Triton cluster: `install.py` picked a single compiler candidate and hard-failed if it didn't work. On Triton, the `scicomp-python-env` module ships a conda-style Python distribution whose bundled `x86_64-conda-linux-gnu-g++` wrapper passes `--version` but can't locate its own `cc1plus` backend (confirmed directly from the user's real error output).
- Compiler resolution now cascades through candidates (conda-provided compiler first, then system `g++`/`c++`) mirroring the pattern `blaslapack.py` already used for BLAS, verifying each one with a real `-print-prog-name=cc1plus` check (cheap, precise) plus the existing trial compile, and transparently falling back with a printed note when one candidate is broken.
- Failure messages are now environment-aware: detect Lmod (`module load ...` guidance) and read-only/module-provided conda environments (skip the useless `conda install` suggestion), instead of always showing apt-get/brew/conda hints that don't apply on a cluster.
- Added `install.py --doctor` to run just the requirement checks and report what would be used, without waiting through the multi-minute ITensor build — useful for diagnosing a cluster environment.
- Updated `README.md` (new HPC/Lmod section) and `CLAUDE.md` to document the new cascading/Lmod-aware behavior.

## Test plan
- [x] `python3 install.py --doctor` on a plain Linux laptop (conda Python, system BLAS) — still resolves the same conda compiler as before, doctor mode exits cleanly before compiling.
- [x] Simulated the exact Triton failure with a fake broken conda-style `g++` wrapper (passes `--version`, fails `-print-prog-name=cc1plus`) — cascade correctly falls back to system `g++` with a printed note.
- [x] Simulated the full Triton failure mode (Lmod env vars set, no working compiler anywhere, read-only conda prefix) — failure message correctly shows `module load` guidance and skips the `conda install` suggestion for the read-only env.
- [ ] Not verified on an actual Triton login/compute node (no direct access from this session) — would be good to confirm `python3 install.py` now succeeds there before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)