### PR TITLE
Remove PyPI install section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,6 @@ This library is still under heavy development.
 
 # How to install #
 
-## From PyPI ##
-
-```bash
-pip install dmrgpy
-```
-
-This installs the pure-Python part of the package, which is fully usable
-out of the box: the exact-diagonalization (ED) backend and the
-pure-Python DMRG/TDVP backend (`itensor_version="python"`) both work
-immediately, with no compiler needed. The compiled C++ DMRG backends
-(`itensor_version=2`/`3`, built against a vendored copy of ITensor) are
-not distributed on PyPI -- they are compiled in place from a git clone of
-this repository (see below); without them compiled, `dmrgpy` transparently
-falls back to ED.
-
 ## Linux and Mac ##
 
 Execute the script 


### PR DESCRIPTION
## Summary
- Removes the "From PyPI" install instructions from README.md since the package has not been uploaded to PyPI yet.

## Test plan
- N/A (documentation-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)