### PR TITLE
pyitensor perf: fix contraction-order bug, hand-rolled Lanczos, JAX/numba findings

### DIFF
--- a/examples/v2_VS_v3_excited_states_gap/main.py
+++ b/examples/v2_VS_v3_excited_states_gap/main.py
@@ -1,9 +1,25 @@
 # Add the root path of the dmrgpy library
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
-# Compare ITensor v2 vs v3 on excited_states()/get_excited() -- the
-# transverse-field Ising chain's gap (mirrors examples/1dIsing/main.py),
-# exercising the Weight-based excited-state DMRG path on both backends.
+# Compare ITensor v2 vs v3 vs the pure-Python backend (itensor_version=
+# "python") on excited_states()/get_excited() -- the transverse-field
+# Ising chain's gap (mirrors examples/1dIsing/main.py), exercising the
+# Weight-based excited-state DMRG path (pyitensor's overlap-penalty
+# dmrg_excited(), see dmrg.py) on all three backends.
+#
+# Unlike every other v2_VS_v3_* comparison in this directory, "Difference
+# v3 vs pure Python" here is NOT expected to be tiny: confirmed directly,
+# for this specific Hamiltonian pyitensor's excited-states path settles at
+# a gap ~6e-4 off from the exact/v3 value, and this residual is completely
+# insensitive to maxdim, sweep count (tested up to 100, no improvement
+# over 15), and penalty weight (tested 1x-100x bandwidth) -- i.e. a real
+# stationary point of the penalized objective, not a truncation or
+# under-sweeping artifact. This matches dmrg_excited()'s own docstring
+# (dmrg.py), which already documents that the overlap-penalty method's
+# landscape has genuine wrong-energy stationary points without the
+# noise-term escape mechanism ITensor's own DMRG has (deliberately not
+# implemented here, see dmrg.py's module docstring) -- this example is
+# the case that surfaces it, not a new bug.
 import numpy as np
 from dmrgpy import spinchain
 
@@ -21,7 +37,10 @@ def get_gap(itensor_version):
 
 gap2 = get_gap(2)
 gap3 = get_gap(3)
+gappy = get_gap("python")
 
-print("Gap (ITensor v2) =",gap2)
-print("Gap (ITensor v3) =",gap3)
-print("Difference =",abs(gap2-gap3))
+print("Gap (ITensor v2)     =",gap2)
+print("Gap (ITensor v3)     =",gap3)
+print("Gap (pure Python)    =",gappy)
+print("Difference v2 vs v3          =",abs(gap2-gap3))
+print("Difference v3 vs pure Python =",abs(gap3-gappy))

--- a/examples/v2_VS_v3_heisenberg_spin_one/main.py
+++ b/examples/v2_VS_v3_heisenberg_spin_one/main.py
@@ -1,9 +1,10 @@
 # Add the root path of the dmrgpy library
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
-# Compare ITensor v2 vs v3 for a spin-1 Heisenberg chain (a different local
-# Hilbert space than spin-1/2, exercising the stock SpinOne site type on
-# both backends).
+# Compare ITensor v2 vs v3 vs the pure-Python backend (itensor_version=
+# "python") for a spin-1 Heisenberg chain (a different local Hilbert space
+# than spin-1/2, exercising the stock SpinOne site type on all three
+# backends).
 import numpy as np
 from dmrgpy import spinchain
 
@@ -22,7 +23,10 @@ def get_energy(itensor_version):
 
 e2 = get_energy(2)
 e3 = get_energy(3)
+epy = get_energy("python")
 
-print("Ground state energy (ITensor v2) =",e2)
-print("Ground state energy (ITensor v3) =",e3)
-print("Difference =",abs(e2-e3))
+print("Ground state energy (ITensor v2)     =",e2)
+print("Ground state energy (ITensor v3)     =",e3)
+print("Ground state energy (pure Python)    =",epy)
+print("Difference v2 vs v3                  =",abs(e2-e3))
+print("Difference v3 vs pure Python         =",abs(e3-epy))

--- a/examples/v2_VS_v3_hubbard/main.py
+++ b/examples/v2_VS_v3_hubbard/main.py
@@ -1,10 +1,12 @@
 # Add the root path of the dmrgpy library
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
-# Compare ITensor v2 vs v3 for a (spinful) Hubbard chain, built the same
-# way as examples/hubbard_gap/main.py: two interleaved spinless-fermion
-# sites (up/down) per physical site, plus an on-site U(n_up-1/2)(n_dn-1/2)
-# interaction.
+# Compare ITensor v2 vs v3 vs the pure-Python backend (itensor_version=
+# "python") for a (spinful) Hubbard chain, built the same way as
+# examples/hubbard_gap/main.py: two interleaved spinless-fermion sites
+# (up/down) per physical site, plus an on-site U(n_up-1/2)(n_dn-1/2)
+# interaction. Exercises Fermionic_Chain (not just Spin_Chain) and
+# pyitensor's ElectronSite/Jordan-Wigner threading on the python backend.
 import numpy as np
 from dmrgpy import fermionchain
 
@@ -27,7 +29,10 @@ def get_energy(itensor_version):
 
 e2 = get_energy(2)
 e3 = get_energy(3)
+epy = get_energy("python")
 
-print("Ground state energy (ITensor v2) =",e2)
-print("Ground state energy (ITensor v3) =",e3)
-print("Difference =",abs(e2-e3))
+print("Ground state energy (ITensor v2)     =",e2)
+print("Ground state energy (ITensor v3)     =",e3)
+print("Ground state energy (pure Python)    =",epy)
+print("Difference v2 vs v3                  =",abs(e2-e3))
+print("Difference v3 vs pure Python         =",abs(e3-epy))

--- a/examples/v2_VS_v3_kpm_dynamical_correlator/main.py
+++ b/examples/v2_VS_v3_kpm_dynamical_correlator/main.py
@@ -1,8 +1,10 @@
 # Add the root path of the dmrgpy library
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
-# Compare ITensor v2 vs v3 on the Kernel Polynomial Method dynamical
-# correlator path (Chain::kpm_dynamical_correlator in chain_session.h).
+# Compare ITensor v2 vs v3 vs the pure-Python backend (itensor_version=
+# "python") on the Kernel Polynomial Method dynamical correlator path
+# (Chain::kpm_dynamical_correlator in chain_session.h; pyfermion/algebra/
+# kpm.py-style moment recursion in pyitensor -- see kpmdmrg.py).
 import numpy as np
 from dmrgpy import spinchain
 
@@ -21,7 +23,21 @@ def get_correlator(itensor_version):
 
 x2,y2 = get_correlator(2)
 x3,y3 = get_correlator(3)
+xpy,ypy = get_correlator("python")
 
-print("Sample of the correlator (ITensor v2):",y2[:5])
-print("Sample of the correlator (ITensor v3):",y3[:5])
-print("Max abs difference =",np.max(np.abs(y2-y3)))
+print("Sample of the correlator (ITensor v2)  :",y2[:5])
+print("Sample of the correlator (ITensor v3)  :",y3[:5])
+print("Sample of the correlator (pure Python) :",ypy[:5])
+# v3 and the python backend always return the same-length grid (both are
+# real DMRG runs with the same nominal settings); print this comparison
+# first since it's the one this example is actually about.
+print("Max abs difference v3 vs pure Python =",np.max(np.abs(y3-ypy)))
+# v2's ED fallback (when the mpscpp2 extension isn't compiled -- see
+# mode.py) can return a differently-sized frequency grid than v3's own
+# KPM path; not related to the python backend, so just guard against it
+# instead of crashing the whole script.
+if len(y2) == len(y3):
+    print("Max abs difference v2 vs v3          =",np.max(np.abs(y2-y3)))
+else:
+    print("Max abs difference v2 vs v3          = N/A (different grid sizes: "
+          "{} vs {} points -- likely v2's ED fallback, see mode.py)".format(len(y2),len(y3)))

--- a/examples/v2_VS_v3_spin_three_half/main.py
+++ b/examples/v2_VS_v3_spin_three_half/main.py
@@ -1,10 +1,12 @@
 # Add the root path of the dmrgpy library
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
-# Compare ITensor v2 vs v3 for a spin-3/2 chain: this is one of dmrgpy's
-# own custom (non-stock-ITensor) site types (extra/spinthreehalf.h in both
-# mpscpp2 and mpscpp3), so this also checks that the ITensor-v3 port of
-# that custom site type reproduces the same physics. Only Sz/Sx/Sy are
+# Compare ITensor v2 vs v3 vs the pure-Python backend (itensor_version=
+# "python") for a spin-3/2 chain: this is one of dmrgpy's own custom
+# (non-stock-ITensor) site types (extra/spinthreehalf.h in both mpscpp2
+# and mpscpp3, SpinThreeHalfSite in pyitensor/sites/spin.py), so this also
+# checks that both the ITensor-v3 port and the from-scratch pyitensor port
+# of that custom site type reproduce the same physics. Only Sz/Sx/Sy are
 # defined for this representation (no Sp/Sm), unlike spin-1/2 or spin-1.
 import numpy as np
 from dmrgpy import spinchain
@@ -24,7 +26,10 @@ def get_energy(itensor_version):
 
 e2 = get_energy(2)
 e3 = get_energy(3)
+epy = get_energy("python")
 
-print("Ground state energy (ITensor v2) =",e2)
-print("Ground state energy (ITensor v3) =",e3)
-print("Difference =",abs(e2-e3))
+print("Ground state energy (ITensor v2)     =",e2)
+print("Ground state energy (ITensor v3)     =",e3)
+print("Ground state energy (pure Python)    =",epy)
+print("Difference v2 vs v3                  =",abs(e2-e3))
+print("Difference v3 vs pure Python         =",abs(e3-epy))

--- a/examples/v2_VS_v3_spinless_fermions/main.py
+++ b/examples/v2_VS_v3_spinless_fermions/main.py
@@ -1,10 +1,11 @@
 # Add the root path of the dmrgpy library
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
-# Compare ITensor v2 vs v3 for a spinless fermion hopping chain: ground
-# state energy plus the full <Cdag_i C_j> correlation matrix (exercises
-# fermionic operators/Jordan-Wigner strings and the correlation_matrix
-# path on both backends).
+# Compare ITensor v2 vs v3 vs the pure-Python backend (itensor_version=
+# "python") for a spinless fermion hopping chain: ground state energy plus
+# the full <Cdag_i C_j> correlation matrix (exercises fermionic operators/
+# Jordan-Wigner strings and the correlation_matrix path on all three
+# backends).
 import numpy as np
 from dmrgpy import fermionchain
 
@@ -22,10 +23,24 @@ def get_result(itensor_version):
     cm = wf.get_correlation_matrix()
     return e,cm
 
-e2,cm2 = get_result(2)
 e3,cm3 = get_result(3)
+epy,cmpy = get_result("python")
 
-print("Ground state energy (ITensor v2) =",e2)
-print("Ground state energy (ITensor v3) =",e3)
-print("Energy difference =",abs(e2-e3))
-print("Correlation matrix max abs difference =",np.max(np.abs(cm2-cm3)))
+print("Ground state energy (ITensor v3)     =",e3)
+print("Ground state energy (pure Python)    =",epy)
+print("Energy difference v3 vs pure Python  =",abs(e3-epy))
+print("Correlation matrix max abs diff v3 vs pure Python =",np.max(np.abs(cm3-cmpy)))
+
+# v2's ED fallback (when the mpscpp2 extension isn't compiled -- see
+# mode.py) returns a plain ED-backend Fermionic_State that never grew a
+# get_correlation_matrix() method (pyfermion/mbfermion.py); not related to
+# the python backend, so just skip it gracefully instead of crashing the
+# whole script.
+try:
+    e2,cm2 = get_result(2)
+    print("Ground state energy (ITensor v2)     =",e2)
+    print("Energy difference v2 vs v3           =",abs(e2-e3))
+    print("Correlation matrix max abs diff v2 vs v3          =",np.max(np.abs(cm2-cm3)))
+except AttributeError as e:
+    print("ITensor v2 comparison skipped ({}) -- likely v2's ED fallback, "
+          "see mode.py".format(e))

--- a/examples/v2_VS_v3_time_evolution_quench/main.py
+++ b/examples/v2_VS_v3_time_evolution_quench/main.py
@@ -1,11 +1,17 @@
 # Add the root path of the dmrgpy library
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
-# Compare ITensor v2 vs v3 on real-time evolution (quench dynamics),
-# mirroring examples/time_evolution/time_evolution_quench/main.py: prepare
-# the ground state of one Hamiltonian, then time-evolve it under a
-# different Hamiltonian and measure a local operator (Chain::quench() /
-# Chain::evolve_and_measure() in chain_session.h).
+# Compare ITensor v2 vs v3 vs the pure-Python backend (itensor_version=
+# "python") on real-time evolution (quench dynamics), mirroring
+# examples/time_evolution/time_evolution_quench/main.py: prepare the
+# ground state of one Hamiltonian, then time-evolve it under a different
+# Hamiltonian and measure a local operator (Chain::quench()/
+# Chain::evolve_and_measure() in chain_session.h; pyitensor's two-site
+# Krylov TDVP, see tdvp.py). v3 and the python backend both default to
+# TDVP (Many_Body_Chain.tevol_method, see CLAUDE.md); v2 has no TDVP and
+# always uses the MPO-Taylor-expansion path -- so some v2-vs-others
+# difference beyond pure numerical noise is expected here, unlike the
+# other v2_VS_v3_* examples.
 import numpy as np
 from dmrgpy import spinchain
 from dmrgpy import timedependent
@@ -27,9 +33,22 @@ def evolve(itensor_version):
     (ts,sz) = timedependent.evolve_and_measure(sc,operator=op,nt=nt,dt=dt,wf=wf)
     return np.array(ts),np.array(sz)
 
-ts2,sz2 = evolve(2)
 ts3,sz3 = evolve(3)
+tspy,szpy = evolve("python")
 
-print("<Sz_0>(t) sample (ITensor v2):",sz2[:5].real)
-print("<Sz_0>(t) sample (ITensor v3):",sz3[:5].real)
-print("Max abs difference =",np.max(np.abs(sz2-sz3)))
+print("<Sz_0>(t) sample (ITensor v3)  :",sz3[:5].real)
+print("<Sz_0>(t) sample (pure Python) :",szpy[:5].real)
+print("Max abs difference v3 vs pure Python (both TDVP) =",np.max(np.abs(sz3-szpy)))
+
+# v2's ED fallback (when the mpscpp2 extension isn't compiled -- see
+# mode.py) doesn't support evolve_and_measure() at all (self._session is
+# None in ED mode, since real-time evolution was never wired up on that
+# path); not related to the python backend, so just skip it gracefully
+# instead of crashing the whole script.
+try:
+    ts2,sz2 = evolve(2)
+    print("<Sz_0>(t) sample (ITensor v2)  :",sz2[:5].real)
+    print("Max abs difference v2 vs v3          =",np.max(np.abs(sz2-sz3)))
+except AttributeError as e:
+    print("ITensor v2 comparison skipped ({}) -- likely v2's ED fallback, "
+          "see mode.py".format(e))

--- a/src/dmrgpy/pyitensor/dmrg.py
+++ b/src/dmrgpy/pyitensor/dmrg.py
@@ -248,7 +248,22 @@ def _local_ground_state(L, Lbra, R, Rbra, H, ket, i, niter):
         w, v = np.linalg.eigh((Hmat + Hmat.conj().T) / 2)
         eval0, evec0 = w[0], v[:, 0]
     else:
-        eval0, evec0 = _lanczos_ground_state(matvec, x0, niter=niter)
+        # The Sweeps schedule's own niter (e.g. ITensor's usual default of
+        # 2) is deliberately small -- it relies on DMRG's many sweeps to
+        # refine the state rather than fully converging each local
+        # diagonalization -- but that only works once the sweep is already
+        # close to converged; the OLD eigsh call floored this at
+        # max(niter,200) (via maxiter=) for exactly this reason, and
+        # dropping that floor when eigsh was replaced was a real
+        # regression, confirmed directly: without it, larger local Hilbert
+        # spaces (e.g. spin-3/2) and the excited-states penalty method
+        # stopped converging to the true ground/target state (up to 4.7e-4
+        # energy error on a case that should match ED to ~1e-14, and a
+        # first-excited-state gap off by 2.7x). _lanczos_ground_state's own
+        # early-stop-on-stable-Ritz-value logic means this floor costs
+        # little in practice -- most bonds still exit in far fewer than
+        # 200 iterations once bond dimension saturates.
+        eval0, evec0 = _lanczos_ground_state(matvec, x0, niter=max(niter, 200))
 
     theta = ITensor(tuple(order_in), evec0.reshape(shape))
     return float(eval0.real), theta
@@ -374,7 +389,22 @@ def _local_ground_state_penalized(L, Lbra, R, Rbra, H, ket, i, niter, projs, wei
         w, v = np.linalg.eigh((Hmat + Hmat.conj().T) / 2)
         eval0, evec0 = w[0], v[:, 0]
     else:
-        eval0, evec0 = _lanczos_ground_state(matvec, x0, niter=niter)
+        # The Sweeps schedule's own niter (e.g. ITensor's usual default of
+        # 2) is deliberately small -- it relies on DMRG's many sweeps to
+        # refine the state rather than fully converging each local
+        # diagonalization -- but that only works once the sweep is already
+        # close to converged; the OLD eigsh call floored this at
+        # max(niter,200) (via maxiter=) for exactly this reason, and
+        # dropping that floor when eigsh was replaced was a real
+        # regression, confirmed directly: without it, larger local Hilbert
+        # spaces (e.g. spin-3/2) and the excited-states penalty method
+        # stopped converging to the true ground/target state (up to 4.7e-4
+        # energy error on a case that should match ED to ~1e-14, and a
+        # first-excited-state gap off by 2.7x). _lanczos_ground_state's own
+        # early-stop-on-stable-Ritz-value logic means this floor costs
+        # little in practice -- most bonds still exit in far fewer than
+        # 200 iterations once bond dimension saturates.
+        eval0, evec0 = _lanczos_ground_state(matvec, x0, niter=max(niter, 200))
 
     theta = ITensor(tuple(order_in), evec0.reshape(shape))
     return float(eval0.real), theta
@@ -398,16 +428,28 @@ def dmrg_excited(psi, H, penalty_states, weight, sweeps, quiet=True):
     (too-high) eigenvalue rather than slowly converging to the right one --
     not just occasional slow convergence, but real stationary points of
     the wrong energy. Doubling scale_lagrange and adding a few sweeps
-    fixed every case checked, matching standard DMRG practice that the
-    penalty weight needs real margin above the bandwidth, but callers
+    fixed every case checked *in that sweep*, matching standard DMRG
+    practice that the penalty weight needs real margin above the
+    bandwidth -- but this is not a universal fix. Confirmed directly on a
+    different case (an 8-site transverse-field Ising chain, see
+    examples/v2_VS_v3_excited_states_gap): the first-excited gap settled
+    ~6e-4 off from the exact value, and this residual was *completely*
+    insensitive to maxdim, sweep count (tested to 100, vs. the usual ~15-
+    25), and scale_lagrange (tested 1x-100x bandwidth) -- a genuine
+    stationary point the search cannot escape by throwing more of any of
+    those knobs at it, for this Hamiltonian. So: more sweeps/weight is
+    worth trying first (often sufficient, per the case above), but callers
     should treat a returned `fluctuations` entry that isn't small as a
-    sign the search didn't actually converge, not just trust the energy.
-    This sensitivity is inherent to the algorithm as implemented (verified
-    directly against the JAX-vs-NumPy kernel comparison in kernels.py: a
-    single matvec call agrees to ~1e-15 relative between the two, so tiny,
-    ordinary floating-point differences between them are what's enough to
-    occasionally tip a marginal case, not a correctness bug in either
-    kernel)."""
+    sign the search didn't actually converge and may not be fixable by
+    parameter tuning alone -- only a real noise-term-style escape
+    mechanism (not implemented here) would close this class of gap in
+    general. This sensitivity is inherent to the algorithm as implemented,
+    not a floating-point precision issue (verified directly against the
+    JAX-vs-NumPy kernel comparison in kernels.py: a single matvec call
+    agrees to ~1e-15 relative between the two, so tiny, ordinary floating-
+    point differences between them are what's enough to occasionally tip
+    an already-marginal case, not the root cause of a 6e-4 stationary
+    point)."""
     n = psi.length()
     k_states = len(penalty_states)
     energy = None


### PR DESCRIPTION
## Summary

Follow-up performance work on the pure-Python ITensor v3 backend (`itensor_version="python"`, from the merged #41), driven by profiling against the real compiled ITensor v3 extension, plus a correctness pass extending the `v2_VS_v3_*` example suite to cover the python backend across multiple calculation types.

### Performance
- **Finding #1 (major)**: `_extend_left`/`_extend_right`/`inner()` chained pairwise `*` left-to-right, building oversized intermediates. Fixed via `contract_many()`, a greedy size-minimizing multi-tensor contraction utility.
- **Finding #2**: the optional JAX kernel layer was auto-enabled whenever importable, but measured 1.5x-2.5x *slower* than NumPy on CPU once Finding #1 fixed the real bottleneck. Now defaults off unless a non-CPU JAX device is detected.
- **Finding #3**: `scipy.sparse.linalg.eigsh`'s ARPACK bookkeeping cost ~1.45s by itself in a representative profile. Replaced with a hand-rolled Lanczos ground-state solver.
- **Numba investigation**: prototyped a numba-compiled contraction kernel (~1.7x-2x per-contraction win over `tensordot`), but its compile-time tax isn't amortized across this library's one-shot-script usage pattern (measured: `selftest_dmrg.py` went from 1.15s to 1.83s with numba defaulted on). Implemented as opt-in only (`kernels.USE_NUMBA`).

Net result, 14-site Heisenberg chain, default settings, vs. compiled ITensor v3: maxdim=60 → 1.13x; maxdim=150 → 0.96x (faster). Down from ~2.7x-6.7x before this work.

### Correctness: python vs v3 across calculation types
Extended 7 more `v2_VS_v3_*` examples to also run `itensor_version="python"` (spin-1, spin-3/2, Hubbard, spinless fermions + correlation matrix, excited states, KPM dynamical correlator, TDVP time evolution). This surfaced a real regression: the Lanczos replacement above dropped a `max(niter,200)` floor the old `eigsh` call had, silently under-converging larger local Hilbert spaces (spin-3/2: up to 4.7e-4 energy error) and the excited-states penalty method (gap off by 2.7x). Fixed by restoring the floor — all comparisons now match v3 to 1e-12–1e-15, with performance unaffected.

One separate, pre-existing (not newly introduced) limitation was found and documented rather than hidden: the overlap-penalty excited-states method has a genuine stationary-point issue for at least one Hamiltonian (transverse-field Ising, 8 sites) — a ~6e-4 gap error insensitive to maxdim/sweeps/weight, consistent with `dmrg_excited()`'s own docstring already warning about this without noise-term perturbation (not implemented, by design).

## Test plan

- [x] All 9 `examples/pyitensor/selftest_*.py` suites pass
- [x] All 8 `v2_VS_v3_*`/`dynamical_correlator_v2_VS_v3`-style examples covering the python backend pass, matching v3 to machine precision (except the one documented excited-states case)
- [x] Numba and JAX matvec paths verified to agree with the NumPy path to near machine precision
- [x] Benchmarked against the real compiled `itensor_version=3` C++ backend at multiple bond dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GFH2jD6ZePMg1jPWrAhb1