### PR TITLE
Speed up TD/TDVP dynamical correlator; reimplement CVM in pure Python fixing blow-ups

### DIFF
--- a/src/dmrgpy/cvm.py
+++ b/src/dmrgpy/cvm.py
@@ -29,21 +29,85 @@ def dynamical_correlator(self,es=np.linspace(0.,10.0,100),
 
 def cvm_dmrg(self,name="XX",delta=1e-1,e=0.0,**kwargs):
     """
-    Return the dynamical correlator for a single energy, via the
-    in-process pybind11 extension (mpscpp2/chain_session.h's
-    Chain::cvm_dynamical_correlator). Parameter names differ from the C++
-    side's (omega, eta, energy) to match this file's existing naming:
-    e -> omega, delta -> eta, self.e0 -> energy.
+    Return the dynamical correlator for a single energy/frequency using
+    the Correction Vector Method, computed entirely in Python (see
+    cvm_correction_vector below) rather than via the in-process pybind11
+    extension's Chain::cvm_dynamical_correlator/bicstab (which is a hand-
+    rolled, unguarded BiCGSTAB on the non-Hermitian z-H operator, prone to
+    breakdown/blow-up for small eta -- see cvm_correction_vector's
+    docstring). Parameter names differ from the underlying convention
+    (omega, eta, energy) to match this file's existing naming: e -> omega,
+    delta -> eta, self.e0 -> energy.
     """
     name = operatornames.str2MO(self,name,**kwargs)
     A = name[0]
     B = name[1]
-    self._session.set_sweep_params(self.maxm,self.nsweeps,self.cutoff,self.noise)
+    return cvm_correction_vector(self,A,B,e,delta,
+            tol=self.cvm_tol,max_it=int(self.cvm_nit))
+
+
+def cvm_correction_vector(self,A,B,omega,eta,tol=1e-5,max_it=1000):
+    """
+    Correction Vector Method (Ramasesha; Kuhner & White 1999):
+    -Im<GS|A (omega+E0+i*eta-H)^{-1} B|GS>/pi, computed by solving the
+    Hermitian, positive-definite system
+
+        [(H-omega-E0)^2 + eta^2] xc = -eta * B|GS>
+
+    via conjugate gradient, then recovering the correction vector as
+
+        x = i*xc + (H-omega-E0)/eta * xc = (omega+E0+i*eta-H)^{-1} B|GS>
+
+    This is the same algorithm the ED backend already uses
+    (edtk/timedependent.py::solve_cv), just carried out with MPS algebra
+    (StaticOperator/MPS arithmetic) instead of dense matrices. Because
+    (H-omega-E0)^2+eta^2 is Hermitian positive-definite whenever H is
+    Hermitian, *exact* CG would converge with a monotonically non-increasing
+    residual and no breakdown mode -- unlike the previous direct solve of
+    the non-Hermitian (z-H) system via a hand-rolled BiCGSTAB
+    (Chain::cvm_dynamical_correlator/bicstab in chain_session.h), which had
+    no protection against BiCGSTAB's well-known near-singular breakdown and
+    could blow up. In practice every MPS here is truncated
+    (maxdim=cvm_maxm) at every step, so the residual can still wander
+    non-monotonically (confirmed directly: traced iteration-by-iteration on
+    a 14-site chain) -- CG's breakdown-free guarantee is about avoiding
+    BiCGSTAB's *divide-by-near-zero* failure mode, not about guaranteeing
+    monotonic convergence once every intermediate vector is lossily
+    compressed. To stay robust against that, the correction vector
+    achieving the lowest residual seen so far is tracked and returned
+    (rather than trusting whatever the loop ends on at max_it or an
+    increased residual). Implemented purely with already-exposed Python
+    primitives (self.toMPO()/StaticOperator for a build-once/apply-many
+    MPO, MPS +/-/scalar-* and .dot() for the rest), so no new C++/pybind11
+    bindings and no recompilation are needed to tune this further -- unlike
+    the KPM/TDVP paths, which run their inner loop in C++.
+    """
+    wf0 = self.get_gs() # ground state (cheap/cached; also sets self.e0)
+    self._session.set_sweep_params(self.cvm_maxm,self.nsweeps,self.cutoff,self.noise)
     self._session.set_verbose(self.verbose)
-    self._session.set_mpomaxm(max(self.maxm,self.mpomaxm))
-    return self._session.cvm_dynamical_correlator(
-            A.to_terms(),B.to_terms(),e,delta,self.e0,
-            self.cvm_tol,int(self.cvm_nit))
+    self._session.set_mpomaxm(max(self.cvm_maxm,self.mpomaxm))
+    Hshift = self.toMPO(self.hamiltonian-(self.e0+omega)) # (H-omega-E0), built once
+    def applyA(v): return Hshift*(Hshift*v) + (eta*eta)*v # (H-omega-E0)^2+eta^2
+    b = (-eta)*(B*wf0) # -eta*B|GS>
+    xc = b # initial guess, matches the old bicstab's own x=b start
+    r = b - applyA(xc)
+    p = r
+    rs_old = r.dot(r).real # ||r||^2, real since A is Hermitian PD
+    best_xc,best_res = xc,np.sqrt(abs(rs_old))
+    for k in range(max_it):
+        Ap = applyA(p)
+        alpha = rs_old/p.dot(Ap).real # real: <p|A|p> is real for Hermitian A
+        xc = xc + alpha*p
+        r = r - alpha*Ap
+        rs_new = r.dot(r).real
+        res = np.sqrt(abs(rs_new))
+        if res<best_res: best_xc,best_res = xc,res # guard against truncation-driven non-monotonicity
+        if res<=tol: break
+        p = r + (rs_new/rs_old)*p
+        rs_old = rs_new
+    x = 1j*best_xc + (Hshift*best_xc)*(1./eta) # full correction vector
+    G = wf0.dot(A*x) # <GS|A|x>
+    return -G.imag/np.pi
 
 
 

--- a/src/dmrgpy/manybodychain.py
+++ b/src/dmrgpy/manybodychain.py
@@ -73,6 +73,10 @@ class Many_Body_Chain():
           # evolve_and_measure_dmrg() for the actual dispatch.
       self.cvm_tol = 1e-5 # tolerance for CVM
       self.cvm_nit = 1e3 # iterations for CVM
+      self.cvm_maxm = self.maxm # bond dimension for the CVM correction
+          # vector, independent of the ground state's own maxm (mirrors
+          # kpmmaxm): a correction vector solving [(H-omega)^2+eta^2]xc=b
+          # can need a different entanglement structure than the GS.
       self.kpm_scale = 0.7 # scaling of the spectra for KPM
       self.kpm_accelerate = True # set to true
       self.kpm_n_scale = 3 # scaling factor for the number of polynomials

--- a/src/dmrgpy/timedependent.py
+++ b/src/dmrgpy/timedependent.py
@@ -131,12 +131,33 @@ def evolution_ABA(self,A=None,B=None,mode="DMRG",wf=None,**kwargs):
 
 
 def dynamical_correlator(self,window=[-1,10],es=None,dt=0.1,
-        nt=None,factor=1,delta=5e-2,**kwargs):
-    """Compute a certain dynamical correlator"""
+        nt=None,factor=1,delta=5e-2,damping_periods=6,**kwargs):
+    """
+    Compute a dynamical correlator from real-time evolution + Fourier
+    transform (submode="TD", TDVP-backed for itensor_version=3).
+
+    The raw finite-time correlator C(t) is windowed with an exponential
+    decay exp(-delta*t) before the FFT. This is what actually turns
+    `delta` into a Lorentzian broadening of width `delta` in the resulting
+    spectral function -- matching what `delta` means in the KPM/CVM
+    submodes -- and lets the required total evolution time follow directly
+    from the decay itself: `damping_periods`/delta e-foldings of exp(-delta*t)
+    make the truncation error exp(-damping_periods) negligible (default 6
+    -> ~0.25%), instead of the previous undamped 100/delta default, which
+    had no explicit broadening mechanism and relied on brute-force long
+    evolution (and the resulting rectangular-window ringing) to get a
+    comparably resolved spectrum. This cuts the number of time steps -- and
+    thus wall-clock cost, the dominant cost of this submode -- by more than
+    an order of magnitude for the same `delta`, making it competitive with
+    KPM. The Fourier sum is normalized as a Riemann sum (factor dtnew) to
+    match the analytic Fourier-transform convention of the other submodes,
+    replacing the previous ad hoc 1/sqrt(nt) scaling that was tied to the
+    old undamped/long-time convention.
+    """
     self.get_gs() # get the ground state
-    if nt is None: nt=int(100/delta/dt)
+    if nt is None: nt=int(damping_periods/delta/dt)
     (ts,cs) = evolution_DC(self,dt=dt,nt=nt,**kwargs) # get correlator
-#    cs = cs*np.exp(-1j*self.e0*ts) # factor out the phase
+    cs = cs*np.exp(-delta*ts) # damping window -> Lorentzian broadening "delta"
     # interpolate the time evolution
     ftr = interp1d(ts,cs.real,fill_value=0.0,bounds_error=False)
     fti = interp1d(ts,cs.imag,fill_value=0.0,bounds_error=False)
@@ -147,7 +168,7 @@ def dynamical_correlator(self,window=[-1,10],es=None,dt=0.1,
     cs = cnew.copy() # overwrite
     dtnew = dt/factor
     # do the fourier transform
-    ss = np.fft.fft(cs) # fourier transform
+    ss = np.fft.fft(cs)*dtnew # fourier transform (Riemann-sum normalization)
     ws = np.fft.fftfreq(len(cs),d=dtnew)*2.*np.pi # fourier frequencies
     fr = interp1d(ws,ss.real,fill_value=0.0,bounds_error=False)
     fi = interp1d(ws,ss.imag,fill_value=0.0,bounds_error=False)
@@ -156,7 +177,7 @@ def dynamical_correlator(self,window=[-1,10],es=None,dt=0.1,
     gr = fr(es)+ 1j*fi(es) # advanced
     ga = np.conjugate(gr) # retarded
 #    gp = fr(es) - fr(-es) + 1j*fi(es) + 1j*fi(-es)
-    return (es,gr/np.sqrt(nt))
+    return (es,gr)
 
 
 


### PR DESCRIPTION
This PR now bundles two independent dynamical-correlator fixes done in the same session/branch.

## 1. TD/TDVP dynamical correlator: fix normalization bug, make it competitive with KPM

`submode="TD"` (real-time evolution + FFT, TDVP-backed for `itensor_version=3`) had no explicit spectral-broadening mechanism: it relied on brute-force long evolution (`nt=int(100/delta/dt)`) plus rectangular-window ringing to approximate a spectrum resolved to width `delta`, making it far slower than `submode="KPM"` for comparable smearing.

Fixed by applying an `exp(-delta*t)` damping window to the correlator before the FFT (this is what actually turns `delta` into a Lorentzian broadening of width `delta`, matching what `delta` means in the KPM/CVM submodes), and deriving `nt` directly from the decay (`damping_periods/delta` e-foldings, default 6, ~0.25% truncation error) instead of the old ad hoc factor of 100. Also renormalized the FFT as a proper Riemann sum (`* dtnew`), replacing the old `1/sqrt(nt)` scaling, which was tied to the old long-time convention and turned out to be wrong by a large, nt-dependent factor (confirmed against ED-based KPM on a small chain: old normalization gave a peak ~6x too high).

**Benchmark** (30-site S=1/2 Heisenberg chain, `itensor_version=3`, `delta=0.1`): KPM ~110-130s (unchanged) vs. TD(TDVP) ~2450s → ~182s (was ~20-25x slower than KPM, now ~1.4x).

## 2. CVM dynamical correlator: reimplement as pure-Python CG, fix blow-ups

`submode="CVM"` sometimes "blows up" (reported by the user). Root cause: `Chain::cvm_dynamical_correlator` (`mpscpp3/chain_session.h`) solves `(z-H)x=b` directly via a hand-rolled, unguarded BiCGSTAB on the non-Hermitian `z=omega+E0+i*eta` operator, with no protection against BiCGSTAB's well-known near-singular breakdown (division by a near-zero inner product), on top of MPS truncation at every step.

**Directly reproduced the blow-up**: on a 30-site S=1/2 chain at `omega=1, eta=0.2`, the old solver returned `-639904678.4` — a nonsensical value ~10 orders of magnitude off from anything physical.

Replaced it with the classic **Correction Vector Method** (Ramasesha; Kühner-White 1999): solve the Hermitian, positive-definite system `[(H-omega-E0)^2+eta^2] xc = -eta*B|GS>` via conjugate gradient, then recover the correction vector from `xc`. This is exactly what the ED backend already does (`edtk/timedependent.py::solve_cv`) — the DMRG/MPS backend just never had it. Same point as above now gives `0.01592`, a sane value.

Implemented **entirely in `src/dmrgpy/cvm.py`**, using primitives already exposed to Python (`StaticOperator` for a build-once/apply-many MPO, `MPS` +/-/scalar-* and `.dot()` for the rest) — **no new C++/pybind11 bindings, no recompilation needed** to tune this further, per the user's ask. Also tracks the best-residual correction vector seen across CG iterations rather than trusting the final iterate: MPS truncation at every step means the residual isn't strictly monotonic in practice even though the underlying operator is positive-definite (confirmed by tracing residuals iteration-by-iteration on a 14-site chain).

Added `self.cvm_maxm` (`manybodychain.py`), mirroring the existing `kpmmaxm` pattern, so the correction vector's bond dimension can be tuned independently of the ground state's.

**Scope**: in scope is `submode="CVM"` for Hermitian Hamiltonians (the common case). Out of scope, left untouched: `submode="CVM_explicit"` (non-Hermitian dynamics path) and `submode="CVMimag"`, which still use `apply_inverse`/`bicstab` since the Hermitian CG trick doesn't apply to a non-Hermitian Hamiltonian.

## Test plan
- [x] TD/TDVP: verified correctness on a small (n=6) chain against an independent ED-based KPM reference; benchmarked the 30-site speedup above.
- [x] TD/TDVP: ran `dynamical_correlator_time_evolution_tdvp` example headless — no exceptions.
- [x] CVM: verified against the ED-backed `submode="CVM"` (`solve_cv`) on a small (n=6) **spin-1/2** chain (matches to ~1e-8) and a small (n=6) **fermionic** hopping+interaction chain (matches to ~1e-7).
- [x] CVM: directly reproduced the old solver's blow-up on a 30-site chain (`-639904678.4`) and confirmed the new solver gives a sane value (`0.01592`) at the same point.
- [x] CVM: re-ran an 80-point frequency scan on a 10-site chain that the old solver couldn't finish in 590s (slow/uneven convergence, only ~31/80 points done) — the new solver completes all 80 points in 259s with every value finite, no blow-ups.
- [x] CVM: ran the `dynamical_correlator_cvm` example headless — no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)