### PR TITLE
Fix install.py failing when run as 'python' instead of 'python3'

### DIFF
--- a/installtk/requirements.py
+++ b/installtk/requirements.py
@@ -223,10 +223,20 @@ def _check_pybind11(python_exe):
         _fail("Could not determine the Python extension suffix for '"
               +python_exe+"'.")
 
-    config_tool = python_exe+"-config"
-    if not os.path.isfile(config_tool):
-        _fail("'"+config_tool+"' was not found -- needed by the pybind11 "
-              "extension Makefile to compute its own include/link flags.\n"
+    # Check for the C headers directly rather than for a
+    # '<python_exe>-config' binary: conda installs 'python3-config'/
+    # 'python3.13-config' but no 'python-config', so the old name-based
+    # check spuriously failed whenever install.py was run as 'python'
+    # instead of 'python3' (the Makefile no longer uses python-config
+    # either -- it asks the interpreter for EXT_SUFFIX via sysconfig).
+    header = subprocess.run([python_exe, "-c",
+            "import sysconfig, os; "
+            "print(os.path.join(sysconfig.get_paths()['include'], "
+            "'Python.h'))"],
+            capture_output=True, text=True)
+    if header.returncode != 0 or not os.path.isfile(header.stdout.strip()):
+        _fail("'Python.h' was not found for '"+python_exe+"' -- needed "
+              "to compile the pybind11 extension.\n"
               "This usually means the interpreter's *-dev/*-devel package "
               "isn't installed, e.g.:\n"
               "  Ubuntu/Debian: sudo apt-get install python3-dev")

--- a/src/dmrgpy/mpscpp2/Makefile
+++ b/src/dmrgpy/mpscpp2/Makefile
@@ -50,7 +50,10 @@ clean:
 
 PYTHON=python3
 PYBIND_INCLUDES=$(shell $(PYTHON) -m pybind11 --includes)
-EXT_SUFFIX=$(shell $(PYTHON)-config --extension-suffix)
+# Ask the interpreter itself for the suffix (not $(PYTHON)-config):
+# conda ships python3-config but no python-config, so the -config
+# form breaks whenever PYTHON is a bare 'python'.
+EXT_SUFFIX=$(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
 EXT_MODULE=_dmrgcpp$(EXT_SUFFIX)
 
 CONDA_GXX=$(shell d=$$(dirname $$(command -v $(PYTHON)) 2>/dev/null); ls $$d/*-conda*-g++ 2>/dev/null | head -1)

--- a/src/dmrgpy/mpscpp3/Makefile
+++ b/src/dmrgpy/mpscpp3/Makefile
@@ -31,7 +31,10 @@ clean:
 
 PYTHON=python3
 PYBIND_INCLUDES=$(shell $(PYTHON) -m pybind11 --includes)
-EXT_SUFFIX=$(shell $(PYTHON)-config --extension-suffix)
+# Ask the interpreter itself for the suffix (not $(PYTHON)-config):
+# conda ships python3-config but no python-config, so the -config
+# form breaks whenever PYTHON is a bare 'python'.
+EXT_SUFFIX=$(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
 EXT_MODULE=_dmrgcpp$(EXT_SUFFIX)
 
 CONDA_GXX=$(shell d=$$(dirname $$(command -v $(PYTHON)) 2>/dev/null); ls $$d/*-conda*-g++ 2>/dev/null | head -1)


### PR DESCRIPTION
## What was happening

`python install.py` failed the requirement check with:

```
'/u/40/ladovj1/unix/apps/anaconda3/bin/python-config' was not found -- needed by the pybind11 extension Makefile...
```

while `python3 install.py` passed — even though both names are symlinks to the exact same `python3.13` binary.

Root cause: the preflight check (`installtk/requirements.py`) and both pybind Makefiles (`mpscpp2`, `mpscpp3`) derived the config-tool name by appending `-config` to the interpreter path. Conda (like most modern Python distributions) installs `python3-config` → `python3.13-config` but **no** `python-config`, so the derived name only exists when the script happens to be invoked as `python3`.

## The fix

Stop guessing the config-tool name entirely:

- **Makefiles**: `EXT_SUFFIX` now comes from asking the interpreter itself — `$(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"` — instead of `$(PYTHON)-config --extension-suffix`. Works for any spelling of the interpreter name.
- **Preflight**: checks for `Python.h` directly (via the target interpreter's `sysconfig.get_paths()['include']`) instead of using `python-config`'s existence as a proxy for the dev headers, keeping the same actionable `python3-dev` hint when headers really are missing.

## Verification

- `python install.py --doctor` and `python3 install.py --doctor` both pass (previously only the latter).
- Dry-run `make pybind PYTHON=.../bin/python` in `mpscpp2` resolves the correct `_dmrgcpp.cpython-313-x86_64-linux-gnu.so` module name; a standalone make snippet confirms the same for `python3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sc11zqTtbXDaZK4jWXapWV