### PR TITLE
Fix regressions found comparing DMRG/ED results against a 4-day-old baseline

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -36,8 +36,8 @@ There is no `setup.py`/`pyproject.toml`; DMRGPY is used directly from
 installer.
 
 ```bash
-python install.py                        # compiles ITensor v2 (mpscpp2) + its pybind11 extension
-python install.py --itensor-version=3     # compiles ITensor v3 (mpscpp3) instead
+python install.py                        # compiles ITensor v3 (mpscpp3, the default) + its pybind11 extension
+python install.py --itensor-version=2     # compiles ITensor v2 (mpscpp2) instead
 python install.py --itensor-version=both  # compiles both v2 and v3 backends
 python install.py --gpp=g++-6             # use a specific compiler (needs g++ >= 6, LAPACK/BLAS)
 python install.py --doctor                # check build requirements only, skip the build
@@ -152,8 +152,8 @@ between the two solver families.
 
 | `itensor_version` | Engine | Requires | Fallback |
 |---|---|---|---|
-| `2` (default) | ITensor v2, in-process C++ (`mpscpp2`) | compiled pybind11 extension | ED |
-| `3` | ITensor v3, in-process C++ (`mpscpp3`) | compiled pybind11 extension | ED |
+| `2` | ITensor v2, in-process C++ (`mpscpp2`) | compiled pybind11 extension | ED |
+| `3` (default) | ITensor v3, in-process C++ (`mpscpp3`) | compiled pybind11 extension | ED |
 | `"python"` | pure-Python `pyitensor/` | NumPy/SciPy only | none |
 | `"julia_live"` | live in-process Julia session (`mpsjulialive/`), ITensors.jl | `pyjulia` + Julia install | none (feature-by-feature; missing methods simply aren't implemented) |
 
@@ -243,7 +243,7 @@ both the thin dispatch module and its `tk` counterpart.
 Dynamical correlators and generic operator distributions are computed
 with the Kernel Polynomial Method (`kpmdmrg.py`;
 `Chain::kpm_dynamical_correlator` / `Chain::general_kpm` in
-`chain_session.h` on the C++ side; `pyfermion/algebra/kpm.py`-style
+`chain_session.h` on the C++ side; `algebra/kpm.py`-style
 moment recursion on the ED side) rather than by direct spectral
 decomposition, since exact diagonalization of the full spectrum is
 infeasible for large chains.
@@ -252,10 +252,16 @@ infeasible for large chains.
 
 The pure-Python backend (`itensor_version="python"`) trades raw speed for
 zero build dependencies. Numbers below were measured directly on one
-machine, with `numba` installed (pyitensor's default accelerated
-matvec/effective-Hamiltonian kernel, see `pyitensor/kernels.py`) —
-absolute times will vary by machine and load, but the qualitative trends
-should hold.
+machine, with `numba` installed *and* explicitly opted in
+(`pyitensor.kernels.USE_NUMBA = True`) for its accelerated
+matvec/effective-Hamiltonian kernel (see `pyitensor/kernels.py`). This
+kernel is **not** used automatically just by having `numba` installed --
+`USE_NUMBA` defaults to `False`, because the one-time JIT compile cost is
+a net regression for this library's typical one-shot-script usage
+pattern (see `kernels.py`'s own docstring for measured numbers). Set
+`kernels.USE_NUMBA = True` yourself before running DMRG if you want this
+path. Absolute times will vary by machine and load, but the qualitative
+trends should hold.
 
 ### 5.1 Ground state energy (Heisenberg spin-1/2 chain)
 
@@ -315,15 +321,18 @@ shown in §5.1/§5.2, not these first-call numbers.
   without a C++ toolchain, or small systems (n ≲ 20) where the 1.3–2x
   overhead doesn't matter.
 - Install `numba` (and optionally `jax`) alongside the pure-Python
-  backend — without it, `pyitensor` falls back to plain NumPy loops and
-  is substantially slower than the numbers above (see
-  `pyitensor/__init__.py`'s own docstring).
+  backend *and* set `pyitensor.kernels.USE_NUMBA = True` (off by
+  default, see §5's note above) — without both steps, `pyitensor` falls
+  back to plain NumPy loops and is substantially slower than the numbers
+  above (see `pyitensor/__init__.py`'s own docstring).
 - For production-size chains, dynamical correlators, or anything
   performance-sensitive, compile the C++ extension (`python install.py`)
   and use `itensor_version=2` or `3`.
-- `examples/backend_timing_gs_energy/main.py` reproduces the §5.1 table
-  directly against the current codebase and current machine — re-run it
-  rather than trusting these numbers verbatim on a different setup.
+- `examples/backend_timing_gs_energy/main.py` reproduces the n=8..20
+  rows of the §5.1 table directly against the current codebase and
+  current machine (n=24..32 aren't included, to keep the example fast to
+  run) — re-run it rather than trusting these numbers verbatim on a
+  different setup.
 
 ## 6. Directory reference
 

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -71,8 +71,8 @@ directly from \texttt{src/}, added to \texttt{PYTHONPATH} (or symlinked
 into \texttt{site-packages}) by the installer.
 
 \begin{lstlisting}[language=bash]
-python install.py                        # compiles ITensor v2 (mpscpp2) + its pybind11 extension
-python install.py --itensor-version=3     # compiles ITensor v3 (mpscpp3) instead
+python install.py                        # compiles ITensor v3 (mpscpp3, the default) + its pybind11 extension
+python install.py --itensor-version=2     # compiles ITensor v2 (mpscpp2) instead
 python install.py --itensor-version=both  # compiles both v2 and v3 backends
 python install.py --gpp=g++-6             # use a specific compiler (needs g++ >= 6, LAPACK/BLAS)
 python install.py --doctor                # check build requirements only, skip the build
@@ -206,8 +206,8 @@ results can be cross-validated between the two solver families.
 \toprule
 \texttt{itensor\_version} & Engine & Requires & Fallback \\
 \midrule
-\texttt{2} (default) & ITensor v2, in-process C++ (mpscpp2) & compiled pybind11 ext. & ED \\
-\texttt{3} & ITensor v3, in-process C++ (mpscpp3) & compiled pybind11 ext. & ED \\
+\texttt{2} & ITensor v2, in-process C++ (mpscpp2) & compiled pybind11 ext. & ED \\
+\texttt{3} (default) & ITensor v3, in-process C++ (mpscpp3) & compiled pybind11 ext. & ED \\
 \texttt{"python"} & pure-Python \texttt{pyitensor/} & NumPy/SciPy only & none \\
 \texttt{"julia\_live"} & live in-process Julia (mpsjulialive), ITensors.jl & pyjulia + Julia & none (per-feature) \\
 \bottomrule
@@ -315,7 +315,7 @@ Dynamical correlators and generic operator distributions are computed
 with the Kernel Polynomial Method (\texttt{kpmdmrg.py};
 \texttt{Chain::kpm\_dynamical\_correlator} / \texttt{Chain::general\_kpm}
 in \texttt{chain\_session.h} on the C++ side;
-\texttt{pyfermion/algebra/kpm.py}-style moment recursion on the ED side)
+\texttt{algebra/kpm.py}-style moment recursion on the ED side)
 rather than by direct spectral decomposition, since exact
 diagonalization of the full spectrum is infeasible for large chains.
 
@@ -324,10 +324,17 @@ diagonalization of the full spectrum is infeasible for large chains.
 
 The pure-Python backend (\texttt{itensor\_version="python"}) trades raw
 speed for zero build dependencies. Numbers below were measured directly
-on one machine, with \texttt{numba} installed (pyitensor's default
-accelerated matvec/effective-Hamiltonian kernel, see
-\texttt{pyitensor/kernels.py}) --- absolute times will vary by machine
-and load, but the qualitative trends should hold.
+on one machine, with \texttt{numba} installed \emph{and} explicitly
+opted in (\texttt{pyitensor.kernels.USE\_NUMBA = True}) for its
+accelerated matvec/effective-Hamiltonian kernel (see
+\texttt{pyitensor/kernels.py}). This kernel is \textbf{not} used
+automatically just by having \texttt{numba} installed --- \texttt{USE\_NUMBA}
+defaults to \texttt{False}, because the one-time JIT compile cost is a
+net regression for this library's typical one-shot-script usage pattern
+(see \texttt{kernels.py}'s own docstring for measured numbers). Set
+\texttt{kernels.USE\_NUMBA = True} yourself before running DMRG if you
+want this path. Absolute times will vary by machine and load, but the
+qualitative trends should hold.
 
 \subsection{Ground state energy (Heisenberg spin-1/2 chain)}
 
@@ -407,7 +414,9 @@ ratios shown above, not these first-call numbers.
     CI/environments without a C++ toolchain, or small systems ($n
     \lesssim 20$) where the 1.3--2$\times$ overhead doesn't matter.
   \item Install \texttt{numba} (and optionally \texttt{jax}) alongside
-    the pure-Python backend --- without it, \texttt{pyitensor} falls back
+    the pure-Python backend \emph{and} set
+    \texttt{pyitensor.kernels.USE\_NUMBA = True} (off by default, see the
+    note above) --- without both steps, \texttt{pyitensor} falls back
     to plain NumPy loops and is substantially slower than the numbers
     above (see \texttt{pyitensor/\_\_init\_\_.py}'s own docstring).
   \item For production-size chains, dynamical correlators, or anything
@@ -415,9 +424,10 @@ ratios shown above, not these first-call numbers.
     (\texttt{python install.py}) and use \texttt{itensor\_version=2} or
     \texttt{3}.
   \item \texttt{examples/backend\_timing\_gs\_energy/main.py} reproduces
-    the ground-state table directly against the current codebase and
-    current machine --- re-run it rather than trusting these numbers
-    verbatim on a different setup.
+    the $n=8..20$ rows of the ground-state table directly against the
+    current codebase and current machine ($n=24..32$ aren't included, to
+    keep the example fast to run) --- re-run it rather than trusting
+    these numbers verbatim on a different setup.
 \end{itemize}
 
 \section{Directory reference}

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -453,28 +453,38 @@ parameter $\lambda$, the fidelity susceptibility measures how sharply
 the ground state changes as $\lambda$ varies — and diverges at a quantum
 phase transition, where the gap to the first excited state closes:
 
-$$\chi(\lambda)=\sum_{n\neq0}\frac{|\langle 0|H_1|n\rangle|^2}{(E_n-E_0)^2+\delta^2}\qquad(\text{perturbative form})$$
+$$\chi(\lambda)=\sum_{n\neq0}\frac{|\langle 0|H_1|n\rangle|^2}{(E_n-E_0)^2+\delta^2}\qquad(\text{perturbative form, }\texttt{fmode="PT"})$$
+
+`get_fidelity`'s **default** is not this perturbative form but a
+non-perturbative estimator (`fmode="derivative"`) that computes $\chi$
+directly from finite differences of the ground-state overlap matrix
+between nearby $\lambda$ values, which also handles a (near-)degenerate
+ground-state manifold via a smooth gauge choice:
 
 ```python
 from dmrgpy import fidelity
-chi = fidelity.get_fidelity(sc, h0, h1, lam, n=3)
+chi = fidelity.get_fidelity(sc, h0, h1, lam, n=3) # fmode="derivative" (default)
+chi_pt = fidelity.get_fidelity(sc, h0, h1, lam, n=3, fmode="PT") # perturbative form above
 ```
 
 Scanning $\lambda$ and plotting $\chi(\lambda)$, a peak (sharpening and
 diverging with system size) locates a quantum critical point without
-needing to know its universality class in advance. An alternative,
-non-perturbative estimator computes $\chi$ directly from finite
-differences of the ground-state overlap matrix between nearby $\lambda$
-values (`fmode="derivative"`), which also handles a (near-)degenerate
-ground-state manifold via a smooth gauge choice.
+needing to know its universality class in advance.
 
 ## 13. Ground-state degeneracy
 
 Exact and near (e.g.\ symmetry-protected, or finite-size-split
-topological) ground-state degeneracies are estimated by a
-Gaussian-broadened level count around the ground-state energy:
+topological) ground-state degeneracies are estimated by a narrow,
+super-Gaussian-broadened level count around the ground-state energy
+(`degeneracy.py`'s `gs_degeneracy_simple`/`eigenvalue_degeneracy`):
 
-$$g(E_0)\approx\sum_i\exp\!\left[-\left(\frac{E_i-E_0}{\delta}\right)^2\right]$$
+$$g(E_0)\approx\sum_i\exp\!\left[-\left(\frac{(E_i-E_0)^2}{\delta}\right)^2\right]$$
+
+Note the quartic falloff in $(E_i-E_0)$ (not a plain Gaussian) — this
+makes the window considerably narrower than $\delta$ would suggest for a
+standard Gaussian, so `delta` needs to be picked accordingly (typically
+larger than the target energy resolution) to count near-degenerate
+levels rather than only exactly-degenerate ones.
 
 summed over a growing number of low-lying computed eigenstates $E_i$
 until the count converges — a value near an integer $g$ signals a

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -562,31 +562,42 @@ closes:
 
 \begin{equation}
 \chi(\lambda)=\sum_{n\neq0}\frac{|\langle 0|H_1|n\rangle|^2}{(E_n-E_0)^2+\delta^2}
-\qquad(\text{perturbative form})
+\qquad(\text{perturbative form, }\texttt{fmode="PT"})
 \end{equation}
+
+\texttt{get\_fidelity}'s \textbf{default} is not this perturbative form
+but a non-perturbative estimator (\texttt{fmode="derivative"}) that
+computes $\chi$ directly from finite differences of the ground-state
+overlap matrix between nearby $\lambda$ values, which also handles a
+(near-)degenerate ground-state manifold via a smooth gauge choice:
 
 \begin{lstlisting}
 from dmrgpy import fidelity
-chi = fidelity.get_fidelity(sc, h0, h1, lam, n=3)
+chi = fidelity.get_fidelity(sc, h0, h1, lam, n=3) # fmode="derivative" (default)
+chi_pt = fidelity.get_fidelity(sc, h0, h1, lam, n=3, fmode="PT") # perturbative form above
 \end{lstlisting}
 
 Scanning $\lambda$ and plotting $\chi(\lambda)$, a peak (sharpening and
 diverging with system size) locates a quantum critical point without
-needing to know its universality class in advance. An alternative,
-non-perturbative estimator computes $\chi$ directly from finite
-differences of the ground-state overlap matrix between nearby $\lambda$
-values (\texttt{fmode="derivative"}), which also handles a
-(near-)degenerate ground-state manifold via a smooth gauge choice.
+needing to know its universality class in advance.
 
 \section{Ground-state degeneracy}
 
 Exact and near (e.g.\ symmetry-protected, or finite-size-split
-topological) ground-state degeneracies are estimated by a
-Gaussian-broadened level count around the ground-state energy:
+topological) ground-state degeneracies are estimated by a narrow,
+super-Gaussian-broadened level count around the ground-state energy
+(\texttt{degeneracy.py}'s \texttt{gs\_degeneracy\_simple}/
+\texttt{eigenvalue\_degeneracy}):
 
 \begin{equation}
-g(E_0)\approx\sum_i\exp\!\left[-\left(\frac{E_i-E_0}{\delta}\right)^2\right]
+g(E_0)\approx\sum_i\exp\!\left[-\left(\frac{(E_i-E_0)^2}{\delta}\right)^2\right]
 \end{equation}
+
+Note the quartic falloff in $(E_i-E_0)$ (not a plain Gaussian) --- this
+makes the window considerably narrower than $\delta$ would suggest for a
+standard Gaussian, so \texttt{delta} needs to be picked accordingly
+(typically larger than the target energy resolution) to count
+near-degenerate levels rather than only exactly-degenerate ones.
 
 summed over a growing number of low-lying computed eigenstates $E_i$
 until the count converges --- a value near an integer $g$ signals a

--- a/examples/backend_switch_consistency/main.py
+++ b/examples/backend_switch_consistency/main.py
@@ -1,0 +1,54 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
+
+# Regression test for a real bug: Many_Body_Chain.setup_cpp()/
+# setup_python()/setup_julia() -- the documented way to "switch an
+# existing chain between backends" (see CLAUDE.md) -- used to leave
+# self.computed_gs/self.wf0/self.e0 pointing at the OLD backend's
+# ground state. Concretely this meant:
+#   (1) gs_energy() after switching silently returned the stale energy
+#       from the previous backend instead of recomputing on the new one
+#       (gs_energy()'s "if self.computed_gs: return self.e0" fired first);
+#   (2) vev() then handed the OLD backend's MPS cpp_handle to the NEW
+#       backend's C++ session, which is a hard TypeError (an mpscpp2 MPS
+#       is not valid input to an mpscpp3 Chain.vev(), or vice versa).
+# Fixed by resetting that cached state whenever the backend changes. This
+# test builds one chain, computes on v2, switches to v3, and checks both
+# that nothing crashes and that the post-switch results are genuinely
+# fresh v3 results (matching ED), not silently-reused v2 leftovers.
+import numpy as np
+from dmrgpy import spinchain
+
+n = 4 # small enough for ED
+spins = ["S=1/2" for i in range(n)]
+sc = spinchain.Spin_Chain(spins, itensor_version=2)
+
+h = 0
+for i in range(n-1):
+    h = h + sc.Sx[i]*sc.Sx[i+1] + sc.Sy[i]*sc.Sy[i+1] + sc.Sz[i]*sc.Sz[i+1]
+sc.set_hamiltonian(h)
+e_v2 = sc.gs_energy(mode="DMRG")
+vev_v2 = sc.vev(sc.Sz[0], mode="DMRG").real
+print("v2: energy =",e_v2,"  <Sz_0> =",vev_v2)
+
+# Switch backend on the SAME chain object, WITHOUT calling
+# set_hamiltonian() again -- this is exactly the pattern that used to
+# crash/return stale results. (set_hamiltonian()'s default restart=True
+# already resets the ground-state cache as a side effect, which is why
+# this bug only shows up when the Hamiltonian is *not* re-set after the
+# switch -- reusing the same Hamiltonian across a backend switch is
+# precisely the use case setup_cpp()/setup_python() exist for.)
+sc.setup_cpp(3)
+e_v3 = sc.gs_energy(mode="DMRG")
+vev_v3 = sc.vev(sc.Sz[0], mode="DMRG").real
+print("v3 (after switch): energy =",e_v3,"  <Sz_0> =",vev_v3)
+
+e_ed = sc.gs_energy(mode="ED")
+print("ED (ground truth): energy =",e_ed)
+
+tol = 1e-3
+diff = abs(e_v3-e_ed)
+print("Difference v3 (post-switch) vs ED =",diff)
+assert diff<tol, "post-switch v3 energy disagrees with ED by %g (tol=%g) -- looks like a stale cache"%(diff,tol)
+
+print("TEST PASSED")

--- a/examples/thermal_purification_VS_exact/main.py
+++ b/examples/thermal_purification_VS_exact/main.py
@@ -1,0 +1,60 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
+
+# Regression test for a real physics bug: thermal.py's anneal() used to
+# dose the purified wavefunction with the FULL beta=1/T instead of
+# beta/2, i.e. it applied |Psi(beta)> = e^{-beta H}|Psi(0)> instead of
+# the standard purification convention |Psi(beta)> = e^{-beta H/2}|Psi(0)>
+# (needed so that tracing out the ancilla gives rho ~ e^{-beta H}, the
+# actual thermal state of T). Confirmed directly: Thermal_Spin_Chain(T=1)
+# used to report the thermal energy of the exact T=0.5 state, not T=1 --
+# i.e. every finite-T calculation through this class was silently
+# computing at T/2. Fixed by using beta/2 as the imaginary-time dose.
+# This test checks the purification-based thermal energy directly
+# against an exact Boltzmann-weighted average over ED eigenvalues.
+import numpy as np
+from dmrgpy import spinchain
+from dmrgpy import thermal
+
+n = 4 # small enough for exact diagonalization
+spins = ["S=1/2" for i in range(n)]
+T = 1.0
+
+# exact reference: Tr[H exp(-H/T)] / Tr[exp(-H/T)] via full ED spectrum
+sc_ed = spinchain.Spin_Chain(spins)
+h_ed = 0
+for i in range(n-1):
+    h_ed = h_ed + sc_ed.Sx[i]*sc_ed.Sx[i+1] + sc_ed.Sy[i]*sc_ed.Sy[i+1] + sc_ed.Sz[i]*sc_ed.Sz[i+1]
+sc_ed.set_hamiltonian(h_ed)
+Hmat = sc_ed.get_ED_obj().get_hamiltonian()
+Hmat = Hmat.toarray() if hasattr(Hmat,"toarray") else Hmat
+evals = np.linalg.eigvalsh(Hmat)
+w = np.exp(-(evals-evals.min())/T)
+e_exact = np.sum(evals*w)/np.sum(w)
+print("Exact thermal energy (T=%.2f) ="%T, e_exact)
+
+# purification-based thermal energy (mode="ED" so no compiled extension
+# is needed for the ancilla chain's ground state / annealing steps)
+tc = thermal.Thermal_Spin_Chain(spins)
+h = 0
+for i in range(n-1):
+    h = h + tc.Sx[i]*tc.Sx[i+1] + tc.Sy[i]*tc.Sy[i+1] + tc.Sz[i]*tc.Sz[i+1]
+tc.set_hamiltonian(h)
+tc.T = T
+tc.mode = "ED"
+wf = tc.get_gs()
+e_purification = wf.dot(h*wf).real
+print("Purification thermal energy (T=%.2f) ="%T, e_purification)
+
+diff = abs(e_purification-e_exact)
+print("Difference =",diff)
+
+# Generous tolerance: anneal() uses first-order Euler steps (dbeta=0.1
+# by default), so some discretization error versus the exact Boltzmann
+# average is expected -- this tolerance is meant to catch a real
+# regression (e.g. the old missing-factor-of-2 bug, which was off by
+# nearly 2x in energy, not this), not to pin down the discretization.
+tol = 0.05
+assert diff<tol, "purification thermal energy disagrees with exact ED by %g (tol=%g) -- check thermal.py's anneal() beta schedule"%(diff,tol)
+
+print("TEST PASSED")

--- a/examples/v2_VS_v3_boson/main.py
+++ b/examples/v2_VS_v3_boson/main.py
@@ -1,0 +1,54 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
+
+# Regression test: ground state energy of a bosonic Bose-Hubbard-like
+# chain must agree across ITensor v2, v3, ED, and the pure-Python
+# backend. There was previously no v2_VS_v3_* comparison for the boson
+# model at all (unlike spin, fermion, parafermion chains) -- this fills
+# that gap, at a size (n=6) beyond the n=3 covered by
+# examples/bosonic_hubbard/main.py. n is capped at 6 (not pushed further,
+# unlike the other v2_VS_v3_* tests) because ED needs the full Hilbert
+# space dimension (Bosonic_Chain's default per-site dimension^n) under
+# get_ED_obj()'s own 10000 cutoff -- 4**6=4096, 4**7=16384.
+import numpy as np
+from dmrgpy import bosonchain
+
+n = 6
+
+def get_energy(itensor_version, mode="DMRG"):
+    bc = bosonchain.Bosonic_Chain(n)
+    # Switch backend *before* seeding random couplings: constructing the
+    # pure-Python backend consumes draws from numpy's global RNG as a side
+    # effect (unlike v2/v3, which never touch np.random), so seeding
+    # first would silently desync "the same" Hamiltonian across backends
+    # -- see examples/v2_VS_v3_parafermion/main.py for the concrete
+    # failure this caused when gotten wrong.
+    if itensor_version!="python": bc.setup_cpp(itensor_version)
+    else: bc.setup_python()
+    np.random.seed(11)
+    h = 0
+    for i in range(n-1):
+        h = h + np.random.random()*(bc.Adag[i]*bc.A[i+1] + bc.Adag[i+1]*bc.A[i])
+    for i in range(n):
+        den = bc.Adag[i]*bc.A[i]
+        h = h + 0.3*den*den
+    bc.set_hamiltonian(h)
+    return bc.gs_energy(mode=mode)
+
+e2 = get_energy(2)
+e3 = get_energy(3)
+eed = get_energy(2, mode="ED")
+epy = get_energy("python") # n=8 < 10, python backend is in scope
+
+print("Ground state energy (ITensor v2)  =",e2)
+print("Ground state energy (ITensor v3)  =",e3)
+print("Ground state energy (ED)          =",eed)
+print("Ground state energy (pure Python) =",epy)
+
+tol = 1e-2
+for name,e in [("v3",e3),("ED",eed),("python",epy)]:
+    diff = abs(e2-e)
+    print("Difference v2 vs %s = %.2e"%(name,diff))
+    assert diff<tol, "v2 vs %s disagree by %g (tol=%g)"%(name,diff,tol)
+
+print("TEST PASSED")

--- a/examples/v2_VS_v3_large_heisenberg/main.py
+++ b/examples/v2_VS_v3_large_heisenberg/main.py
@@ -1,0 +1,37 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
+
+# Regression test: ITensor v2 and v3 must keep agreeing on the ground
+# state energy of a Heisenberg spin-1/2 chain at larger system sizes
+# (n>=20), not just the small n=8 case covered by
+# examples/v2_VS_v3_heisenberg_spin_half. ED is not feasible at these
+# sizes, so this checks DMRG-vs-DMRG cross-backend consistency instead.
+# Added after directly comparing dmrgpy's current in-process v2/v3
+# backends against the old (pre-rewrite) file-based v2 backend at
+# n=20..32 and finding agreement to ~1e-6..1e-14 (normal DMRG variational
+# noise from differing internal sweep paths, not a regression) -- this
+# test locks in that same v2-vs-v3 agreement going forward.
+import numpy as np
+from dmrgpy import spinchain
+
+sizes = [16, 24, 32]
+
+def get_energy(itensor_version, n):
+    spins = ["S=1/2" for i in range(n)]
+    sc = spinchain.Spin_Chain(spins, itensor_version=itensor_version)
+    h = 0
+    for i in range(n-1):
+        h = h + sc.Sx[i]*sc.Sx[i+1] + sc.Sy[i]*sc.Sy[i+1] + sc.Sz[i]*sc.Sz[i+1]
+    sc.set_hamiltonian(h)
+    return sc.gs_energy(mode="DMRG")
+
+tol = 1e-3 # generous: only meant to catch a real divergence, not to pin
+           # down DMRG's sweep-to-sweep numerical noise
+for n in sizes:
+    e2 = get_energy(2, n)
+    e3 = get_energy(3, n)
+    diff = abs(e2-e3)
+    print("n=%d  v2=%.10f  v3=%.10f  diff=%.2e"%(n, e2, e3, diff))
+    assert diff<tol, "v2 vs v3 disagree by %g at n=%d (tol=%g)"%(diff, n, tol)
+
+print("TEST PASSED")

--- a/examples/v2_VS_v3_parafermion/main.py
+++ b/examples/v2_VS_v3_parafermion/main.py
@@ -1,0 +1,61 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
+
+# Regression test: ground state energy of a Z3 parafermion chain must
+# agree across ITensor v2, v3, and ED. There was previously no
+# v2_VS_v3_* comparison for the parafermion model at all (unlike spin,
+# fermion, boson chains), and ED mode used to crash outright here with
+# "KeyError: ('Id', 1)" -- multioperator.py's MO2matrix (the ED
+# evaluation path) didn't filter the zero-coefficient "Id" placeholder
+# term that "0 + MultiOperator" (the pervasive "h = 0; h = h + term"
+# idiom) creates via __radd__, so it tried (and failed) to look up an
+# operator ED's parafermion backend never registered. Fixed by filtering
+# near-zero-coefficient terms in MO2matrix, matching what to_terms()
+# already does for the DMRG path -- this test locks that fix in.
+import numpy as np
+from dmrgpy import parafermionchain
+
+n = 6
+
+def get_energy(itensor_version, mode="DMRG"):
+    pc = parafermionchain.Parafermionic_Chain(n)
+    # Switch backend *before* seeding: constructing the pure-Python backend
+    # (setup_python()) consumes draws from numpy's global RNG as a side
+    # effect (its internal random-state initialization), unlike v2/v3 which
+    # never touch np.random. Seeding before this point would desync the
+    # "same" Hamiltonian across backends -- confirmed directly: an earlier
+    # version of this test seeded first and saw the python backend land on
+    # a wildly different (and wrongly suspected buggy) energy purely
+    # because it solved a different random Hamiltonian, not because of any
+    # real physics bug.
+    if itensor_version!="python": pc.setup_cpp(itensor_version)
+    else: pc.setup_python()
+    np.random.seed(3) # same Hamiltonian for every backend
+    h = 0
+    for i in range(n):
+        for j in range(n):
+            h = h + pc.N[i]*pc.N[j]*np.random.random()
+            h = h + pc.Sig[i]*pc.Sigd[j]*np.random.random()
+            h = h + pc.Tau[i]*pc.Taud[j]*np.random.random()
+    h = h + h.get_dagger() # Hermitize, this is what creates the stray
+                            # zero "Id" term the fix above addresses
+    pc.set_hamiltonian(h)
+    return pc.gs_energy(mode=mode)
+
+e2 = get_energy(2)
+e3 = get_energy(3)
+eed = get_energy(2, mode="ED") # was: KeyError('Id', 1) before the fix
+epy = get_energy("python") # n=6 < 10, python backend is in scope
+
+print("Ground state energy (ITensor v2)  =",e2)
+print("Ground state energy (ITensor v3)  =",e3)
+print("Ground state energy (ED)          =",eed)
+print("Ground state energy (pure Python) =",epy)
+
+tol = 1e-2
+for name,e in [("v3",e3),("ED",eed),("python",epy)]:
+    diff = abs(e2-e)
+    print("Difference v2 vs %s = %.2e"%(name,diff))
+    assert diff<tol, "v2 vs %s disagree by %g (tol=%g)"%(name,diff,tol)
+
+print("TEST PASSED")

--- a/src/dmrgpy/manybodychain.py
+++ b/src/dmrgpy/manybodychain.py
@@ -137,18 +137,38 @@ class Many_Body_Chain():
           from . import cppext
           out._session = cppext.get_backend(self.itensor_version).Chain(out.sites)
       return out
+  def _reset_dmrg_state(self):
+      """Invalidate any cached ground state computed under the previous
+      backend/session. Without this, switching backend on an existing
+      chain (setup_cpp/setup_python/setup_julia) would leave
+      self.computed_gs=True and self.wf0 pointing at the OLD backend's
+      wavefunction: gs_energy() would then silently return the stale
+      energy without recomputing on the new backend, and vev()/get_gs()
+      would hand the old backend's MPS handle to the new backend's
+      session (a hard crash for the C++ backends, since an mpscpp2 MPS
+      cpp_handle is not valid input to an mpscpp3 Chain, or vice versa).
+      Same fields restart() resets, minus has_ED_obj (the ED backend is
+      independent of itensor_version, so it doesn't need invalidating
+      just because the DMRG backend changed)."""
+      self.computed_gs = False
+      self.gs_from_file = False
+      self.skip_dmrg_gs = False
+      self.wf0 = None
   def setup_julia(self):
       """Setup the Julia mode"""
       self.itensor_version = "julia_live"
+      self._reset_dmrg_state()
       self.initialize()
   def setup_cpp(self,version=DEFAULT_ITENSOR_VERSION):
       """Setup the C++ mode (version 2 = ITensor v2, 3 = ITensor v3)"""
       self.itensor_version = version
+      self._reset_dmrg_state()
       self.initialize()
   def setup_python(self):
       """Setup the pure-Python DMRG backend (pyitensor.chain.Chain, no
       compiler/pybind11 needed) -- see cppext.py."""
       self.itensor_version = "python"
+      self._reset_dmrg_state()
       self.initialize()
   def get_mode(self,**kwargs):
       from .mode import get_mode

--- a/src/dmrgpy/mode.py
+++ b/src/dmrgpy/mode.py
@@ -29,6 +29,22 @@ def get_mode(self,mode="DMRG"):
         if not cppext.available(self.itensor_version):
             print("C++ extension not compiled, using default ED routines")
             return "ED" # use exact diagonalization
+    # ITensor v3's dmrg() always does two-site updates (see chain_session.h's
+    # dmrg_args()) and its sweep loop aborts the whole process (SIGABRT,
+    # "LocalOp is default constructed" deep inside ITensor's own
+    # DMRGWorker/davidson sweep loop, mps/localop.h) rather than raising a
+    # catchable Python exception, for chains with too few sites to have a
+    # well-defined sweep range. Confirmed empirically: n=1 and n=2 both
+    # abort (regardless of model or Hamiltonian -- tried spin, fermionic,
+    # diagonal-only and hopping terms), n=3 is fine. That sweep loop is
+    # vendored ITensor code (mpscpp3/ITensor/), out of scope to patch here,
+    # so fall back to ED for these unsupported sizes, same as the
+    # extension-not-compiled fallback above. v2 and the pure-Python backend
+    # both handle n=1/n=2 correctly and are unaffected.
+    if self.itensor_version==3 and self.ns<3:
+        print("ITensor v3's two-site DMRG can't handle a chain this short "
+              "(n=%d < 3 sites), using default ED routines"%self.ns)
+        return "ED" # use exact diagonalization
     # if there is an enforced mode, then use that one
     if self.mode is not None: return self.mode # use the enforced mode
     else:

--- a/src/dmrgpy/multioperator.py
+++ b/src/dmrgpy/multioperator.py
@@ -289,7 +289,15 @@ def MO2matrix(MO,obj):
     """Given a certain object containing the method "get_operator",
     return a matrix"""
     out = 0.0*obj.get_identity() # initialize
-    for iop in MO.op: # loop over components
+    # This is a consumption point (like write()/to_terms()), so drop
+    # near-zero-coefficient terms here too -- e.g. the "0*identity()"
+    # placeholder that "0 + MultiOperator" (the "h = 0; h = h + term"
+    # idiom used pervasively across this codebase) creates via __radd__.
+    # Without this, a term naming an operator/site combination that was
+    # never registered with obj (e.g. Parafermionic_Chain's ED backend
+    # has no ("Id",1) entry) crashes get_operator() below even though
+    # its contribution is exactly zero.
+    for iop in _filter_small(MO.op): # loop over components
         otmp = iop[0]*obj.get_identity() # factor
         for i in range(len(iop)-1): # loop over terms in the product
             term = iop[i+1] # get this term

--- a/src/dmrgpy/thermal.py
+++ b/src/dmrgpy/thermal.py
@@ -60,9 +60,16 @@ class Thermal_Spin_Chain():
                 
 def anneal(sc,h,wf,T,dbeta=0.1):
     """Anneal a certain wavefunction using an exponential"""
-    beta = 1./T # beta part
-    n = int(beta/dbeta) # number of steps
-    h0 = h*(beta/n) # this temperature step
+    # Purification convention: |Psi(beta)> = e^{-beta*H/2}|Psi(0)>, so that
+    # tracing out the ancilla out of |Psi(beta)><Psi(beta)| gives
+    # rho ~ e^{-beta*H}, i.e. the physical thermal state at the requested
+    # T = 1/beta. Applying the full beta here (as this used to) doses the
+    # wavefunction with e^{-beta*H} instead of e^{-beta*H/2}, which after
+    # tracing out the ancilla is the thermal state of T/2, not T -- confirmed
+    # numerically against exact ED thermal averages (see docs/user_guide).
+    beta_half = 1./(2.*T) # half-beta part
+    n = int(beta_half/dbeta) # number of steps
+    h0 = h*(beta_half/n) # this temperature step
     wf = wf.normalize() # normalize
     for i in range(n): # do as many steps
         print("Annealing, energy",wf.dot(h*wf).real)


### PR DESCRIPTION
## Summary

Follow-up to the code review on this branch. The user asked to compare current DMRG/ED results (v2, v3, and the pure-Python backend on systems <10 sites) against the codebase from 4 days ago (commit `2701a072`), on systems <20 sites. That comparison surfaced two real regressions plus a couple of pre-existing bugs and doc errors, all fixed here.

- **`multioperator.py`**: `MO2matrix` (the ED evaluation path) now drops near-zero-coefficient terms before consuming them, matching what `to_terms()` already does for the DMRG path. Without this, the zero-coefficient `"Id"` placeholder term created by `0 + MultiOperator` (the `h = 0; h = h + term` idiom used throughout the codebase) survived into ED's raw operator lookup and crashed with `KeyError` for parafermion chains. Confirmed regression: `examples/parafermion_energy/main.py` crashed at HEAD but ran fine at the 4-day-old baseline.
- **`mode.py`**: falls back to ED when `itensor_version=3` and the chain has fewer than 3 sites. ITensor v3's two-site `dmrg()` hard-aborts (`SIGABRT`, "LocalOp is default constructed") on such chains instead of raising a catchable exception. `examples/hubbard_site/main.py` (an n=2 chain) crashed under the current default backend before this fix; v2 was default 4 days ago and didn't hit this.
- **`manybodychain.py`**: `setup_cpp()`/`setup_python()`/`setup_julia()` now reset the cached ground state. Previously, switching backend on an existing chain silently returned the stale energy from the old backend, or crashed `vev()` by handing the old backend's MPS handle to the new backend's session. Pre-existing (not a new regression), but undermines the documented "switch an existing chain between backends" pattern.
- **`thermal.py`**: `anneal()` now doses the purified wavefunction with `beta/2` instead of the full `beta`, matching the standard purification convention and the existing docs. Confirmed numerically against exact ED thermal averages.
- **`docs/documentation.{md,tex}`** and **`docs/user_guide.{md,tex}`**: fixed several factual errors found while fact-checking the new docs against source (wrong default backend, wrong file path, numba-on-by-default claim, degeneracy formula, `get_fidelity` default mode).

## Test plan

- [x] `examples/parafermion_energy/main.py` runs end-to-end (previously crashed in ED mode)
- [x] `examples/hubbard_site/main.py` runs end-to-end (previously `SIGABRT`)
- [x] `examples/MPS_VS_ED/main.py`, `examples/bilinear_biquadratic/main.py` re-verified, no regressions
- [x] `thermal.py` fix verified against exact ED thermal-average ground truth
- [x] Backend-switch fix verified: no crash, correct recomputation, on both a short (ED-fallback) and normal chain
- [x] Both `docs/*.tex` recompile cleanly with `pdflatex` (no errors, no undefined references after a full pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RW4YMmaZh1K9rbtf9CJMaH