### PR TITLE
Add TDZ: complex-time-evolution dynamical correlator (arXiv:2311.10909)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -247,6 +247,48 @@ moment recursion on the ED side) rather than by direct spectral
 decomposition, since exact diagonalization of the full spectrum is
 infeasible for large chains.
 
+### 4.9 TDZ / complex-time-evolution dynamical correlator
+
+`tdz.py` implements `submode="TDZ"` (Cao, Lu, Stoudenmire & Parcollet,
+"Dynamical correlation functions from complex time evolution",
+arXiv:2311.10909): instead of evolving along the real-time axis
+(`submode="TD"`, `timedependent.py`), it evolves along a complex-time
+contour `z(t,alpha0)`, whose negative imaginary part damps high-energy
+content as the simulation proceeds, keeping the MPS bond dimension
+needed for a given accuracy much smaller than under real-time evolution
+alone. The true real-time correlator is then recovered order by order
+via a perturbative Taylor expansion in `alpha0` around the simulated
+contour (`_reconstruct_real_axis`, hardcoding the paper's own explicit
+n<=4 Appendix-B formulas). Each order needs only a fixed set of
+precomputed overlap targets (`{H^n(B|GS>)}`, built once via repeated
+`toMPO`/`StaticOperator` application, independent of t) plus pure scalar
+contour integrals -- no new tensor-network machinery beyond a single new
+per-step propagator primitive:
+
+- **`itensor_version` 3 or `"python"`, `tevol_method="TDVP"`** (the
+  paper's own setup): a single two-site-TDVP step with a *complex* time
+  argument -- `pyitensor/tdvp.py`'s Krylov-exponentiation core
+  (`_lanczos_expm_multiply`) was already fully generic to complex
+  coefficients with no changes needed; `mpscpp3/chain_session.h`'s
+  `Chain::tdvp_step` (moved from a private helper to a public method and
+  widened from `double dt` to `Cplx dt`) simply forwards to the vendored
+  `TDVP/tdvp.h`, which documents its own time argument as natively "real,
+  imaginary, or complex".
+- **`itensor_version=2`** (mpscpp2 has no TDVP at all): a single
+  MPO-Taylor step, `Chain::evolve_taylor_step` in both
+  `mpscpp2/chain_session.h` and `mpscpp3/chain_session.h` (the latter as
+  a cross-check / non-TDVP alternative), built on the existing
+  `evoloperator()` Taylor-expansion of `exp(z*H)` (also mpscpp2-only,
+  now widened from a real `dt` to a complex `z` throughout, including
+  `pyitensor/chain.py`'s own `_evoloperator`) -- the pre-existing
+  deliberately-reproduced "z^3/6 multiplies H2 not H3" quirk (see
+  CLAUDE.md) is unaffected by this widening.
+
+Current scope: only the "greater" branch of the correlator is computed
+(the same simplification `submode="TD"` already makes), fed into the
+same windowing/FFT tail as `"TD"` (factored out into
+`timedependent._fourier_transform_correlator` so both submodes share it).
+
 ## 5. Backend performance: v3 vs the pure-Python backend
 
 The pure-Python backend (`itensor_version="python"`) trades raw speed for
@@ -346,6 +388,7 @@ shown in §5.1/§5.2, not these first-call numbers.
 | `src/dmrgpy/mpsjulialive/`, `mpsjulia/` | Julia/ITensors.jl backend modules |
 | `src/dmrgpy/edtk/`, `pyfermion/`, `pyspin/`, `pyboson/`, `pyzn/` | exact-diagonalization backend |
 | `src/dmrgpy/kpmdmrg.py` | Kernel Polynomial Method dynamical correlators |
+| `src/dmrgpy/tdz.py` | complex-time-evolution dynamical correlator ("TDZ", arXiv:2311.10909) |
 | `examples/` | 100+ self-contained example scripts (also the regression suite) |
 | `examples/v2_VS_v3_*` | backend-vs-backend correctness comparisons |
 | `examples/backend_timing_gs_energy/` | backend-vs-backend timing comparison |

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -318,6 +318,56 @@ in \texttt{chain\_session.h} on the C++ side;
 rather than by direct spectral decomposition, since exact
 diagonalization of the full spectrum is infeasible for large chains.
 
+\subsection{TDZ / complex-time-evolution dynamical correlator}
+
+\texttt{tdz.py} implements \texttt{submode="TDZ"} (Cao, Lu, Stoudenmire
+\& Parcollet, ``Dynamical correlation functions from complex time
+evolution,'' arXiv:2311.10909): instead of evolving along the real-time
+axis (\texttt{submode="TD"}, \texttt{timedependent.py}), it evolves
+along a complex-time contour $z(t,\alpha_0)$, whose negative imaginary
+part damps high-energy content as the simulation proceeds, keeping the
+MPS bond dimension needed for a given accuracy much smaller than under
+real-time evolution alone. The true real-time correlator is then
+recovered order by order via a perturbative Taylor expansion in
+$\alpha_0$ around the simulated contour
+(\texttt{\_reconstruct\_real\_axis}, hardcoding the paper's own explicit
+$n\le4$ Appendix~B formulas). Each order needs only a fixed set of
+precomputed overlap targets ($\{H^n(B|\mathrm{GS}\rangle)\}$, built once
+via repeated \texttt{toMPO}/\texttt{StaticOperator} application,
+independent of $t$) plus pure scalar contour integrals -- no new
+tensor-network machinery beyond a single new per-step propagator
+primitive:
+
+\begin{itemize}
+\item \textbf{\texttt{itensor\_version} 3 or \texttt{"python"},
+\texttt{tevol\_method="TDVP"}} (the paper's own setup): a single
+two-site-TDVP step with a \emph{complex} time argument --
+\texttt{pyitensor/tdvp.py}'s Krylov-exponentiation core
+(\texttt{\_lanczos\_expm\_multiply}) was already fully generic to
+complex coefficients with no changes needed;
+\texttt{mpscpp3/chain\_session.h}'s \texttt{Chain::tdvp\_step} (moved
+from a private helper to a public method and widened from
+\texttt{double dt} to \texttt{Cplx dt}) simply forwards to the vendored
+\texttt{TDVP/tdvp.h}, which documents its own time argument as natively
+``real, imaginary, or complex.''
+\item \textbf{\texttt{itensor\_version=2}} (mpscpp2 has no TDVP at
+all): a single MPO-Taylor step, \texttt{Chain::evolve\_taylor\_step} in
+both \texttt{mpscpp2/chain\_session.h} and
+\texttt{mpscpp3/chain\_session.h} (the latter as a cross-check /
+non-TDVP alternative), built on the existing \texttt{evoloperator()}
+Taylor expansion of $\exp(zH)$ (also mpscpp2-only, now widened from a
+real \texttt{dt} to a complex \texttt{z} throughout, including
+\texttt{pyitensor/chain.py}'s own \texttt{\_evoloperator}) -- the
+pre-existing deliberately-reproduced ``$z^3/6$ multiplies H2 not H3''
+quirk (see CLAUDE.md) is unaffected by this widening.
+\end{itemize}
+
+Current scope: only the ``greater'' branch of the correlator is
+computed (the same simplification \texttt{submode="TD"} already makes),
+fed into the same windowing/FFT tail as \texttt{"TD"} (factored out into
+\texttt{timedependent.\_fourier\_transform\_correlator} so both
+submodes share it).
+
 \section{Backend performance: v3 vs the pure-Python backend}
 \label{sec:perf}
 
@@ -446,6 +496,7 @@ Path & Contents \\
 \texttt{src/dmrgpy/mpsjulialive/}, \texttt{mpsjulia/} & Julia/ITensors.jl backend modules \\
 \texttt{src/dmrgpy/edtk/}, \texttt{pyfermion/}, \texttt{pyspin/}, \texttt{pyboson/}, \texttt{pyzn/} & exact-diagonalization backend \\
 \texttt{src/dmrgpy/kpmdmrg.py} & Kernel Polynomial Method dynamical correlators \\
+\texttt{src/dmrgpy/tdz.py} & complex-time-evolution dynamical correlator (``TDZ'', arXiv:2311.10909) \\
 \texttt{examples/} & 100+ self-contained example scripts (also the regression suite) \\
 \texttt{examples/v2\_VS\_v3\_*} & backend-vs-backend correctness comparisons \\
 \texttt{examples/backend\_timing\_gs\_energy/} & backend-vs-backend timing comparison \\

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -289,6 +289,54 @@ fine resolution over a *narrow* frequency window, at the cost of a real
 dynamical simulation (bond dimension grows with entanglement generated
 during the evolution).
 
+**`submode="TDZ"` — complex-time evolution (Cao, Lu, Stoudenmire &
+Parcollet, arXiv:2311.10909).** Real-time evolution (`"TD"` above) grows
+entanglement, so the MPS bond dimension needed for a given accuracy
+grows with the simulated time $T$. TDZ instead evolves along a complex
+time contour
+
+$$z(t,\alpha_0)=\int_0^t e^{-i\alpha_0 f(t')}\,dt',\qquad f(t)=e^{-t\omega_0},\qquad \omega_0=2\pi/t_{\max}$$
+
+Since $\mathrm{Im}\,z(t,\alpha_0)<0$ for $\alpha_0>0$, this progressively
+damps high-energy content as it evolves, so the bond dimension needed
+for a given accuracy grows far more slowly than under real-time
+evolution alone (the original paper reports $\chi\sim20$–$30$ vs
+$\chi\sim500$–$700$ for comparable accuracy on the Anderson impurity
+model). The true real-time ($\alpha_0=0$) correlator is then recovered
+order by order via a perturbative Taylor expansion in $\alpha_0$ around
+the simulated contour,
+
+$$C(t,0)\approx\phi^{(0)}(t,\alpha_0)+\sum_{n=1}^{n_{\max}}g^{(n)}(t,\alpha_0)$$
+
+where $\phi^{(n)}(t,\alpha_0)=\langle H^n B|\mathrm{GS}\rangle\cdot
+|\psi(t,\alpha_0)\rangle$ (precomputed once per $n$, reused as a fixed
+overlap target at every time step) and $g^{(n)}$ are explicit
+combinatorial expressions in $\phi^{(1..n)}$ and the pure contour
+integrals $J^{(n)}(t,\alpha_0)=-i\,\partial^n_{\alpha_0}z(t,\alpha_0)$
+(see the paper's Appendix B; this implementation hardcodes $n\le4$,
+which the paper finds always suffices for $\alpha_0\lesssim0.3$). The
+reconstructed $C(t,0)$ is then windowed/Fourier-transformed exactly as
+in `"TD"`.
+
+```python
+(x, y) = sc.get_dynamical_correlator(mode="DMRG", submode="TDZ",
+                                      name=(sc.Sz[0], sc.Sz[0]),
+                                      alpha0=0.1, n_max=4, dt=0.05)
+```
+
+`alpha0` is the contour angle parameter (larger reduces the bond
+dimension needed further, but requires a larger `n_max` to reconstruct
+the real axis accurately); `n_max` (≤4) is the reconstruction order;
+`dt`/`tmax`/`nt` set the underlying time step/duration exactly as in
+`"TD"`. Uses two-site TDVP when available (`itensor_version` 3 or
+`"python"`, `tevol_method="TDVP"`, the paper's own setup) or falls back
+to the MPO-Taylor propagator otherwise (`itensor_version=2`, which has
+no TDVP) — the same TDVP-vs-Taylor choice `"TD"` already makes. Current
+scope: only the "greater" branch of the correlator is computed (the same
+simplification `"TD"` itself already makes), so this is best used the
+same way as `"TD"`: high-resolution work in a narrow frequency window,
+now reachable at a lower bond-dimension cost for a given simulated time.
+
 **`submode="EX"` — exact diagonalization in a truncated DMRG subspace.**
 Builds $A$, $B$, $H$ explicitly in the subspace spanned by the lowest
 `nex` (orthogonalized) DMRG excited states, then evaluates the exact
@@ -310,7 +358,9 @@ matters more than matching KPM's polynomial-expansion artifacts.
 
 **Choosing a method:** KPM (default) for a first look at the full
 spectrum; CVM or TD when you need high resolution in a specific,
-narrow frequency window; EX when a handful of excited states already
+narrow frequency window; TDZ instead of TD when that window also needs
+long simulated times/low frequencies, where TD's real-time bond-dimension
+growth becomes limiting; EX when a handful of excited states already
 capture the physics (e.g. a small gapped system); maxent when you want a
 guaranteed-positive reconstruction from limited moment data (e.g.\
 combined with finite-temperature ED, see §9).

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -369,6 +369,61 @@ want fine resolution over a \emph{narrow} frequency window, at the cost
 of a real dynamical simulation (bond dimension grows with entanglement
 generated during the evolution).
 
+\textbf{\texttt{submode="TDZ"} --- complex-time evolution (Cao, Lu,
+Stoudenmire \& Parcollet, arXiv:2311.10909).} Real-time evolution
+(\texttt{"TD"} above) grows entanglement, so the MPS bond dimension
+needed for a given accuracy grows with the simulated time $T$. TDZ
+instead evolves along a complex time contour
+
+\begin{equation}
+z(t,\alpha_0)=\int_0^t e^{-i\alpha_0 f(t')}\,dt',\qquad f(t)=e^{-t\omega_0},\qquad \omega_0=2\pi/t_{\max}
+\end{equation}
+
+Since $\mathrm{Im}\,z(t,\alpha_0)<0$ for $\alpha_0>0$, this
+progressively damps high-energy content as it evolves, so the bond
+dimension needed for a given accuracy grows far more slowly than under
+real-time evolution alone (the original paper reports $\chi\sim20$--$30$
+vs $\chi\sim500$--$700$ for comparable accuracy on the Anderson impurity
+model). The true real-time ($\alpha_0=0$) correlator is then recovered
+order by order via a perturbative Taylor expansion in $\alpha_0$ around
+the simulated contour,
+
+\begin{equation}
+C(t,0)\approx\phi^{(0)}(t,\alpha_0)+\sum_{n=1}^{n_{\max}}g^{(n)}(t,\alpha_0)
+\end{equation}
+
+where $\phi^{(n)}(t,\alpha_0)=\langle H^n B|\mathrm{GS}\rangle\cdot
+|\psi(t,\alpha_0)\rangle$ (precomputed once per $n$, reused as a fixed
+overlap target at every time step) and $g^{(n)}$ are explicit
+combinatorial expressions in $\phi^{(1..n)}$ and the pure contour
+integrals $J^{(n)}(t,\alpha_0)=-i\,\partial^n_{\alpha_0}z(t,\alpha_0)$
+(see the paper's Appendix B; this implementation hardcodes $n\le4$,
+which the paper finds always suffices for $\alpha_0\lesssim0.3$). The
+reconstructed $C(t,0)$ is then windowed/Fourier-transformed exactly as
+in \texttt{"TD"}.
+
+\begin{verbatim}
+(x, y) = sc.get_dynamical_correlator(mode="DMRG", submode="TDZ",
+                                      name=(sc.Sz[0], sc.Sz[0]),
+                                      alpha0=0.1, n_max=4, dt=0.05)
+\end{verbatim}
+
+\texttt{alpha0} is the contour angle parameter (larger reduces the bond
+dimension needed further, but requires a larger \texttt{n\_max} to
+reconstruct the real axis accurately); \texttt{n\_max} ($\le4$) is the
+reconstruction order; \texttt{dt}/\texttt{tmax}/\texttt{nt} set the
+underlying time step/duration exactly as in \texttt{"TD"}. Uses
+two-site TDVP when available (\texttt{itensor\_version} 3 or
+\texttt{"python"}, \texttt{tevol\_method="TDVP"}, the paper's own setup)
+or falls back to the MPO-Taylor propagator otherwise
+(\texttt{itensor\_version=2}, which has no TDVP) --- the same
+TDVP-vs-Taylor choice \texttt{"TD"} already makes. Current scope: only
+the ``greater'' branch of the correlator is computed (the same
+simplification \texttt{"TD"} itself already makes), so this is best
+used the same way as \texttt{"TD"}: high-resolution work in a narrow
+frequency window, now reachable at a lower bond-dimension cost for a
+given simulated time.
+
 \textbf{\texttt{submode="EX"} --- exact diagonalization in a truncated
 DMRG subspace.} Builds $A$, $B$, $H$ explicitly in the subspace spanned
 by the lowest \texttt{nex} (orthogonalized) DMRG excited states, then
@@ -393,7 +448,9 @@ artifacts.
 
 \textbf{Choosing a method:} KPM (default) for a first look at the full
 spectrum; CVM or TD when you need high resolution in a specific,
-narrow frequency window; EX when a handful of excited states already
+narrow frequency window; TDZ instead of TD when that window also needs
+long simulated times/low frequencies, where TD's real-time bond-dimension
+growth becomes limiting; EX when a handful of excited states already
 capture the physics (e.g.\ a small gapped system); maxent when you want
 a guaranteed-positive reconstruction from limited moment data (e.g.\
 combined with finite-temperature ED, see Section~\ref{sec:thermal}).

--- a/examples/dynamical_correlator/dynamical_correlator_tdz_VS_ED/main.py
+++ b/examples/dynamical_correlator/dynamical_correlator_tdz_VS_ED/main.py
@@ -1,0 +1,123 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+# Regression test for submode="TDZ" (tdz.py): complex-time evolution +
+# perturbative real-axis reconstruction, following Cao, Lu, Stoudenmire &
+# Parcollet, "Dynamical correlation functions from complex time
+# evolution", arXiv:2311.10909.
+#
+# Checked two ways:
+#
+#   - Peak position vs exact ED (like KPM in dynamical_correlator_VS_ED):
+#     TDZ reconstructs the real-time correlator only up to the requested
+#     Taylor order in alpha0 plus the usual dt time-discretization error,
+#     so its dominant peak should land close to (not necessarily exactly
+#     on) the exact excitation energy -- checked on all three DMRG
+#     backends (2, 3, "python"). itensor_version=2 has no TDVP, so it
+#     exercises tdz.py's MPO-Taylor fallback path (evolve_taylor_step())
+#     rather than TDVP (tdvp_step()); both must agree with each other and
+#     with ED.
+#
+#   - Convergence of the alpha0-Taylor reconstruction itself: at a fixed,
+#     deliberately large alpha0, the raw complex-time correlator (n_max=0,
+#     no reconstruction at all) is compared to the reconstructed one
+#     (n_max=4) against the real-time ("TD" submode) reference, directly
+#     in the time domain (not just peak positions) -- confirming that
+#     each order of the Taylor-in-alpha0 reconstruction (Appendix B of
+#     the paper) actually improves the agreement, not just that the final
+#     answer happens to look reasonable. This is the check that caught a
+#     real sign/prefactor bug during development (an erroneous extra
+#     factor of "i" in assembling phi^(0)+sum(g^(n)) that made n_max=1
+#     *worse* than n_max=0): with the bug, increasing n_max did not
+#     monotonically improve agreement; with the fix, each order improves
+#     it by roughly a factor of alpha0.
+import numpy as np
+from scipy.signal import find_peaks
+from dmrgpy import spinchain
+from dmrgpy import tdz as tdzmod
+from dmrgpy import timedependent as tdmod
+
+n = 4
+es = np.linspace(-0.5, 4.0, 200)  # fine enough to resolve peak positions
+delta = 0.15
+
+
+def make_chain(itensor_version=None):
+    sc = spinchain.Spin_Chain([2 for i in range(n)])
+    if itensor_version is not None:
+        if itensor_version != "python": sc.setup_cpp(itensor_version)
+        else: sc.setup_python()
+    h = 0
+    for i in range(n-1):
+        h = h + sc.Sx[i]*sc.Sx[i+1] + sc.Sy[i]*sc.Sy[i+1] + sc.Sz[i]*sc.Sz[i+1]
+    sc.set_hamiltonian(h)
+    return sc
+
+
+def peak_energies(x, y):
+    """Energies of the resolvable peaks (>=5% of the tallest one)"""
+    y = np.array(y).real
+    x = np.array(x)
+    idx, _ = find_peaks(y, height=0.05*np.max(y))
+    return x[idx]
+
+
+# --- exact ED ground truth ---
+sc_ed = make_chain()
+name = (sc_ed.Sz[0], sc_ed.Sz[0])  # <Sz_0(t) Sz_0(0)>
+x_ed, y_ed = sc_ed.get_dynamical_correlator(mode="ED", submode="ED", name=name, es=es, delta=delta)
+y_ed = np.array(y_ed)
+peaks_ed = peak_energies(x_ed, y_ed)
+print("ED peak energies =", peaks_ed)
+assert len(peaks_ed) >= 2, "expected at least 2 resolvable peaks in this window"
+
+# --- TDZ on all three DMRG backends ---
+tol_peak = 0.15  # generous: TDZ's default dt=0.1 time-discretization + n_max=4 truncation
+for v in [2, 3, "python"]:
+    sc = make_chain(v)
+    name = (sc.Sz[0], sc.Sz[0])
+    x_tdz, y_tdz = sc.get_dynamical_correlator(mode="DMRG", submode="TDZ", name=name,
+            es=es, alpha0=0.1, n_max=4, dt=0.05, delta=delta)
+    peaks_tdz = peak_energies(x_tdz, y_tdz)
+    print("TDZ(v%s) peak energies =" % v, peaks_tdz)
+    assert len(peaks_tdz) >= len(peaks_ed), \
+        "v%s TDZ found %d peaks, expected at least the %d ED found" % (v, len(peaks_tdz), len(peaks_ed))
+    for e_ed in peaks_ed:
+        closest = peaks_tdz[np.argmin(np.abs(peaks_tdz-e_ed))]
+        diff = abs(closest-e_ed)
+        print("  v%s ED peak at %.4f -> nearest TDZ peak at %.4f (diff=%.3f)" % (v, e_ed, closest, diff))
+        assert diff < tol_peak, \
+            "v%s TDZ has no peak within %g of the ED peak at %.4f (closest: %.4f)" % (v, tol_peak, e_ed, closest)
+
+# --- alpha0-Taylor reconstruction: each order should improve agreement
+# with the real-time ("TD") reference at a fixed, deliberately large
+# alpha0, confirming the reconstruction itself (not just the final
+# peak-matching result) is implemented correctly ---
+sc = make_chain("python")
+sc.get_gs()
+name = (sc.Sz[0], sc.Sz[0])
+A = name[0].get_dagger()
+B = name[1]
+dt, nt = 0.05, 40
+omega0 = 2.*np.pi/(nt*dt)
+
+ts_ref, cs_ref = tdmod.evolution_dmrg_DC(sc, name=name, nt=nt, dt=dt)
+cs_ref_raw = cs_ref.real - 1j*cs_ref.imag  # undo evolution_dmrg_DC's own conjugation
+
+alpha0 = 0.2
+diffs = []
+for n_max in range(5):
+    _, cs_z = tdzmod._complex_time_correlator(sc, A, B, alpha0, n_max, dt, nt, omega0)
+    # time-aligned comparison: "TD"'s correlator[k] is measured after the
+    # (k+1)-th step (true time (k+1)*dt) but returned under label k*dt --
+    # see tdz.py's own note on this pre-existing timedependent.py quirk.
+    diff = np.max(np.abs(cs_z[1:] - cs_ref_raw[:len(cs_z)-1]))
+    diffs.append(diff)
+    print("n_max=%d  max|TDZ - TD| (time-aligned) = %.3e" % (n_max, diff))
+
+for k in range(1, len(diffs)):
+    assert diffs[k] < diffs[k-1], \
+        "increasing n_max from %d to %d did not improve agreement with the real-time reference (%.3e -> %.3e) -- the alpha0-Taylor reconstruction is broken" % (k-1, k, diffs[k-1], diffs[k])
+assert diffs[-1] < 1e-6, "n_max=4 reconstruction should match the real-time reference very closely at alpha0=0.2, got %.3e" % diffs[-1]
+
+print("TEST PASSED")

--- a/src/dmrgpy/dynamics.py
+++ b/src/dmrgpy/dynamics.py
@@ -2,6 +2,7 @@ from . import kpmdmrg
 from . import timedependent
 from . import cvm
 from . import dcex
+from . import tdz
 
 def get_dynamical_correlator(self,submode="KPM",**kwargs):
     if self.itensor_version in (2,3,"python"): # C++ or pure-Python
@@ -12,8 +13,10 @@ def get_dynamical_correlator(self,submode="KPM",**kwargs):
     #        submode = "CVM_explicit" # only mode that works with non-Hemrmitian
         if submode=="KPM": # KPM method
             return kpmdmrg.get_dynamical_correlator(self,**kwargs)
-        elif submode=="TD": # time dependent 
+        elif submode=="TD": # time dependent
             return timedependent.dynamical_correlator(self,**kwargs)
+        elif submode=="TDZ": # complex-time evolution (arXiv:2311.10909)
+            return tdz.dynamical_correlator_tdz(self,**kwargs)
         elif submode=="CVM_explicit": # CVM mode
             return cvm.dynamical_correlator_cvm_explicit(self,**kwargs)
         elif submode=="CVM": # CVM mode

--- a/src/dmrgpy/mpscpp2/bindings.cc
+++ b/src/dmrgpy/mpscpp2/bindings.cc
@@ -199,6 +199,16 @@ PYBIND11_MODULE(_dmrgcpp, m)
             }, py::arg("terms_h"),py::arg("terms_op"),py::arg("wf"),
                py::arg("nt"),py::arg("dt"),py::arg("fit_td")=true,
                "Returns (correlator, final_wf)")
+        .def("evolve_taylor_step",&Chain::evolve_taylor_step,
+             py::arg("H"),py::arg("wf"),py::arg("z"),
+             "Applies one Taylor-expanded exp(z*H) step (z may be "
+             "complex) to an already-built MPO H and MPS wf. Lets a "
+             "caller drive the evolution one variable-sized step at a "
+             "time, unlike quench()/evolve_and_measure() above, which "
+             "use one fixed real dt for their whole internal loop (used "
+             "by the \"TDZ\" complex-time-evolution dynamical "
+             "correlator, see tdz.py -- mpscpp2's only route there, "
+             "since it has no TDVP).")
         .def("overlap",&Chain::overlap_mps,py::arg("wf1"),py::arg("wf2"))
         .def("overlap_aMb",[](Chain& self, MPS const& wf1,
                                std::vector<PyTerm> const& terms, MPS const& wf2) {

--- a/src/dmrgpy/mpscpp2/chain_session.h
+++ b/src/dmrgpy/mpscpp2/chain_session.h
@@ -450,6 +450,25 @@ class Chain
         return out;
         }
 
+    // Applies one Taylor-expanded exp(z*H) step (evoloperator() below,
+    // see its own comment for the pre-existing z^3/6-uses-H2-not-H3
+    // quirk this preserves unchanged) to wf, given an already-built MPO
+    // H and a possibly-complex z -- exposed for callers (tdz.py's "TDZ"
+    // complex-time-evolution dynamical correlator) that need a
+    // per-step-varying complex increment, unlike quench()/
+    // evolve_and_measure() above, which use one fixed real dt for their
+    // whole internal loop. This is mpscpp2's only route to TDZ, since it
+    // has no TDVP (see mpscpp3/chain_session.h's own public tdvp_step());
+    // mpscpp3 exposes this same method too, as a cross-check / non-TDVP
+    // alternative there.
+    MPS
+    evolve_taylor_step(MPO const& H, MPS const& wf, Cplx z) const
+        {
+        auto expH = evoloperator(H,z);
+        auto args = Args("Cutoff",cutoff_,"Maxm",maxm_);
+        return exactApplyMPO(expH,wf,args);
+        }
+
     // Correction-vector-method (CVM) dynamical correlator at a single
     // frequency point, mirroring cvm_dynamical_correlator.h's task plus
     // cvm.h's spectral_function()/bicstab() exactly, but taking the two
@@ -832,11 +851,11 @@ class Chain
     // old-vs-new comparisons diverge for a reason unrelated to the
     // migration itself.
     MPO
-    evoloperator(MPO const& H, double dt) const
+    evoloperator(MPO const& H, Cplx dt) const
         {
         auto ampo = AutoMPO(sites_);
         ampo += 1.0,"Id",1;
-        Cplx z(0.0,-dt);
+        Cplx z = Cplx(0.0,-1.0)*dt;
         auto Iden = MPO(ampo);
         auto out = sum_mpo(Iden,z*H);
         auto H2 = mult_mpo(H,H);

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -225,6 +225,25 @@ PYBIND11_MODULE(_dmrgcpp, m)
             }, py::arg("terms_h"),py::arg("terms_op"),py::arg("wf"),
                py::arg("nt"),py::arg("dt"),
                "TDVP counterpart of evolve_and_measure(). Returns (correlator, final_wf)")
+        .def("tdvp_step",&Chain::tdvp_step,
+             py::arg("H"),py::arg("wf"),py::arg("dt"),
+             "One two-site-TDVP step of size dt (may be complex -- see "
+             "TDVP/README.md's own \"t\" convention) applied to an "
+             "already-built MPO H and MPS wf. Lets a caller drive the "
+             "evolution one variable-sized step at a time, unlike "
+             "quench_tdvp/evolve_and_measure_tdvp above, which loop "
+             "internally over a fixed number of equal, real dt steps "
+             "(used by the \"TDZ\" complex-time-evolution dynamical "
+             "correlator, see tdz.py, whose per-step contour increment "
+             "varies with t).")
+        .def("evolve_taylor_step",&Chain::evolve_taylor_step,
+             py::arg("H"),py::arg("wf"),py::arg("z"),
+             "Applies one Taylor-expanded exp(z*H) step (z may be "
+             "complex) to an already-built MPO H and MPS wf -- the "
+             "MPO-Taylor (non-TDVP) analogue of tdvp_step() above, used "
+             "by \"TDZ\" (tdz.py) as a cross-check / non-TDVP "
+             "alternative here, and as mpscpp2's only route to TDZ "
+             "(mpscpp2 has no TDVP).")
         .def("evolve_and_measure",
             [](Chain& self, std::vector<PyTerm> const& terms_h,
                std::vector<PyTerm> const& terms_op, MPS const& wf,

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -376,6 +376,24 @@ class Chain
         return out;
         }
 
+    // Applies one Taylor-expanded exp(z*H) step (evoloperator() below,
+    // see its own comment for the pre-existing z^3/6-uses-H2-not-H3
+    // quirk this preserves unchanged) to wf, given an already-built MPO
+    // H and a possibly-complex z -- exposed for callers (tdz.py's "TDZ"
+    // complex-time-evolution dynamical correlator) that need a
+    // per-step-varying complex increment, unlike quench()/
+    // evolve_and_measure() above, which use one fixed real dt for their
+    // whole internal loop. mpscpp2 (which has no TDVP) uses this same
+    // method as its only route to TDZ; here it's a cross-check /
+    // non-TDVP alternative to the public tdvp_step() below.
+    MPS
+    evolve_taylor_step(MPO const& H, MPS const& wf, Cplx z) const
+        {
+        auto expH = evoloperator(H,z);
+        auto args = Args("Cutoff",cutoff_,"MaxDim",maxm_);
+        return apply_mpo(expH,wf,args);
+        }
+
     // TDVP counterparts of quench()/evolve_and_measure() above: same
     // physics (real-time evolution under H_, same EGS-shift convention in
     // quench_tdvp() so results are directly comparable to the MPO-Taylor
@@ -429,6 +447,43 @@ class Chain
             }
         out.final_wf = psi;
         return out;
+        }
+
+    // One step exp(dt*H) of two-site TDVP (TDVP/tdvp.h), given an
+    // already-built MPO H (e.g. from build_operator()) and MPS psi --
+    // exposed publicly (moved here from a private helper of the same
+    // name used only by quench_tdvp()/evolve_and_measure_tdvp() above)
+    // so a caller can drive the evolution one variable-sized step at a
+    // time, unlike those two methods, which loop internally over a fixed
+    // number of equal, real dt steps and thus can't be reused for a
+    // per-step-varying complex time increment (see tdz.py's "TDZ"
+    // dynamical-correlator submode, which needs exactly that: the
+    // per-step contour increment dz_k = exp(-i*alpha0*f(t_k))*dt varies
+    // with t_k). dt may be any complex number: TDVP/README.md documents
+    // its own "t" argument (here dt, since tdvp()'s own convention is
+    // U=exp(t*H)) as "real, imaginary, or complex" -- real time
+    // evolution (dt purely imaginary here, by this method's own
+    // -i*dt convention) and complex time evolution (TDZ) share this same
+    // code path unchanged, nothing backend-specific needed for either.
+    // One Sweeps(1) TDVP "sweep" is a left-to-right pass with a dt/2 step
+    // followed by a right-to-left pass with another dt/2 step, i.e.
+    // exactly one full step of size dt -- matching how
+    // quench()/evolve_and_measure() apply their evoloperator() MPO once
+    // per iteration. niter=50 bounds the Lanczos iterations used to
+    // solve each local effective TDVP equation (tdvp.h's "MaxIter"); not
+    // exposed as a knob since neither the MPO-Taylor path this replaces
+    // has an equivalent one.
+    MPS
+    tdvp_step(MPO const& H, MPS psi, Cplx dt) const
+        {
+        Cplx t = Cplx(0.0,-1.0)*dt;
+        auto sweeps = Sweeps(1);
+        sweeps.maxdim() = maxm_;
+        sweeps.cutoff() = cutoff_;
+        sweeps.niter() = 50;
+        tdvp(psi,H,t,sweeps,{"Quiet",!verbose_,"Silent",!verbose_,
+                              "NumCenter",2,"DoNormalize",true});
+        return psi;
         }
 
     double
@@ -606,29 +661,6 @@ class Chain
         return out;
         }
 
-    // One real-time step exp(-i*dt*H) of two-site TDVP (TDVP/tdvp.h).
-    // t=(0,-dt): TDVP's own convention is U=exp(t*H), so real-time
-    // evolution needs a purely imaginary t (see TDVP/README.md). One
-    // Sweeps(1) TDVP "sweep" is a left-to-right pass with a t/2 step
-    // followed by a right-to-left pass with another t/2 step, i.e. exactly
-    // one full step of size t -- matching how quench()/evolve_and_measure()
-    // apply their evoloperator() MPO once per iteration. niter=50 bounds
-    // the Lanczos iterations used to solve each local effective TDVP
-    // equation (tdvp.h's "MaxIter"); not exposed as a knob since neither
-    // the MPO-Taylor path this replaces has an equivalent one.
-    MPS
-    tdvp_step(MPO const& H, MPS psi, double dt) const
-        {
-        Cplx t(0.0,-dt);
-        auto sweeps = Sweeps(1);
-        sweeps.maxdim() = maxm_;
-        sweeps.cutoff() = cutoff_;
-        sweeps.niter() = 50;
-        tdvp(psi,H,t,sweeps,{"Quiet",!verbose_,"Silent",!verbose_,
-                              "NumCenter",2,"DoNormalize",true});
-        return psi;
-        }
-
     Args
     dmrg_args() const { return Args("Quiet",!verbose_,"Silent",!verbose_); }
 
@@ -803,11 +835,11 @@ class Chain
     // the z^3/6 term multiplies H2 again instead of H3. See the v2 file's
     // comment for why this is preserved rather than fixed.
     MPO
-    evoloperator(MPO const& H, double dt) const
+    evoloperator(MPO const& H, Cplx dt) const
         {
         auto ampo = AutoMPO(sites_);
         ampo += 1.0,"Id",1;
-        Cplx z(0.0,-dt);
+        Cplx z = Cplx(0.0,-1.0)*dt;
         auto Iden = toMPO(ampo);
         auto out = sum_mpo(Iden,z*H);
         auto H2 = mult_mpo(H,H);

--- a/src/dmrgpy/pyitensor/chain.py
+++ b/src/dmrgpy/pyitensor/chain.py
@@ -23,7 +23,7 @@ from .mpsalgebra import randomMPS, traceC
 from .sites import SiteX
 from .svd import svd
 from .sweeps import Sweeps
-from .tdvp import tdvp_step
+from .tdvp import tdvp_step as _tdvp_step_fn
 from .tensor import commonIndex, dag, prime, swapPrime
 
 _BUILD_CUTOFF = 1e-14  # mo_terms.h's build_mpo() never exposes a cutoff knob at all
@@ -189,6 +189,35 @@ class Chain:
     def apply_pure_operator(self, A, wf):
         return self._apply_mpo(A, wf)
 
+    def tdvp_step(self, H, wf, dt):
+        """One two-site-TDVP step of size dt, given an already-built MPO H
+        (e.g. from build_operator()) and a raw MPS handle wf -- lets a
+        caller (tdz.py's TDZ submode) drive the evolution one
+        variable-sized step at a time, unlike quench_tdvp/
+        evolve_and_measure_tdvp above, which loop internally over a fixed
+        number of equal, real dt steps and thus can't be reused for a
+        per-step-varying complex time increment. dt may be any complex
+        number: tdvp.py's tdvp_step() forward/backward coefficients are
+        already generic to complex dt (the backward half-sweep's
+        coefficient is just the negative of the forward one, not its
+        conjugate -- the real-time-only case just happens to make those
+        coincide), so real time (dt purely imaginary by this module's own
+        -i*dt convention, matching mpscpp3's chain_session.h) and complex
+        time (TDZ) share this same code path unchanged."""
+        return _tdvp_step_fn(wf.copy(), H, dt, cutoff=self.cutoff,
+                maxdim=self.maxm, niter=50)
+
+    def evolve_taylor_step(self, H, wf, z):
+        """Applies one Taylor-expanded exp(z*H) step (_evoloperator()
+        above, z may be complex) to an already-built MPO H and MPS wf --
+        the MPO-Taylor (non-TDVP) analogue of tdvp_step() above, used by
+        tdz.py's "TDZ" submode as a cross-check / non-TDVP alternative
+        here, matching mpscpp2/mpscpp3's own evolve_taylor_step()
+        bindings (mpscpp2 has no TDVP, so this is its only route to
+        TDZ)."""
+        expH = self._evoloperator(H, z)
+        return self._apply_mpo(expH, wf)
+
     def multiply_operators(self, A, B):
         return self._mult_mpo(A, B)
 
@@ -265,7 +294,7 @@ class Chain:
         norm0 = np.sqrt(inner(psi1, psi1))
         correlator = []
         for _ in range(nt):
-            psi1 = tdvp_step(psi1, Hshift, dt, cutoff=self.cutoff, maxdim=self.maxm, niter=50)
+            psi1 = _tdvp_step_fn(psi1, Hshift, dt, cutoff=self.cutoff, maxdim=self.maxm, niter=50)
             psi1.normalize()
             psi1 = psi1 * norm0
             correlator.append(inner(psi2, psi1))
@@ -277,7 +306,7 @@ class Chain:
         psi = wf
         correlator = []
         for _ in range(nt):
-            psi = tdvp_step(psi, H, dt, cutoff=self.cutoff, maxdim=self.maxm, niter=50)
+            psi = _tdvp_step_fn(psi, H, dt, cutoff=self.cutoff, maxdim=self.maxm, niter=50)
             correlator.append(inner(psi, A, psi))
         return correlator, psi
 
@@ -471,9 +500,12 @@ class Chain:
         # port of mpscpp3/chain_session.h's evoloperator(), including its
         # deliberately-reproduced quirk: H3 is computed but the z^3/6 term
         # multiplies H2 again, not H3. See that file's own comment for why
-        # this is preserved rather than fixed.
+        # this is preserved rather than fixed. dt may be complex (see
+        # evolve_taylor_step() below, used by tdz.py's "TDZ" submode):
+        # z=-1j*dt generalizes complex(0.0,-dt) correctly for that case
+        # (the two coincide whenever dt is real).
         Iden = self._identity_mpo()
-        z = complex(0.0, -dt)
+        z = -1j * dt
         out = self._sum_mpo(Iden, H * z)
         H2 = self._mult_mpo(H, H)
         H3 = self._mult_mpo(H, H2)  # computed to match the original; unused below, see note

--- a/src/dmrgpy/tdz.py
+++ b/src/dmrgpy/tdz.py
@@ -1,0 +1,230 @@
+"""
+Complex-time-evolution dynamical correlator (submode "TDZ"), following
+Cao, Lu, Stoudenmire & Parcollet, "Dynamical correlation functions from
+complex time evolution", arXiv:2311.10909.
+
+Idea: instead of evolving |psi(t)> along the real-time axis (submode
+"TD", timedependent.py), evolve along a complex-time contour
+z(t,alpha0) = Integral_0^t exp(-i*alpha0*f(t')) dt', f(t)=exp(-t*omega0)
+(the paper's "decreasing-angle" contour, its Appendix A). Since
+Im(z(t,alpha0))<0, this evolution damps high-energy content as it goes,
+so the MPS bond dimension needed for a given accuracy grows far more
+slowly than under real-time evolution (the paper reports chi~20-30 vs
+chi~500-700 for comparable accuracy on the Anderson impurity model). The
+true real-time (alpha0=0) correlator is then recovered order by order via
+a perturbative Taylor expansion in alpha0 around this simulated contour
+(Eq. 6), see _reconstruct_real_axis below.
+
+Each order n of that expansion needs two ingredients (Eq. 7 and
+Appendix B):
+  - phi^(n)(t,alpha0) = <GS|O1 H^n|psi(t,alpha0)> -- since H is
+    Hermitian this is just <H^n(O1^dagger GS)|psi(t,alpha0)>, so
+    {H^n(O1^dagger GS)}_{n=0..n_max} can be precomputed ONCE (repeated
+    MPO application to a fixed vector, independent of t) and reused as a
+    fixed bra at every time step -- the per-step cost is then just
+    n_max+1 overlaps against the evolving state, not n_max+1 fresh MPO
+    applications per step.
+  - J^(n)(t,alpha0) = -i*d^n/dalpha0^n[z(t,alpha0)] -- a pure scalar
+    contour integral, no tensor-network work at all.
+
+This module implements the algorithm as plain Python using only the
+already-exposed toMPO()/StaticOperator/.dot() primitives (the same
+pattern cvm.py's cvm_correction_vector uses for its own hand-rolled
+Python-level CG algorithm), plus one new backend primitive per
+itensor_version: a single complex-time-step propagator
+(self._session.tdvp_step(H_handle, wf_handle, dz), see
+pyitensor/chain.py and, once added, mpscpp3/mpscpp2's own pybind11
+bindings) -- distinct from quench_tdvp/evolve_and_measure_tdvp
+(timedependent.py), which assume one constant *real* dt for their whole
+internal loop and thus can't be reused here, since the per-step contour
+increment dz_k varies with t_k (f(t) is not constant).
+"""
+import numpy as np
+
+from . import operatornames
+from . import multioperator
+from .timedependent import _fourier_transform_correlator
+
+_MAX_SUPPORTED_ORDER = 4  # explicit Appendix-B g^(n) formulas only go this far
+
+
+def _cumtrapz0(y, dt):
+    """Cumulative trapezoidal integral of y (uniform grid, spacing dt),
+    with out[0]=0 and len(out)==len(y)."""
+    out = np.zeros(len(y), dtype=complex)
+    out[1:] = np.cumsum(0.5*(y[:-1]+y[1:])*dt)
+    return out
+
+
+def _reconstruct_real_axis(alpha0, n_max, Jn, phi):
+    """
+    Combine phi^(n)(t,alpha0) (n=0..n_max, overlaps of H^n(B|GS>) against
+    the complex-time-evolved state) and J^(n)(t,alpha0) (n=1..n_max, pure
+    contour-integral scalars) into the real-time (alpha0->0) correlator,
+    via the explicit order-by-order reconstruction of arXiv:2311.10909's
+    Eq. 6, with the g^(n) terms given explicitly in its Appendix B
+    (reproduced here verbatim for n=1..4; the paper finds n_max<=4-5
+    always suffices for alpha0<~0.3, so this is a hardcoded cap rather
+    than a fully general Faa-di-Bruno recursion for arbitrary n).
+
+    phi[0](t,alpha0) is the raw complex-time correlator itself (n=0, no
+    Hamiltonian insertion): G>(t,alpha0) = -i*phi[0](t,alpha0) is the
+    base point of the Taylor series in Eq. 6, i.e.
+    G>(t,0) ~= -i*(phi[0](t,alpha0) + sum_n g^(n)(t,alpha0)) -- the
+    literal g^(n) formulas hardcoded below (Appendix B) are consistent
+    with the paper's own Eq. 3/4/7/B1 definitions only once this overall
+    "-i" on the *whole* bracket is included (confirmed independently by
+    an exact single-eigenstate toy-model derivation: expanding
+    G>(alpha0)=-i*exp(-i*z(alpha0)*E1) directly in alpha0 and comparing
+    to the phi^(n)/J^(n) machinery pins down this placement uniquely).
+    This function instead returns the *bare* correlator
+    C(t,0) := i*G>(t,0) = phi[0] + sum_n g^(n), matching this codebase's
+    own evolution_dmrg_DC/quench_tdvp convention (no -i prefactor)
+    rather than the paper's own G> convention directly, so the result
+    can feed the same downstream FFT tail unchanged (see
+    dynamical_correlator_tdz) -- note this is *not* i*phi[0]+i*sum_n
+    g^(n): the two i's from C:=i*G> and G>=-i*(...) cancel exactly.
+    """
+    if n_max > _MAX_SUPPORTED_ORDER:
+        raise NotImplementedError(
+                "TDZ only implements the explicit n<=%d Taylor "
+                "reconstruction terms given in arXiv:2311.10909's "
+                "Appendix B; the paper itself finds this always "
+                "suffices for alpha0<~0.3" % _MAX_SUPPORTED_ORDER)
+    gsum = 0.0
+    if n_max >= 1:
+        gsum = gsum - alpha0*Jn[1]*phi[1]
+    if n_max >= 2:
+        gsum = gsum + (alpha0**2/2.)*(Jn[2]*phi[1] + Jn[1]**2*phi[2])
+    if n_max >= 3:
+        gsum = gsum + (-alpha0**3/6.)*(Jn[3]*phi[1] + 3*Jn[1]*Jn[2]*phi[2]
+                + Jn[1]**3*phi[3])
+    if n_max >= 4:
+        gsum = gsum + (alpha0**4/24.)*(Jn[4]*phi[1]
+                + (4*Jn[1]*Jn[3] + 3*Jn[2]**2)*phi[2]
+                + 6*Jn[1]**2*Jn[2]*phi[3] + Jn[1]**4*phi[4])
+    return phi[0] + gsum
+
+
+def _advance_complex_time_step(self, Hop, wf, dz):
+    """
+    One complex-time evolution step of size dz (a possibly-complex
+    scalar), advancing wf under exp(-i*dz*Hop). Uses two-site TDVP
+    (whose forward/backward coefficients are already generic to complex
+    time steps -- see pyitensor/tdvp.py's module docstring and
+    mpscpp3/TDVP/README.md, which documents its own "t" argument as
+    "real, imaginary, or complex") when available, matching exactly the
+    same TDVP-vs-Taylor-MPO choice self.tevol_method/timedependent.py
+    already makes for real-time evolution. Falls back to the MPO-Taylor
+    evolve_taylor_step() (also generic to complex z -- see
+    mpscpp2/mpscpp3's own evoloperator()/pyitensor's _evoloperator())
+    otherwise -- mpscpp2's only route to TDZ, since it has no TDVP at
+    all.
+    """
+    if self.itensor_version in (3, "python") and self.tevol_method == "TDVP":
+        handle = self._session.tdvp_step(Hop.cpp_handle, wf.cpp_handle, dz)
+    else:
+        handle = self._session.evolve_taylor_step(Hop.cpp_handle, wf.cpp_handle, dz)
+    from . import mps as mpsmod
+    return mpsmod.MPS(self, cpp_handle=handle).copy()
+
+
+def _complex_time_correlator(self, A, B, alpha0, n_max, dt, nt, omega0):
+    """
+    Single-direction complex-time-evolution correlator
+    C(t,0) ~ <B GS|exp(-iHt)A GS> (bare convention, matching
+    evolution_dmrg_DC/quench_tdvp -- see this module's docstring),
+    reconstructed from an alpha0!=0 complex-time simulation. A,B are
+    MultiOperators; the caller is responsible for any dagger convention
+    (dynamical_correlator_tdz passes A=O1.get_dagger(),B=O2, exactly
+    mirroring evolution_dmrg_DC's own A/B convention).
+
+    Returns (ts,cs) with ts=dt*arange(nt), matching evolution_DC's own
+    (pre-conjugation) return shape so the two submodes can share the same
+    downstream windowing/FFT tail.
+    """
+    self.get_gs()  # ensures self.wf0 (ground state) and self.e0 are set
+    Hop = self.toMPO(self.hamiltonian - self.e0)  # build once, reused every step
+    wf_g = self.wf0
+
+    wf_fwd = self.toMPO(A)*wf_g  # |psi(0,alpha0)> = A|GS>, forward-evolved
+    bras = [self.toMPO(B)*wf_g]  # bras[0] = B|GS> (n=0, no H inserted)
+    for _n in range(n_max):
+        bras.append(Hop*bras[-1])  # bras[n] = H^n(B|GS>), built once, not per step
+
+    ts = dt*np.arange(nt+1)
+    f_t = np.exp(-ts*omega0)  # decreasing-angle contour f_D(t), Appendix A
+    dz_dt = np.exp(-1j*alpha0*f_t)  # dz(t,alpha0)/dt
+    z = _cumtrapz0(dz_dt, dt)
+    dz = np.diff(z)  # per-step complex contour increment, nt steps
+
+    Jn = {}
+    for n in range(1, n_max+1):
+        integrand = -1j*((-1j*f_t)**n)*dz_dt
+        Jn[n] = _cumtrapz0(integrand, dt)
+
+    phi = {n: np.zeros(nt+1, dtype=complex) for n in range(n_max+1)}
+    for k in range(nt+1):
+        for n in range(n_max+1):
+            phi[n][k] = bras[n].dot(wf_fwd)
+        if k < nt:
+            wf_fwd = _advance_complex_time_step(self, Hop, wf_fwd, dz[k])
+
+    cs = _reconstruct_real_axis(alpha0, n_max, Jn, phi)
+    return ts[:nt], cs[:nt]
+
+
+def dynamical_correlator_tdz(self, name="XX", es=None, alpha0=0.1, n_max=4,
+        dt=0.1, tmax=None, nt=None, delta=5e-2, damping_periods=6,
+        window=[-1, 10], factor=1, **kwargs):
+    """
+    Dynamical correlator via complex-time evolution + perturbative
+    real-axis reconstruction (submode "TDZ"; Cao, Lu, Stoudenmire &
+    Parcollet, "Dynamical correlation functions from complex time
+    evolution", arXiv:2311.10909). See this module's own docstring for
+    the algorithm.
+
+    alpha0: complex-time contour angle parameter (paper default range
+        0.1-0.3). Larger alpha0 reduces the bond dimension needed to
+        reach a given accuracy further, but needs a higher n_max to
+        reconstruct the real axis accurately (see the paper's Fig. 4).
+    n_max: order of the Taylor-in-alpha0 reconstruction, <=4 (see
+        _reconstruct_real_axis's docstring for why 4 is the current cap).
+    dt,tmax/nt: as in submode "TD" (timedependent.py) -- dt is the
+        real-time step of the underlying TDVP propagator (the complex
+        contour is layered on top of it, not a replacement for it); nt
+        defaults from damping_periods/delta/dt exactly as "TD" does, if
+        tmax is not given either.
+    es,delta,damping_periods,window,factor: passed straight through to
+        the same windowing/FFT tail "TD" uses
+        (timedependent._fourier_transform_correlator) -- delta here is
+        the *final* Lorentzian broadening applied to the reconstructed
+        real-time correlator before the FFT, a separate knob from alpha0
+        (which only controls entanglement growth during the simulation
+        itself, not the output broadening).
+
+    Note (current scope): only the "greater" branch
+    G>_{O1,O2}(t) ~ <B GS|exp(-iHt)A GS> is computed (A=O1^dagger, B=O2,
+    exactly evolution_dmrg_DC's own convention) and treated as the full
+    time-domain correlator fed to the FFT tail -- the same simplification
+    timedependent.py's own "TD" submode already makes (it computes but
+    never combines in a ga=conj(gr) "lesser" branch, see its
+    dynamical_correlator()). A genuine G< second run (the paper's Eq. 5,
+    alpha0->-alpha0 with O1<->O2 swapped) is a possible follow-up, not
+    required to match "TD"'s existing fidelity.
+    """
+    if nt is None:
+        if tmax is None: nt = int(damping_periods/delta/dt)
+        else: nt = int(tmax/dt)
+    tmax_eff = nt*dt
+    omega0 = 2.*np.pi/tmax_eff  # paper's own convention: lowest resolvable frequency
+
+    name = operatornames.str2MO(self, name, **kwargs)
+    O1, O2 = name[0], name[1]
+    A = O1.get_dagger()  # matches evolution_dmrg_DC's own A=O1.get_dagger()
+    B = O2
+
+    ts, cs = _complex_time_correlator(self, A, B, alpha0, n_max, dt, nt, omega0)
+    cs = cs.real - 1j*cs.imag  # match evolution_DC's own conjugation convention
+    return _fourier_transform_correlator(ts, cs, dt, es=es, window=window,
+            delta=delta, factor=factor)

--- a/src/dmrgpy/timedependent.py
+++ b/src/dmrgpy/timedependent.py
@@ -158,6 +158,22 @@ def dynamical_correlator(self,window=[-1,10],es=None,dt=0.1,
     self.get_gs() # get the ground state
     if nt is None: nt=int(damping_periods/delta/dt)
     (ts,cs) = evolution_DC(self,dt=dt,nt=nt,**kwargs) # get correlator
+    return _fourier_transform_correlator(ts,cs,dt,es=es,window=window,
+            delta=delta,factor=factor)
+
+
+def _fourier_transform_correlator(ts,cs,dt,es=None,window=[-1,10],
+        delta=5e-2,factor=1):
+    """
+    Shared time-domain -> frequency-domain tail: exponential-decay
+    windowing (turns `delta` into a Lorentzian broadening, see
+    dynamical_correlator's docstring), interpolation onto a uniform
+    (optionally oversampled by `factor`) grid, a Riemann-sum-normalized
+    FFT, and interpolation onto the requested frequencies `es`. Factored
+    out of dynamical_correlator (submode "TD") so other time-domain
+    submodes (e.g. "TDZ", see tdz.py) can reuse it unchanged instead of
+    duplicating the FFT/windowing convention.
+    """
     cs = cs*np.exp(-delta*ts) # damping window -> Lorentzian broadening "delta"
     # interpolate the time evolution
     ftr = interp1d(ts,cs.real,fill_value=0.0,bounds_error=False)

--- a/tests/test_dynamical_correlator.py
+++ b/tests/test_dynamical_correlator.py
@@ -150,3 +150,25 @@ def test_ex_dynamical_correlator_peak_matches_kpm_and_cvm():
         peaks[submode] = x[np.argmax(y)]
     assert peaks["EX"] == pytest.approx(peaks["KPM"], abs=1e-9)
     assert peaks["EX"] == pytest.approx(peaks["CVM"], abs=1e-9)
+
+
+@pytest.mark.parametrize("itensor_version", [2, 3, "python"])
+def test_tdz_dynamical_correlator_peak_matches_exact_gap(itensor_version):
+    """TDZ (tdz.py, complex-time evolution + perturbative real-axis
+    reconstruction, arXiv:2311.10909) should locate its dominant peak at
+    the exact gap to within the dt=0.1 (default) time-discretization
+    error, consistently across all three DMRG backends: TDVP
+    (itensor_version 3 or "python") and the MPO-Taylor fallback
+    (itensor_version=2, which has no TDVP -- see tdz.py's
+    _advance_complex_time_step). Confirmed directly (see this module's
+    own dev notes) that all three backends land on the identical peak
+    here, i.e. the TDVP-vs-Taylor-MPO choice does not itself introduce a
+    cross-backend discrepancy at this alpha0/n_max/dt."""
+    sc = _heisenberg_chain()
+    _setup_backend(sc, itensor_version)
+    name = (sc.Sz[0], sc.Sz[0])
+    x, y = sc.get_dynamical_correlator(mode="DMRG", submode="TDZ", name=name,
+                                        es=_PEAK_ES, delta=DELTA)
+    x, y = np.array(x), np.array(y).real
+    peak = x[np.argmax(y)]
+    assert peak == pytest.approx(HEISENBERG_4_GAP, abs=0.03)


### PR DESCRIPTION
## Summary

Implements a new `submode="TDZ"` dynamical-correlator method following Cao, Lu, Stoudenmire & Parcollet, ["Dynamical correlation functions from complex time evolution"](https://arxiv.org/abs/2311.10909) (arXiv:2311.10909).

Instead of evolving `|psi(t)>` along the real-time axis (`submode="TD"`), TDZ evolves along a complex time contour `z(t,alpha0)` whose negative imaginary part damps high-energy content as the simulation proceeds — the paper reports this cuts the MPS bond dimension needed for a given accuracy by roughly an order of magnitude versus real-time evolution. The true real-time correlator is then recovered order-by-order via a perturbative Taylor expansion in the contour angle `alpha0`, using the paper's own explicit Appendix-B formulas (hardcoded here for n<=4, which the paper finds always suffices for alpha0<~0.3).

Implemented first in the pure-Python `pyitensor` backend, then extended to the compiled `mpscpp3` (v3, via a generalized `Chain::tdvp_step` now accepting a complex time argument — the vendored TDVP integrator already supported this natively) and `mpscpp2` (v2, which has no TDVP, via a new `evolve_taylor_step` Taylor-MPO primitive generalized to a complex `z`) backends. All three backends were cross-validated against each other and against exact diagonalization.

- **`src/dmrgpy/tdz.py`**: the algorithm itself — precomputes `{H^n(B|GS>)}` once per operator pair, steps the complex-time evolution, accumulates the pure-scalar contour integrals `J^(n)`, and combines everything via the paper's reconstruction formulas. Wired into `dynamics.py`'s existing submode dispatch.
- **`timedependent.py`**: factored the existing "TD" submode's windowing/FFT tail into a shared helper (`_fourier_transform_correlator`) reused by TDZ.
- **`pyitensor/tdvp.py` / `chain.py`**: exposes a single complex-time-step TDVP primitive. The core Krylov-exponentiation routine was already fully generic to complex time steps — no changes needed there, only a thin new public method.
- **`mpscpp3/chain_session.h` / `bindings.cc`**: `Chain::tdvp_step` moved from a private, `double`-typed helper to a public method taking `Cplx dt`, exposed via pybind11.
- **`mpscpp2` and `mpscpp3/chain_session.h`**: new `evolve_taylor_step` primitive (mpscpp2's only route to TDZ, since it has no TDVP; a cross-check alternative on mpscpp3), built on `evoloperator()` generalized from a real `dt` to a complex `z`.
- **`tests/test_dynamical_correlator.py`**: new parametrized peak-position test across all three backends.
- **`examples/dynamical_correlator/dynamical_correlator_tdz_VS_ED/`**: regression example with real asserts — peak positions vs ED across backends, plus a direct check that each order of the alpha0-Taylor reconstruction improves agreement with the real-time reference (this caught a real sign bug during development, see commit history/code comments in `tdz.py`).
- **`docs/user_guide.{md,tex}`, `docs/documentation.{md,tex}`**: new submode documented in both formats; both `.tex` files verified to compile cleanly with `pdflatex`.

## Test plan

- [x] `pytest tests` — 40 passed (37 pre-existing + 3 new TDZ tests), across `itensor_version` 2/3/python
- [x] New `examples/dynamical_correlator/dynamical_correlator_tdz_VS_ED/main.py` passes: TDZ peak positions match ED on all three backends, and the alpha0-Taylor reconstruction converges properly order-by-order (verified 5th-order convergence in alpha0, independent of dt)
- [x] `docs/documentation.tex` and `docs/user_guide.tex` compile cleanly with `pdflatex` (no errors, no undefined references, no overfull-hbox warnings)
- [x] Rebuilt both `mpscpp2` and `mpscpp3` pybind11 extensions from scratch (`python install.py --itensor-version=2/3`) after the C++ changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)