### PR TITLE
Add pyproject.toml and prepare the package for PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ padetk
 setup.py
 pipupdate.sh
 dist/
+build/
 .parallel/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ This library is still under heavy development.
 
 # How to install #
 
+## From PyPI ##
+
+```bash
+pip install dmrgpy
+```
+
+This installs the pure-Python part of the package, which is fully usable
+out of the box: the exact-diagonalization (ED) backend and the
+pure-Python DMRG/TDVP backend (`itensor_version="python"`) both work
+immediately, with no compiler needed. The compiled C++ DMRG backends
+(`itensor_version=2`/`3`, built against a vendored copy of ITensor) are
+not distributed on PyPI -- they are compiled in place from a git clone of
+this repository (see below); without them compiled, `dmrgpy` transparently
+falls back to ED.
+
 ## Linux and Mac ##
 
 Execute the script 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -31,9 +31,23 @@ whichever solver is requested or available:
 
 ## 2. Installation
 
-There is no `setup.py`/`pyproject.toml`; DMRGPY is used directly from
-`src/`, added to `PYTHONPATH` (or symlinked into `site-packages`) by the
-installer.
+There are two independent install paths, and they cover different
+backends:
+
+- **`pip install dmrgpy`** (via the repo's `pyproject.toml`) installs the
+  pure-Python part of the package only — the ED backend and the
+  pure-Python `itensor_version="python"` DMRG/TDVP backend both work
+  immediately, no compiler needed. The compiled C++ backends
+  (`itensor_version=2`/`3`) are *not* on PyPI: they're built against a
+  ~400MB vendored copy of ITensor, and `pyproject.toml` excludes
+  `mpscpp2`/`mpscpp3` from the distributed package entirely (see its own
+  comments). Without them, DMRGPY still works end to end — it just falls
+  back to ED/`"python"` (see mode.py) — but if you want the compiled
+  backends you need the git-clone path below instead.
+- **A git clone + `python install.py`** is required for the compiled C++
+  backends (and is how this repository is developed). DMRGPY is used
+  directly from `src/`, added to `PYTHONPATH` (or symlinked into
+  `site-packages`) by the installer.
 
 ```bash
 python install.py                        # compiles ITensor v3 (mpscpp3, the default) + its pybind11 extension
@@ -58,8 +72,13 @@ and every call transparently falls back to ED when a requested compiled
 backend isn't present.
 
 No compiler or pybind11 is needed at all to use `itensor_version="python"`
-— only NumPy/SciPy (and optionally `numba`/`jax` for faster execution,
-see §5.4).
+— only NumPy/SciPy/SymPy/`numba` (all four are core `pip install dmrgpy`
+dependencies; `numba` is required rather than optional because
+`algebra/kpmextrapolate.py` imports it at module level, and that module
+is reached unconditionally from `manybodychain.py` via
+`dynamics.py`/`kpmdmrg.py` — this is separate from `pyitensor`'s own
+opt-in JAX/numba-accelerated matvec kernel, which *is* genuinely optional
+and off by default, see §5.4). `jax` is optional either way.
 
 ## 3. Quick start
 
@@ -530,11 +549,12 @@ shown in §5.1/§5.2, not these first-call numbers.
 - Use `itensor_version="python"` for quick prototyping, CI/environments
   without a C++ toolchain, or small systems (n ≲ 20) where the 1.3–2x
   overhead doesn't matter.
-- Install `numba` (and optionally `jax`) alongside the pure-Python
-  backend *and* set `pyitensor.kernels.USE_NUMBA = True` (off by
-  default, see §5's note above) — without both steps, `pyitensor` falls
-  back to plain NumPy loops and is substantially slower than the numbers
-  above (see `pyitensor/__init__.py`'s own docstring).
+- `numba` is already installed (it's a core dependency, see §2); also
+  install `jax` and set `pyitensor.kernels.USE_NUMBA = True` (off by
+  default, see §5's note above) if you want the accelerated matvec
+  kernel — without that opt-in, `pyitensor` falls back to plain NumPy
+  loops and is substantially slower than the numbers above (see
+  `pyitensor/__init__.py`'s own docstring).
 - For production-size chains, dynamical correlators, or anything
   performance-sensitive, compile the C++ extension (`python install.py`)
   and use `itensor_version=2` or `3`.

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -65,10 +65,30 @@ work to whichever solver is requested or available:
 \end{itemize}
 
 \section{Installation}
+\label{sec:install}
 
-There is no \texttt{setup.py}/\texttt{pyproject.toml}; DMRGPY is used
-directly from \texttt{src/}, added to \texttt{PYTHONPATH} (or symlinked
-into \texttt{site-packages}) by the installer.
+There are two independent install paths, and they cover different
+backends:
+
+\begin{itemize}
+  \item \textbf{\texttt{pip install dmrgpy}} (via the repo's
+    \texttt{pyproject.toml}) installs the pure-Python part of the
+    package only --- the ED backend and the pure-Python
+    \texttt{itensor\_version="python"} DMRG/TDVP backend both work
+    immediately, no compiler needed. The compiled C++ backends
+    (\texttt{itensor\_version=2}/\texttt{3}) are \emph{not} on PyPI:
+    they're built against a $\sim$400MB vendored copy of ITensor, and
+    \texttt{pyproject.toml} excludes \texttt{mpscpp2}/\texttt{mpscpp3}
+    from the distributed package entirely. Without them, DMRGPY still
+    works end to end --- it just falls back to ED/\texttt{"python"} (see
+    mode.py) --- but if you want the compiled backends you need the
+    git-clone path below instead.
+  \item \textbf{A git clone + \texttt{python install.py}} is required
+    for the compiled C++ backends (and is how this repository is
+    developed). DMRGPY is used directly from \texttt{src/}, added to
+    \texttt{PYTHONPATH} (or symlinked into \texttt{site-packages}) by
+    the installer.
+\end{itemize}
 
 \begin{lstlisting}[language=bash]
 python install.py                        # compiles ITensor v3 (mpscpp3, the default) + its pybind11 extension
@@ -94,9 +114,15 @@ every call transparently falls back to ED when a requested compiled
 backend isn't present.
 
 No compiler or pybind11 is needed at all to use
-\texttt{itensor\_version="python"} --- only NumPy/SciPy (and optionally
-\texttt{numba}/\texttt{jax} for faster execution, see
-Section~\ref{sec:perf}).
+\texttt{itensor\_version="python"} --- only NumPy/SciPy/SymPy/\texttt{numba}
+(all four are core \texttt{pip install dmrgpy} dependencies;
+\texttt{numba} is required rather than optional because
+\texttt{algebra/kpmextrapolate.py} imports it at module level, and that
+module is reached unconditionally from \texttt{manybodychain.py} via
+\texttt{dynamics.py}/\texttt{kpmdmrg.py} --- this is separate from
+\texttt{pyitensor}'s own opt-in JAX/numba-accelerated matvec kernel,
+which \emph{is} genuinely optional and off by default, see
+Section~\ref{sec:perf}). \texttt{jax} is optional either way.
 
 \section{Quick start}
 
@@ -661,12 +687,13 @@ ratios shown above, not these first-call numbers.
   \item Use \texttt{itensor\_version="python"} for quick prototyping,
     CI/environments without a C++ toolchain, or small systems ($n
     \lesssim 20$) where the 1.3--2$\times$ overhead doesn't matter.
-  \item Install \texttt{numba} (and optionally \texttt{jax}) alongside
-    the pure-Python backend \emph{and} set
+  \item \texttt{numba} is already installed (it's a core dependency, see
+    Section~\ref{sec:install}); also install \texttt{jax} and set
     \texttt{pyitensor.kernels.USE\_NUMBA = True} (off by default, see the
-    note above) --- without both steps, \texttt{pyitensor} falls back
-    to plain NumPy loops and is substantially slower than the numbers
-    above (see \texttt{pyitensor/\_\_init\_\_.py}'s own docstring).
+    note above) if you want the accelerated matvec kernel --- without
+    that opt-in, \texttt{pyitensor} falls back to plain NumPy loops and
+    is substantially slower than the numbers above (see
+    \texttt{pyitensor/\_\_init\_\_.py}'s own docstring).
   \item For production-size chains, dynamical correlators, or anything
     performance-sensitive, compile the C++ extension
     (\texttt{python install.py}) and use \texttt{itensor\_version=2} or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dmrgpy"
+version = "0.1.0"
+description = "Quasi-one-dimensional spin, fermionic, parafermion and bosonic systems with matrix product states (DMRG/ED)"
+readme = "README.md"
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE.md"]
+authors = [{name = "Jose Lado", email = "jose.lado@aalto.fi"}]
+requires-python = ">=3.9"
+dependencies = [
+    "numpy",
+    "scipy",
+    "sympy",
+    "numba",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Programming Language :: Python :: 3",
+    "Operating System :: POSIX",
+    "Operating System :: MacOS",
+]
+
+[project.urls]
+Homepage = "https://github.com/joselado/dmrgpy"
+Repository = "https://github.com/joselado/dmrgpy"
+Issues = "https://github.com/joselado/dmrgpy/issues"
+
+# Extras for optional, non-default backends/tools that are only imported
+# lazily by specific submodules -- never required just to `import dmrgpy`.
+# (numba is NOT here: algebra/kpmextrapolate.py imports it at module level,
+# and that module is reached unconditionally via manybodychain -> dynamics
+# -> kpmdmrg -> algebra.kpm -> algebra.kpmextrapolate, so it's a core
+# dependency in practice, not an optional one.)
+[project.optional-dependencies]
+julia = ["julia"]          # juliarun.py, mpsjulialive/juliasession.py (itensor_version="julia"/"julia_live")
+jax = ["jax"]               # pyitensor/kernels.py
+stats = ["statsmodels"]     # algebra/kpmextrapolate.py (function-local import)
+parallel = ["multiprocess", "dill"]  # parallel.py, algebra/parallel.py, parallelslurm.py
+full = ["dmrgpy[julia,jax,stats,parallel]"]
+
+# NOTE: this PyPI package ships the pure-Python part of dmrgpy only (the ED
+# backend and the pure-Python "pyitensor" DMRG/TDVP backend both work
+# out of the box). The compiled C++ DMRG backends (itensor_version=2/3,
+# built against a ~400MB vendored ITensor copy) are not distributed on
+# PyPI -- they are compiled in place from a git checkout via
+# `python install.py`, which is a repo-level build step, not a pip
+# extension build (see CLAUDE.md / install.py). Without them compiled,
+# dmrgpy transparently falls back to ED (see mode.py), so the package is
+# fully usable as installed; run install.py from a clone of the repo for
+# the faster compiled backends.
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["dmrgpy*"]
+exclude = ["dmrgpy.mpscpp2", "dmrgpy.mpscpp2.*", "dmrgpy.mpscpp3", "dmrgpy.mpscpp3.*"]
+
+[tool.setuptools.package-data]
+dmrgpy = ["mpsjulia/*.jl", "mpsjulia/compiler/*.jl"]
+"dmrgpy.mpsjulialive" = ["*.jl"]
+"dmrgpy.algebra" = ["fortran/algebra/*.f90"]


### PR DESCRIPTION
## Summary
- Adds `pyproject.toml` (setuptools backend) so `pip install dmrgpy` works: ships the pure-Python part of the package (ED backend + the `itensor_version="python"` pure-Python DMRG/TDVP backend), no compiler required.
- Excludes `mpscpp2`/`mpscpp3` (vendored ITensor, ~400MB combined) from the distributed package via `packages.find`'s `exclude` — those still require a git clone + `python install.py` as before. Without them compiled, dmrgpy already falls back to ED (existing `mode.py` dispatch), so the PyPI package is fully usable as-is.
- Adds a missing `src/dmrgpy/mpsjulialive/__init__.py` (a real Python subpackage that had no `__init__.py` and was only working via implicit-namespace-package discovery).
- Moves `numba` into core dependencies: `algebra/kpmextrapolate.py` imports it unconditionally at module level, and that module is reached from every `Many_Body_Chain` subclass via `manybodychain → dynamics → kpmdmrg → algebra.kpm`, so it was never actually optional despite the docs previously saying otherwise (that's separate from `pyitensor`'s own genuinely-optional, opt-in JAX/numba matvec kernel, which stays as-is).
- Updates `README.md` and `docs/documentation.{md,tex}` to document the new `pip install dmrgpy` path and fix the numba-is-optional inaccuracy.

## Test plan
- [x] `python -m build --sdist --wheel .` succeeds; `twine check dist/*` passes on both artifacts
- [x] Wheel contents contain no `mpscpp2`/`mpscpp3`/`__pycache__`/`.pyc` files (verified via `zipfile -l` / `tar tzf`)
- [x] Installed the built wheel into a fresh venv; `import dmrgpy` and `from dmrgpy import spinchain, fermionchain, bosonchain, parafermionchain, spinfermionchain` all succeed
- [x] In that venv, a 4-site Heisenberg chain reproduces the same ground-state energy (-0.75) via both `mode="ED"` and the pure-Python DMRG backend (`setup_python()`)
- [x] `pytest tests/test_spin_chain.py` still passes in the worktree (no compiled backend present, matching the PyPI-install scenario)
- [x] `docs/documentation.tex` recompiles cleanly with `pdflatex` (no errors, no new overfull boxes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)