### PR TITLE
Fix correctness bugs found reviewing the Many_Body_Chain call graph

### DIFF
--- a/src/dmrgpy/densitymatrix.py
+++ b/src/dmrgpy/densitymatrix.py
@@ -34,7 +34,7 @@ def reduced_dm_projective(self,wf,i=0,j=None):
           P01 = self.Cdag[k] # create an electron
           # we need to project on up/dn and rotate to up!
           return [N,P01] # return the projectors
-        elif type(self)==Fermionic_Chain: # spin chain object
+        elif type(self)==Spinful_Fermionic_Chain: # spin chain object
           raise # not implemented yet
         else: raise # not implemented
     Pi = projectors(i) # projectors for site i

--- a/src/dmrgpy/entanglement.py
+++ b/src/dmrgpy/entanglement.py
@@ -10,8 +10,16 @@ def get_correlation_entropy_density(self,**kwargs):
     cm = get_correlation_matrix(self,**kwargs)
     ce,ws = lg.eigh(cm) # return eigenvalues
     ws = ws.T # transpose
-    ce[ce<1e-6] = 1. # set to 1, so that they have zero entropy
-    ss = -ce*np.log(ce) # entropies 
+    # per-mode entanglement entropy of a free-fermion/orbital occupation
+    # number n: -[n*log(n) + (1-n)*log(1-n)] (Peschel's formula), not just
+    # -n*log(n) -- the single-term version silently discarded the
+    # complementary contribution, undercounting the entropy by roughly 2x
+    # for eigenvalues away from 0/1 (confirmed against the ED backend on
+    # examples/entanglement_entropy/correlation_entropy's model). Clipping
+    # both ends avoids log(0) without needing the old ce<1e-6 special case,
+    # since both terms already vanish smoothly as n->0 or n->1.
+    ce = np.clip(ce.real,1e-12,1.-1e-12)
+    ss = -(ce*np.log(ce) + (1.-ce)*np.log(1.-ce)) # entropies
     out = 0.*ws[0].real # initialize
     for i in range(len(ss)): out = out + ss[i]*np.abs(ws[i])**2
     if type(self)==fermionchain.Fermionic_Chain: pass
@@ -34,10 +42,10 @@ def get_correlation_eigenvalues(self,**kwargs):
 def get_correlation_entropy(self,**kwargs):
     """Return the correlation entropy"""
     vs = get_correlation_eigenvalues(self,**kwargs)
-    out = 0.0
-    for v in vs:
-        if v>1e-6: out = out + v*np.log(v)
-    return -out
+    # see get_correlation_entropy_density's comment: use the symmetric
+    # -[v*log(v) + (1-v)*log(1-v)] formula, not just -v*log(v)
+    vs = np.clip(vs.real,1e-12,1.-1e-12)
+    return -np.sum(vs*np.log(vs) + (1.-vs)*np.log(1.-vs))
 
 
 
@@ -74,9 +82,9 @@ def get_second_order_correlation_entropy(self,**kwargs):
     cm = get_highorder_correlation_matrix(self,**kwargs)
 #    print(np.sum(np.abs(cm-np.conjugate(cm.T))))
     vs = lg.eigvalsh(cm) # return eigenvalues
-    out = 0.0
-    for v in vs:
-        if v>1e-6: out = out + v*np.log(v)
-    out = -out
+    # see get_correlation_entropy_density's comment: use the symmetric
+    # -[v*log(v) + (1-v)*log(1-v)] formula, not just -v*log(v)
+    vs = np.clip(vs.real,1e-12,1.-1e-12)
+    out = -np.sum(vs*np.log(vs) + (1.-vs)*np.log(1.-vs))
 #    print(np.round(vs,3),np.round(out,2))
     return out

--- a/src/dmrgpy/groundstate.py
+++ b/src/dmrgpy/groundstate.py
@@ -4,14 +4,14 @@ import numpy as np
 
 def best_gs(sc,n=1):
     """Compute many ground states, and retain only the best one"""
-    wfs = [] # list with GS
-    es = [] # list with energies
     emin = 1e8 # grund state energy
     wf0 = None
     for i in range(n): # loop
         sc.computed_gs = False # initialize
         e0 = sc.gs_energy() # ground state energy
-        if e0<emin: wf0 = sc.wf0 # copy wavefunction
+        if e0<emin: # only keep this one if it actually improves on the best
+            wf0 = sc.wf0 # copy wavefunction
+            emin = e0
     sc.set_initial_wf(wf0) # set the wavefunction
 
 def gs_energy_bestof(self,**kwargs):

--- a/src/dmrgpy/mps.py
+++ b/src/dmrgpy/mps.py
@@ -40,8 +40,8 @@ class MPS():
         else: raise
     def __sub__(self,x):
         return self + (-1)*x
-    def __neg__(self,x):
-        return (-1)*x
+    def __neg__(self):
+        return (-1)*self
     def __truediv__(self,x): return self*(1./x)
     def copy(self,name=None):
         """Copy this wavefunction"""

--- a/src/dmrgpy/mpsalgebratk/trace.py
+++ b/src/dmrgpy/mpsalgebratk/trace.py
@@ -29,7 +29,7 @@ def stochastic_inverse_trace(self,A,n=10,delta=1e-2,mode="DMRG",**kwargs):
     from ..randommps import random_states
     wfs = random_states(self,mode=mode,n=n,orthogonal=True) # states
     n = len(wfs) # overwrite
-    wBw = [wf.dot(self.applyinverse(A,wf,delta=1e-4)) for wf in wfs] # inverses
+    wBw = [wf.dot(self.applyinverse(A,wf,delta=delta)) for wf in wfs] # inverses
     from scipy.stats import tstd
 #    print("Fluctuation",tstd(wBw)/np.sqrt(n))
     return np.sum(wBw)/len(wBw) # return the sum

--- a/src/dmrgpy/mpsjulialive/mps.py
+++ b/src/dmrgpy/mpsjulialive/mps.py
@@ -32,8 +32,8 @@ class MPS():
         else: raise
     def __sub__(self,x):
         return self + (-1)*x
-    def __neg__(self,x):
-        return (-1)*x
+    def __neg__(self):
+        return (-1)*self
     def __truediv__(self,x): return self*(1./x)
     def copy(self,name=None):
         """Copy this wavefunction"""

--- a/src/dmrgpy/operatornames.py
+++ b/src/dmrgpy/operatornames.py
@@ -74,9 +74,13 @@ def name2MO(name,self):
     elif name=="Sx": return self.Sx
     elif name=="Sy": return self.Sy
     elif name=="Sz": return self.Sz
+    # Sp/Sm have no native backend operator name (unlike Sx/Sy/Sz), so build
+    # them from Sx/Sy on the fly: S+ = Sx + i*Sy, S- = Sx - i*Sy (matching
+    # the Sp<->Sm dagger convention in multioperator.py/sympymultioperator.py)
+    elif name=="Sp": return [self.Sx[i]+1j*self.Sy[i] for i in range(self.ns)]
+    elif name=="Sm": return [self.Sx[i]-1j*self.Sy[i] for i in range(self.ns)]
     else:
-        print(name) ; exit()
-        raise
+        raise ValueError("Unrecognized operator name "+str(name))
 
 def str2MO(self,name,i=0,j=0):
     from . import multioperator
@@ -86,6 +90,8 @@ def str2MO(self,name,i=0,j=0):
             if n=="Sx": return self.Sx[i]
             elif n=="Sy": return self.Sy[i]
             elif n=="Sz": return self.Sz[i]
+            elif n=="Sp": return self.Sx[i]+1j*self.Sy[i]
+            elif n=="Sm": return self.Sx[i]-1j*self.Sy[i]
             else: raise
         return [f(n1,i),f(n2,j)]
     elif type(name[0])==multioperator.MultiOperator and type(name[1])==multioperator.MultiOperator:


### PR DESCRIPTION
## Summary

Code review of `manybodychain.py` and everything it calls (directly and one/two hops out), looking for correctness bugs. Six real bugs found and fixed:

- **`entanglement.py`**: `get_correlation_entropy()`/`get_correlation_entropy_density()`/`get_second_order_correlation_entropy()` computed only `-n*log(n)` from the correlation-matrix eigenvalues, missing the `(1-n)*log(1-n)` term of the standard free-fermion/orbital entanglement entropy formula. Verified numerically against the ED backend on the interacting-chain model from `examples/entanglement_entropy/correlation_entropy`: at one eigenvalue set the old formula gave `S=0.778` vs. the correct `S=1.716` — off by >2x.
- **`groundstate.py`**: `best_gs()` initialized `emin=1e8` but never updated it inside the loop, so `Many_Body_Chain.get_gs(best=True, n=...)` silently kept whichever wavefunction the *last* DMRG run happened to produce, not the lowest-energy one.
- **`mps.py`, `mpsjulialive/mps.py`**: `MPS.__neg__(self, x)` took an extra required positional argument. Python calls `__neg__(obj)` with no extra arg for unary `-obj`, so `-wf` on any MPS raised `TypeError`. Fixed to match the correct pattern already used in `edtk/edchain.py`.
- **`operatornames.py`**: `name2MO()` had no `Sp`/`Sm` cases even though `recognize()` can produce them for `"+"`/`"-"` correlator names (e.g. `"+-"`), and fell back to calling the bare `exit()` builtin instead of raising — killing the whole process instead of a catchable error. `str2MO()` (used by the TD/TDVP dynamical-correlator path) had the identical gap. Both fixed by building `Sp = Sx + i*Sy`, `Sm = Sx - i*Sy` on the fly, since there's no native backend operator name for them.
- **`densitymatrix.py`**: `reduced_dm_projective()`'s per-site `projectors()` had a copy-pasted `elif type(self)==Fermionic_Chain` branch that should have checked `Spinful_Fermionic_Chain` (imported but never referenced), making the intended branch permanently unreachable.
- **`mpsalgebratk/trace.py`**: `stochastic_inverse_trace()` accepted a `delta` parameter but always solved with a hardcoded `1e-4`, silently ignoring whatever the caller passed.

Also reviewed the dynamical-correlator dispatch layer (`kpmdmrg.py`, `cvm.py`, `dcex.py`) and the numerical core (`algebra/arnolditk.py`, `algebra/kpm.py`, `algebra/krylov.py`) without finding further confirmed bugs — `arnolditk.py` in particular already carries detailed rationale from its recent restarted-Arnoldi rewrite. A couple of low-priority/dormant items were flagged but intentionally left unfixed (see conversation): an unconditional infinite loop in `arnolditk.random_state()`'s orthogonal-search fallback if the search space is ever exhausted, and whether the `"CVMimag"` submode / automatic non-Hermitian dynamical-correlator fallback still route through the same C++ `apply_inverse` blow-up risk that the CG rewrite (PR #38) specifically avoided for the main CVM submode.

## Test plan

- [x] Verified `get_correlation_entropy()` post-fix exactly matches a hand-derived symmetric-formula reference on an interacting fermion chain (ED backend)
- [x] Verified unary `-wf` no longer raises, and `(-1)*wf == -wf` to machine precision (DMRG/C++ backend)
- [x] Verified `get_gs(best=True, n=3)` runs and converges post-fix
- [x] Verified `name2MO`/`str2MO` resolve `"Sp"`/`"Sm"`/`"+-"` correctly
- [x] Verified `examples/algebra/trace/main.py` (exercises `stochastic_inverse_trace`) still runs and matches the ED cross-check
- [x] All touched files parse cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWuWzjQmgsf1sBjBiAAYNy