### PR TITLE
NH-DMRG: apply code-review findings (follow-up to #52)

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -183,13 +183,14 @@ sc.gs_energy()                  # same E; stores psir as the ground state
 ```
 
 Because a non-Hermitian "energy" is not a variational bound, `nhdmrg()`
-certifies convergence through the eigen-residual
-$\lVert H|\psi_R\rangle-E|\psi_R\rangle\rVert$ and re-runs from a fresh
-random state (up to `ntries` times) if it stalls; `krylovdim`/`restarts`
-tune the per-bond Arnoldi effort. The MPS Arnoldi route
-(`get_excited_states`) remains available on every backend, but is
-typically several orders of magnitude less accurate than NH-DMRG at
-comparable cost — see
+certifies convergence through both eigen-residuals
+$\lVert H|\psi_R\rangle-E|\psi_R\rangle\rVert$ and
+$\lVert H^\dagger|\psi_L\rangle-E^{*}|\psi_L\rangle\rVert$ and re-runs
+from a fresh random state (up to `ntries` times) if either stalls;
+`krylovdim`/`restarts` tune the per-bond Arnoldi effort. The MPS Arnoldi
+route (`get_excited_states`, now used for non-Hermitian *excited* states,
+$n\ge 2$) remains available on every backend, but is typically several
+orders of magnitude less accurate than NH-DMRG at comparable cost — see
 `examples/non_hermitian/nhdmrg_VS_ED_VS_arnoldi`, which cross-checks
 NH-DMRG on all three backends against exact diagonalization and the
 Arnoldi route on an interacting fermionic chain with a staggered

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -232,11 +232,13 @@ sc.gs_energy()                  # same E; stores psir as the ground state
 \end{lstlisting}
 
 Because a non-Hermitian ``energy'' is not a variational bound,
-\lstinline|nhdmrg()| certifies convergence through the eigen-residual
-$\lVert H|\psi_R\rangle-E|\psi_R\rangle\rVert$ and re-runs from a fresh
-random state (up to \lstinline|ntries| times) if it stalls;
-\lstinline|krylovdim|/\lstinline|restarts| tune the per-bond Arnoldi
-effort. The MPS Arnoldi route (\lstinline|get_excited_states|) remains
+\lstinline|nhdmrg()| certifies convergence through both eigen-residuals
+$\lVert H|\psi_R\rangle-E|\psi_R\rangle\rVert$ and
+$\lVert H^\dagger|\psi_L\rangle-E^{*}|\psi_L\rangle\rVert$ and re-runs
+from a fresh random state (up to \lstinline|ntries| times) if either
+stalls; \lstinline|krylovdim|/\lstinline|restarts| tune the per-bond
+Arnoldi effort. The MPS Arnoldi route (\lstinline|get_excited_states|,
+now used for non-Hermitian \emph{excited} states, $n\ge 2$) remains
 available on every backend, but is typically several orders of magnitude
 less accurate than NH-DMRG at comparable cost --- see
 \texttt{examples/non\_hermitian/nhdmrg\_VS\_ED\_VS\_arnoldi}, which

--- a/src/dmrgpy/excited.py
+++ b/src/dmrgpy/excited.py
@@ -41,6 +41,13 @@ def get_excited_states(self,n=2,purify=True,**kwargs):
     """Excited states"""
     H = self.hamiltonian # make a check
     if not self.is_hermitian(H): # non-Hermitian Hamiltonians
+        if n==1 and self.itensor_version in (2,3,"python"):
+            # ground state only: use the same NH-DMRG solve gs_energy()
+            # routes to (groundstate.py's non-Hermitian branch), so the
+            # two entry points cannot return different eigenpair members
+            # of a degenerate multiplet or differently-normalized states
+            e0 = self.gs_energy(**kwargs)
+            return (np.array([e0]),[self.wf0.copy()])
 #        print("Non-Hermitian Hamiltonian, using Arnoldi method")
         return excited_states_non_hermitian(self,n=n,**kwargs)
     if n==1: # workaround for just the ground state

--- a/src/dmrgpy/mpscpp2/chain_session.h
+++ b/src/dmrgpy/mpscpp2/chain_session.h
@@ -810,8 +810,11 @@ class Chain
 
     // Restarted Arnoldi on a matrix-free operator over ITensor "vectors";
     // back-port of mpscpp3/chain_session.h's arnoldi_smallest_real (the
-    // annotated original, including the rationale for the three Sel
-    // eigenvalue-selection modes) to the v2 API.
+    // annotated original: see there for the Sel eigenvalue-selection
+    // rationale, the global-min SRTieBreak semantics shared with
+    // pyitensor's _select_ritz, the residual-bound restart skip, and the
+    // measured reason there is deliberately NO per-step early exit) to
+    // the v2 API.
     enum class Sel { SR, Closest, SRTieBreak };
     template <typename Fn>
     std::pair<Cplx,ITensor>
@@ -858,24 +861,36 @@ class Chain
             ITensor W,D;
             eigen(Hm,W,D);
             auto c = commonIndex(W,D);
+            std::vector<Cplx> ev(m);
+            for (int k=1;k<=m;++k) ev[k-1] = D.cplx(c(k),prime(c)(k));
             int kbest = 1;
-            Cplx ebest = 0;
-            for (int k=1;k<=m;++k)
+            if (sel==Sel::Closest)
                 {
-                auto ek = D.cplx(c(k),prime(c)(k));
-                bool better = false;
-                if (sel==Sel::Closest)
-                    better = std::abs(ek-target)<std::abs(ebest-target);
-                else if (sel==Sel::SRTieBreak)
-                    {
-                    double degtol = 1e-6*(1.0+std::abs(ebest.real()));
-                    if (ek.real()<ebest.real()-degtol) better = true;
-                    else if (ek.real()<ebest.real()+degtol)
-                        better = std::abs(ek-target)<std::abs(ebest-target);
-                    }
-                else better = ek.real()<ebest.real();
-                if (k==1 || better) { ebest = ek; kbest = k; }
+                for (int k=2;k<=m;++k)
+                    if (std::abs(ev[k-1]-target)<std::abs(ev[kbest-1]-target))
+                        kbest = k;
                 }
+            else
+                {
+                double remin = ev[0].real();
+                for (int k=2;k<=m;++k) remin = std::min(remin,ev[k-1].real());
+                if (sel==Sel::SRTieBreak)
+                    {
+                    double degtol = 1e-6*(1.0+std::abs(remin));
+                    kbest = 0;
+                    for (int k=1;k<=m;++k)
+                        if (ev[k-1].real()<remin+degtol)
+                            if (kbest==0 ||
+                                std::abs(ev[k-1]-target)<std::abs(ev[kbest-1]-target))
+                                kbest = k;
+                    }
+                else
+                    {
+                    for (int k=2;k<=m;++k)
+                        if (ev[k-1].real()<ev[kbest-1].real()) kbest = k;
+                    }
+                }
+            Cplx ebest = ev[kbest-1];
             ITensor xnew;
             for (int i=0;i<m;++i)
                 {
@@ -885,6 +900,12 @@ class Chain
                 }
             lambda = ebest;
             x0 = xnew;
+            // standard Arnoldi residual bound for the selected Ritz pair
+            // (see the mpscpp3 original's comment); skip further restarts
+            // once the build already converged
+            double resid_est = h.at(m).at(m-1).real()
+                              *std::abs(W.cplx(a(m),c(kbest)));
+            if (resid_est<1e-10*(1.0+std::abs(ebest))) break;
             }
         return {lambda,x0};
         }

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -127,7 +127,8 @@ PYBIND11_MODULE(_dmrgcpp, m)
                 return py::make_tuple(out.energy,out.psil,out.psir);
             }, py::arg("terms_h"),py::arg("terms_hadj"),
                py::arg("krylovdim")=20,py::arg("restarts")=2,
-               "Non-Hermitian DMRG (mpscpp3-only, no mpscpp2 counterpart): "
+               "Non-Hermitian DMRG (this file is the annotated original; "
+               "mpscpp2 carries a v2-API back-port): "
                "optimizes a biorthogonal left/right eigenpair of the "
                "non-Hermitian operator given by terms_h, targeting the "
                "eigenvalue with smallest real part; terms_hadj must be the "

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -866,13 +866,28 @@ class Chain
     // Restarted Arnoldi on a matrix-free operator over ITensor "vectors"
     // (the two-site blocks of nhdmrg()): builds a krylovdim-step Krylov
     // space with modified Gram-Schmidt (plus one re-orthogonalization
-    // pass), diagonalizes the small Hessenberg matrix with ITensor's
-    // dense non-hermitian eigen(), keeps the Ritz pair whose eigenvalue
-    // has the smallest real part, and restarts from that Ritz vector.
-    // This is the C++ stand-in for the reference's KrylovKit
-    // eigsolve(...; ishermitian=false, which=:SR) local solver -- like
-    // there, it runs at low accuracy per bond (the outer DMRG sweeps do
-    // the actual converging, so krylovdim/restarts stay small).
+    // pass), diagonalizes the small Hessenberg matrix once per build with
+    // ITensor's dense non-hermitian eigen(), keeps the Ritz pair selected
+    // by `sel`, and restarts from that Ritz vector. This is the C++
+    // stand-in for the reference's KrylovKit eigsolve(...;
+    // ishermitian=false, which=:SR) local solver -- like there, it runs
+    // at low accuracy per bond (the outer DMRG sweeps do the actual
+    // converging). Remaining restarts are skipped when the standard
+    // Arnoldi residual bound ||A y - lambda y|| = |h(m+1,m)|*|last
+    // Ritz-vector component| certifies the build already converged --
+    // that check reuses the one end-of-build diagonalization, so it is
+    // free, and it halves the matvec count on already-converged bonds.
+    // A per-step stop-on-stable-Ritz-value exit (the idea pyitensor's
+    // hermitian _lanczos_ground_state uses) was tried and reverted:
+    // unlike the symmetric tridiagonal solve there, the non-hermitian
+    // Hessenberg eigen() per step costs as much as the matvec it hopes
+    // to save at these block sizes -- measured directly on a 20-site
+    // chain, the per-step variant REGRESSED nhdmrg from ~30s to ~104s.
+    // (The vendored ITensor/itensor/iterativesolvers.h has its own
+    // arnoldi(), but it only supports LargestMagnitude/SmallestReal
+    // selection -- neither the Closest anchoring nor the SRTieBreak
+    // below is expressible with it, and those selections are
+    // load-bearing, see the Sel notes.)
     //
     // Ritz-value selection (`sel`):
     //  - SR: smallest real part (the reference's :SR).
@@ -889,13 +904,19 @@ class Chain
     //    chain). Anchoring the left solve to the right solve's eigenvalue
     //    pins both onto the same eigenpair.
     //  - SRTieBreak: smallest real part, but among Ritz values whose real
-    //    parts are degenerate within a small tolerance, the one closest to
-    //    `target` (the previous bond's eigenvalue). Used by the right
-    //    solve from the second bond on, so a Re-degenerate +-Im pair
-    //    cannot make consecutive bond solves flip branch mid-sweep (the
-    //    same failure mode as above, one level up: each flip re-targets
-    //    the truncation onto a different eigenstate, and the sweep stalls
-    //    at a non-eigenstate -- also confirmed on the same XX chain).
+    //    parts sit within a small tolerance of the *global* minimum, the
+    //    one closest to `target` (the previous bond's eigenvalue). Used
+    //    by the right solve from the second bond on, so a Re-degenerate
+    //    +-Im pair cannot make consecutive bond solves flip branch
+    //    mid-sweep (the same failure mode as above, one level up: each
+    //    flip re-targets the truncation onto a different eigenstate, and
+    //    the sweep stalls at a non-eigenstate -- also confirmed on the
+    //    same XX chain). The global-min-then-candidates formulation is
+    //    deliberately identical to pyitensor/nhdmrg.py's _select_ritz
+    //    (an earlier greedy running-best variant here could settle on a
+    //    different member of a degenerate cluster than the Python port,
+    //    silently diverging the backends on exactly the spectra the
+    //    tie-break exists for).
     enum class Sel { SR, Closest, SRTieBreak };
     template <typename Fn>
     std::pair<Cplx,ITensor>
@@ -942,24 +963,39 @@ class Chain
             ITensor W,D;
             eigen(Hm,W,D);
             auto c = commonIndex(W,D);
+            std::vector<Cplx> ev(m);
+            for (int k=1;k<=m;++k) ev[k-1] = eltC(D,c(k),prime(c)(k));
+            // Ritz-value selection; the global-min-then-candidates
+            // SRTieBreak formulation is deliberately identical to
+            // pyitensor/nhdmrg.py's _select_ritz
             int kbest = 1;
-            Cplx ebest = 0;
-            for (int k=1;k<=m;++k)
+            if (sel==Sel::Closest)
                 {
-                auto ek = eltC(D,c(k),prime(c)(k));
-                bool better = false;
-                if (sel==Sel::Closest)
-                    better = std::abs(ek-target)<std::abs(ebest-target);
-                else if (sel==Sel::SRTieBreak)
-                    {
-                    double degtol = 1e-6*(1.0+std::abs(ebest.real()));
-                    if (ek.real()<ebest.real()-degtol) better = true;
-                    else if (ek.real()<ebest.real()+degtol)
-                        better = std::abs(ek-target)<std::abs(ebest-target);
-                    }
-                else better = ek.real()<ebest.real();
-                if (k==1 || better) { ebest = ek; kbest = k; }
+                for (int k=2;k<=m;++k)
+                    if (std::abs(ev[k-1]-target)<std::abs(ev[kbest-1]-target))
+                        kbest = k;
                 }
+            else
+                {
+                double remin = ev[0].real();
+                for (int k=2;k<=m;++k) remin = std::min(remin,ev[k-1].real());
+                if (sel==Sel::SRTieBreak)
+                    {
+                    double degtol = 1e-6*(1.0+std::abs(remin));
+                    kbest = 0;
+                    for (int k=1;k<=m;++k)
+                        if (ev[k-1].real()<remin+degtol)
+                            if (kbest==0 ||
+                                std::abs(ev[k-1]-target)<std::abs(ev[kbest-1]-target))
+                                kbest = k;
+                    }
+                else
+                    {
+                    for (int k=2;k<=m;++k)
+                        if (ev[k-1].real()<ev[kbest-1].real()) kbest = k;
+                    }
+                }
+            Cplx ebest = ev[kbest-1];
             ITensor xnew;
             for (int i=0;i<m;++i)
                 {
@@ -969,6 +1005,13 @@ class Chain
                 }
             lambda = ebest;
             x0 = xnew;
+            // standard Arnoldi residual bound for the selected Ritz pair:
+            // ||A y - lambda y|| = |h(m+1,m)| * |last component of the
+            // Hessenberg eigenvector|; when the build already converged,
+            // further restarts would just rebuild the same subspace
+            double resid_est = h.at(m).at(m-1).real()
+                              *std::abs(eltC(W,a(m),c(kbest)));
+            if (resid_est<1e-10*(1.0+std::abs(ebest))) break;
             }
         return {lambda,x0};
         }

--- a/src/dmrgpy/nhdmrg.py
+++ b/src/dmrgpy/nhdmrg.py
@@ -20,16 +20,15 @@ now only a fallback for backends without a session (julia_live keeps its
 own path in groundstate.py).
 """
 
-import numpy as np
 from . import mps
 
 
 def nhdmrg(self,H=None,krylovdim=20,restarts=2,tol=1e-4,ntries=5):
-    """Run non-Hermitian DMRG on a v3 chain. Returns (energy,psil,psir)
-    with energy the (complex) eigenvalue of smallest real part and
-    psil/psir the biorthogonal left/right eigenvector MPS, normalized so
-    that <psil|psir> = 1 (each tensor pair shares its site and link
-    indices, so both behave as ordinary MPS individually).
+    """Run non-Hermitian DMRG on a session-backend chain. Returns
+    (energy,psil,psir) with energy the (complex) eigenvalue of smallest
+    real part and psil/psir the biorthogonal left/right eigenvector MPS,
+    normalized so that <psil|psir> = 1 (each tensor pair shares its site
+    and link indices, so both behave as ordinary MPS individually).
 
     - H: operator to diagonalize (defaults to self.hamiltonian)
     - krylovdim/restarts: per-bond local Arnoldi effort; the outer DMRG
@@ -37,12 +36,16 @@ def nhdmrg(self,H=None,krylovdim=20,restarts=2,tol=1e-4,ntries=5):
     - tol/ntries: eigen-residual certificate. The non-Hermitian "energy"
       is not a variational bound, so a (rare) stalled sweep can report a
       spurious value below the true spectrum with nothing else looking
-      wrong; the only reliable convergence certificate is the residual
-      ||H|psir> - E|psir>||. Each C++ run starts from its own random MPS,
-      so runs are re-drawn (up to ntries times) until the relative
-      residual drops below tol, and the best run is returned regardless
-      (converged runs sit at ~1e-14 while stalls sit at ~1e-1, so tol's
-      exact value is uncritical).
+      wrong; the only reliable convergence certificate is the pair of
+      residuals ||H|psir> - E|psir>|| and ||Hdag|psil> - E*|psil>||. Both
+      are checked: the right residual alone would accept a run whose
+      anchored adjoint solve locked psil onto a *different* eigenstate,
+      since <psil|H|psir>/<psil|psir> equals E identically whenever psir
+      alone is an eigenvector. Each run starts from its own random MPS,
+      so runs are re-drawn (up to ntries times) until the worse of the
+      two relative residuals drops below tol, and the best run is
+      returned regardless (converged runs sit at ~1e-14 while stalls sit
+      at ~1e-1, so tol's exact value is uncritical).
     """
     if self.itensor_version not in (2,3,"python"):
         raise NotImplementedError("nhdmrg requires itensor_version 2, 3 "
@@ -54,8 +57,9 @@ def nhdmrg(self,H=None,krylovdim=20,restarts=2,tol=1e-4,ntries=5):
             self.noise)
     self._session.set_verbose(self.verbose)
     self._session.set_mpomaxm(max(self.maxm,self.mpomaxm))
+    Hd = H.get_dagger()
     terms = H.to_terms()
-    terms_dag = H.get_dagger().to_terms()
+    terms_dag = Hd.to_terms()
     best = None
     for i in range(max(1,int(ntries))):
         energy,hl,hr = self._session.nhdmrg(terms,terms_dag,
@@ -63,7 +67,8 @@ def nhdmrg(self,H=None,krylovdim=20,restarts=2,tol=1e-4,ntries=5):
         psil = mps.MPS(self,cpp_handle=hl).copy()
         psir = mps.MPS(self,cpp_handle=hr).copy()
         r = H*psir - energy*psir
-        resid = abs(r.dot(r))**0.5/(1.0+abs(energy))
+        l = Hd*psil - energy.conjugate()*psil
+        resid = max(abs(r.dot(r))**0.5,abs(l.dot(l))**0.5)/(1.0+abs(energy))
         if best is None or resid<best[0]:
             best = (resid,energy,psil,psir)
         if resid<tol: break
@@ -81,10 +86,29 @@ def gs_energy_nhdmrg(self,**kwargs):
     """gs_energy-style entry point: run NH-DMRG and store the right
     eigenvector as the chain's ground state wavefunction (the state
     observables like vev() act on), mirroring what the Arnoldi
-    non-Hermitian branch of groundstate.gs_energy stores."""
-    e0,psil,psir = nhdmrg(self,**kwargs)
+    non-Hermitian branch of groundstate.gs_energy stores -- including its
+    unit normalization of wf0 (nhdmrg()'s own psir carries <psil|psir>=1
+    biorthogonal normalization instead, so it is renormalized here; the
+    biorthogonal pair as such stays available through nhdmrg()).
+
+    Accepts (and ignores) unknown keyword arguments: gs_energy() forwards
+    its **kwargs here for non-Hermitian Hamiltonians, and the previous
+    Arnoldi route accepted a different set of solver knobs
+    (maxit/delta/nkry_min/... -- see algebra/arnolditk.py's mpsarnoldi),
+    so a strict signature would turn previously-working calls like
+    get_gs_degeneracy(delta=...) into TypeErrors."""
+    known = ("H","krylovdim","restarts","tol","ntries")
+    passed = {k:v for k,v in kwargs.items() if k in known}
+    ignored = [k for k in kwargs if k not in known]
+    if ignored and self.verbose>0:
+        print("nhdmrg: ignoring keyword arguments",ignored,
+              "(not NH-DMRG parameters)")
+    e0,psil,psir = nhdmrg(self,**passed)
     self.computed_gs = True
     self.e0 = e0
-    self.wf0 = psir.copy()
+    # unit norm, matching the Arnoldi route's convention (MPS.normalize
+    # returns a fresh normalized copy, or None for a degenerate state)
+    wf0 = psir.normalize()
+    self.wf0 = wf0 if wf0 is not None else psir.copy()
     self.nh_left_wf = psil.copy() # left eigenvector, for biorthogonal use
     return self.e0

--- a/src/dmrgpy/pyitensor/dmrg.py
+++ b/src/dmrgpy/pyitensor/dmrg.py
@@ -137,9 +137,17 @@ def _relabel_bra_local(T, chain, i, left_bra, right_bra):
     return bra_piece, left_bra, right_bra
 
 
-def _extend_left(L, left_bra, H, ket, i):
+def _extend_left(L, left_bra, H, ket, i, bra=None):
+    """One more site of the left environment <bra|H|ket>. `bra` defaults
+    to `ket` (the ordinary self-overlap environments of ground-state
+    DMRG); nhdmrg.py passes a *different* MPS as bra (its two-sided
+    environments), which works unchanged because the fidelity-truncated
+    left/right MPS share link Index objects, hitting the exact same
+    bra/ket link-identity collision _relabel_bra_local exists to solve."""
+    if bra is None:
+        bra = ket
     T = ket.A(i)
-    bra_piece, _, right_bra = _relabel_bra_local(T, ket, i, left_bra, None)
+    bra_piece, _, right_bra = _relabel_bra_local(bra.A(i), bra, i, left_bra, None)
     # contract_many(), not a left-to-right `piece = bra_piece*H.A(i)*T;
     # new_L = piece if L is None else L*piece` chain: that ordering builds
     # bra_piece*H.A(i)*T *before* L ever gets a chance to cancel away one
@@ -153,21 +161,23 @@ def _extend_left(L, left_bra, H, ket, i):
     return new_L, right_bra
 
 
-def _extend_right(R, right_bra, H, ket, i):
+def _extend_right(R, right_bra, H, ket, i, bra=None):
+    if bra is None:
+        bra = ket
     T = ket.A(i)
-    bra_piece, left_bra, _ = _relabel_bra_local(T, ket, i, None, right_bra)
+    bra_piece, left_bra, _ = _relabel_bra_local(bra.A(i), bra, i, None, right_bra)
     pieces = [p for p in (R, bra_piece, H.A(i), T) if p is not None]
     new_R = contract_many(pieces)
     return new_R, left_bra
 
 
-def _all_right_environments(H, ket):
+def _all_right_environments(H, ket, bra=None):
     """{i: (R_tensor_or_None, dangling_bra_link_or_None)} for i = N+1..2."""
     n = ket.length()
     env = {n + 1: (None, None)}
     for i in range(n, 1, -1):
         R_next, bra_next = env[i + 1]
-        env[i] = _extend_right(R_next, bra_next, H, ket, i)
+        env[i] = _extend_right(R_next, bra_next, H, ket, i, bra=bra)
     return env
 
 

--- a/src/dmrgpy/pyitensor/nhdmrg.py
+++ b/src/dmrgpy/pyitensor/nhdmrg.py
@@ -13,8 +13,9 @@ and the two deliberate deviations) to this package's engine:
   density matrices), which keeps psil and psir on identical site *and*
   link Index objects throughout -- so the environments hit the exact same
   bra/ket link-identity collision dmrg.py's self-overlap environments do,
-  and reuse its _relabel_bra_local machinery, just with the bra tensors
-  drawn from the *other* MPS.
+  and reuse its _extend_left/_extend_right/_all_right_environments
+  builders directly (their bra= parameter draws the bra tensors from the
+  *other* MPS).
 
 Everything bond-local is done on flat numpy arrays (via dmrg.py's
 two_site_heff matvec factory): the Arnoldi iteration, the biorthogonal
@@ -35,45 +36,46 @@ backends).
 
 import numpy as np
 
-from .dmrg import (_relabel_bra_local, two_site_heff)
+from .dmrg import (_all_right_environments, _extend_left, _extend_right,
+                   two_site_heff)
 from .index import Index
 from .mpsalgebra import inner
 from .svd import _truncate
-from .tensor import ITensor, contract_many
+from .tensor import ITensor
 
 
-def _extend_left_nh(L, left_bra, W, ket, bra, i):
-    """One more site of the two-sided left environment <bra|W|ket>: same
-    as dmrg.py's _extend_left except the bra tensor comes from a different
-    MPS than the ket (they share link Index objects, so the relabeling
-    dance is identical)."""
-    bra_piece, _, right_bra = _relabel_bra_local(bra.A(i), bra, i, left_bra, None)
-    pieces = [p for p in (L, bra_piece, W.A(i), ket.A(i)) if p is not None]
-    return contract_many(pieces), right_bra
-
-
-def _extend_right_nh(R, right_bra, W, ket, bra, i):
-    bra_piece, left_bra, _ = _relabel_bra_local(bra.A(i), bra, i, None, right_bra)
-    pieces = [p for p in (R, bra_piece, W.A(i), ket.A(i)) if p is not None]
-    return contract_many(pieces), left_bra
-
-
-def _all_right_nh(W, ket, bra):
-    n = ket.length()
-    env = {n + 1: (None, None)}
-    for i in range(n, 1, -1):
-        R_next, bra_next = env[i + 1]
-        env[i] = _extend_right_nh(R_next, bra_next, W, ket, bra, i)
-    return env
+def _select_ritz(evals, sel, target):
+    """Index of the Ritz value selected by `sel` ("SR" = smallest real
+    part, "closest" = closest to `target`, "SRTieBreak" = smallest real
+    part with Re-degenerate candidates tie-broken toward `target`). This
+    global-min-then-candidates formulation is the reference semantics all
+    three backends implement (the C++ ports mirror it exactly), so the
+    backends cannot silently target different members of a degenerate
+    Ritz cluster."""
+    if sel == "closest":
+        return int(np.argmin(np.abs(evals - target)))
+    if sel == "SRTieBreak":
+        remin = evals.real.min()
+        degtol = 1e-6 * (1.0 + abs(remin))
+        cand = np.flatnonzero(evals.real < remin + degtol)
+        return int(cand[np.argmin(np.abs(evals[cand] - target))])
+    return int(np.argmin(evals.real))
 
 
 def _arnoldi_smallest_real(matvec, x0, krylovdim, restarts,
                            sel="SR", target=0.0):
     """Restarted Arnoldi over flat numpy vectors; keeps the Ritz pair
-    selected by `sel` ("SR" = smallest real part, "closest" = closest to
-    `target`, "SRTieBreak" = smallest real part with Re-degenerate values
-    tie-broken toward `target`). Mirrors chain_session.h's
-    arnoldi_smallest_real (see the Sel rationale there)."""
+    selected by `sel` (see _select_ritz). Mirrors chain_session.h's
+    arnoldi_smallest_real (see the Sel rationale there). Remaining
+    restarts are skipped when the standard Arnoldi residual bound
+    ||A y - lam y|| = |h[m+1,m]|*|last Ritz-vector component| certifies
+    the build already converged -- computed from the one end-of-build
+    Hessenberg diagonalization, so it is free. A per-step
+    stop-on-stable-Ritz-value exit (dmrg.py's _lanczos_ground_state
+    pattern) was tried and reverted: the non-hermitian np.linalg.eig per
+    step -- unlike the cheap symmetric tridiagonal solve there -- costs
+    as much as the matvec it hopes to save at these block sizes
+    (measured: 18s -> 55s on a 20-site chain)."""
     lam = 0.0 + 0.0j
     x0 = np.asarray(x0, dtype=complex)
     for _ in range(restarts):
@@ -103,17 +105,12 @@ def _arnoldi_smallest_real(matvec, x0, krylovdim, restarts,
             if j + 1 < m:
                 Q.append(w / nw)
         evals, evecs = np.linalg.eig(h[:built, :built])
-        if sel == "closest":
-            k = int(np.argmin(np.abs(evals - target)))
-        elif sel == "SRTieBreak":
-            remin = evals.real.min()
-            degtol = 1e-6 * (1.0 + abs(remin))
-            cand = np.flatnonzero(evals.real < remin + degtol)
-            k = int(cand[np.argmin(np.abs(evals[cand] - target))])
-        else:
-            k = int(np.argmin(evals.real))
+        k = _select_ritz(evals, sel, target)
         lam = complex(evals[k])
         x0 = np.column_stack(Q[:built]) @ evecs[:, k]
+        resid_est = abs(h[built, built - 1]) * abs(evecs[built - 1, k])
+        if resid_est < 1e-10 * (1.0 + abs(lam)):
+            break
     return lam, x0
 
 
@@ -130,14 +127,17 @@ def nhdmrg(H, HA, psi0, sweeps, krylovdim=20, restarts=2, quiet=True):
 
     energy = 0.0 + 0.0j
     have_energy = False
+    # (env tensor, dangling bra link) per boundary, one family per
+    # projected problem: H sandwiched between <psil| and |psir>, and
+    # Hdag sandwiched between <psir| and |psil>. Built once and then
+    # maintained incrementally by the sweeps themselves (each backward
+    # half-sweep refreshes every right entry, each forward half-sweep
+    # every left entry), like the C++ ports -- a per-sweep rebuild would
+    # be redundant work.
+    right_h = _all_right_environments(H, psir, bra=psil)
+    right_a = _all_right_environments(HA, psil, bra=psir)
     for sweep_i in range(sweeps.nsweep):
         maxdim, cutoff, noise, _niter = sweeps.at(sweep_i)
-
-        # (env tensor, dangling bra link) per boundary, one family per
-        # projected problem: H sandwiched between <psil| and |psir>, and
-        # Hdag sandwiched between <psir| and |psil>
-        right_h = _all_right_nh(H, psir, psil)
-        right_a = _all_right_nh(HA, psil, psir)
         left_h = {0: (None, None)}
         left_a = {0: (None, None)}
 
@@ -150,12 +150,14 @@ def nhdmrg(H, HA, psi0, sweeps, krylovdim=20, restarts=2, quiet=True):
                 Ra, Rbra_a = right_a[b + 2]
                 mv_r, order_in, shape, x0r = two_site_heff(
                     Lh, Lbra_h, H, psir, b, Rh, Rbra_h)
-                mv_l, _order_l, _shape_l, x0l = two_site_heff(
+                mv_l, _, _, x0l = two_site_heff(
                     La, Lbra_a, HA, psil, b, Ra, Rbra_a)
                 er, thr = _arnoldi_smallest_real(
                     mv_r, x0r, krylovdim, restarts,
                     sel="SRTieBreak" if have_energy else "SR", target=energy)
-                _el, thl = _arnoldi_smallest_real(
+                # only the eigenvector is needed from the adjoint solve
+                # (its eigenvalue is conj(er) by construction)
+                _, thl = _arnoldi_smallest_real(
                     mv_l, x0l, krylovdim, restarts,
                     sel="closest", target=np.conj(er))
                 energy = er
@@ -246,16 +248,16 @@ def nhdmrg(H, HA, psi0, sweeps, krylovdim=20, restarts=2, quiet=True):
                     psil.set_A(b + 1, center_l)
                     psir.set_A(b + 1, center_r)
                     psil.center = psir.center = b + 1
-                    left_h[b] = _extend_left_nh(Lh, Lbra_h, H, psir, psil, b)
-                    left_a[b] = _extend_left_nh(La, Lbra_a, HA, psil, psir, b)
+                    left_h[b] = _extend_left(Lh, Lbra_h, H, psir, b, bra=psil)
+                    left_a[b] = _extend_left(La, Lbra_a, HA, psil, b, bra=psir)
                 else:
                     psil.set_A(b + 1, site_T)
                     psir.set_A(b + 1, site_T)
                     psil.set_A(b, center_l)
                     psir.set_A(b, center_r)
                     psil.center = psir.center = b
-                    right_h[b + 1] = _extend_right_nh(Rh, Rbra_h, H, psir, psil, b + 1)
-                    right_a[b + 1] = _extend_right_nh(Ra, Rbra_a, HA, psil, psir, b + 1)
+                    right_h[b + 1] = _extend_right(Rh, Rbra_h, H, psir, b + 1, bra=psil)
+                    right_a[b + 1] = _extend_right(Ra, Rbra_a, HA, psil, b + 1, bra=psir)
 
         if not quiet:
             print("NH-DMRG sweep {}: energy = {}".format(sweep_i, energy))

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -60,3 +60,14 @@ def vev_ed_v2_v3(chain, hamiltonian, observable, versions=(2, 3), **kwargs):
         results.append(chain.vev(observable, mode="DMRG", **kwargs))
 
     return tuple(results)
+
+
+def setup_backend(chain, itensor_version):
+    """Switch `chain` onto the requested DMRG backend: itensor_version 2
+    or 3 selects the corresponding compiled C++ extension, "python" the
+    pure-Python pyitensor engine. Shared by the multi-backend test files
+    (each used to hand-roll this same dispatch locally)."""
+    if itensor_version == "python":
+        chain.setup_python()
+    else:
+        chain.setup_cpp(version=itensor_version)

--- a/tests/test_dynamical_correlator.py
+++ b/tests/test_dynamical_correlator.py
@@ -30,11 +30,7 @@ def _heisenberg_chain(n=4):
     return sc
 
 
-def _setup_backend(sc, itensor_version):
-    if itensor_version == "python":
-        sc.setup_python()
-    else:
-        sc.setup_cpp(itensor_version)
+from _helpers import setup_backend as _setup_backend
 
 
 def test_dynamical_correlator_peaks_at_excitation_gap():

--- a/tests/test_nh_dmrg.py
+++ b/tests/test_nh_dmrg.py
@@ -24,6 +24,8 @@ import pytest
 
 from dmrgpy import fermionchain, spinchain, cppext
 
+from _helpers import setup_backend
+
 VERSIONS = [
     pytest.param(2, marks=pytest.mark.skipif(
         not cppext.available(2),
@@ -33,13 +35,6 @@ VERSIONS = [
         reason="requires the compiled mpscpp3 (ITensor v3) extension")),
     pytest.param("python", id="python"),
 ]
-
-
-def setup_backend(chain, version):
-    if version == "python":
-        chain.setup_python()
-    else:
-        chain.setup_cpp(version=version)
 
 
 def nh_fermion_chain(n, version):


### PR DESCRIPTION
Follow-up to #52, which was merged before this review-fix commit landed on the branch — this PR carries exactly that one commit (`5c2f69d`), resolving all 10 findings of the high-effort code review of the NH-DMRG implementation.

## Correctness / behavioral fixes
- **Legacy-kwargs regression (confirmed)**: non-Hermitian `gs_energy()` forwarded `**kwargs` into `nhdmrg()`'s strict signature, so previously-working calls like `get_gs_degeneracy(delta=...)` raised `TypeError`. `gs_energy_nhdmrg` now filters kwargs to NH-DMRG's own parameters. (The slowness of `eigenvalue_degeneracy` on NH chains was A/B-checked against origin/master and is pre-existing.)
- **Two-sided residual certificate**: the retry loop now checks both `||H|ψr⟩−E|ψr⟩||` and `||H†|ψl⟩−E*|ψl⟩||` — the right residual alone would accept a run whose anchored adjoint solve locked ψl onto a different eigenstate, since the biorthogonal Rayleigh quotient equals E identically whenever ψr alone is an eigenvector.
- **Entry-point consistency**: non-Hermitian `get_excited_states(n=1)` now routes through the same NH-DMRG solve as `gs_energy()` (Arnoldi remains the n≥2 solver); `wf0` is stored unit-normalized, matching the Arnoldi route's convention.
- **Cross-backend SRTieBreak unification**: all three backends now use the identical global-min-then-candidates Ritz selection (the C++ greedy running-best could settle on a different member of a Re-degenerate cluster than the Python port).

## Efficiency / cleanup
- Arnoldi solvers skip remaining restarts via the free end-of-build residual bound `|h(m+1,m)|·|last Ritz-vector component|`. A per-step stop-on-stable-Ritz-value exit was implemented, **measured to regress the 20-site benchmark ~3×** (30s→104s C++, 18s→55s Python — a non-Hermitian Hessenberg eig per step costs as much as the matvec it saves), and deliberately reverted with the measurement recorded in code comments.
- pyitensor builds its two-sided right environments once and maintains them incrementally (was: rebuilt every sweep); it now reuses `dmrg.py`'s environment builders via a new `bra=` parameter instead of line-for-line copies.
- Shared `setup_backend()` test helper in `tests/_helpers.py`; removed an unused numpy import; fixed the stale "mpscpp3-only" binding docstring.

## Validation
8 consecutive clean runs of the 13-test NH suite, full pytest suite 53 passed, cross-backend example passes, both `.tex` docs compile cleanly; each behavioral fix exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sc11zqTtbXDaZK4jWXapWV