### PR TITLE
Add Mixed_Spin_Fermion_Chain: mixed spin/spinful-fermion chains (v3)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -119,6 +119,32 @@ for that statistics:
 | `spinfermionchain.py` | `Spin_Fermionic_Chain` | spinful fermions |
 | `bosonchain.py` | `Boson_Chain` | bosonic sites |
 | `parafermionchain.py` | `Parafermion_Chain` | parafermion sites |
+| `mixedchain.py` | `Mixed_Spin_Fermion_Chain` | mixes spin sites and spinful-fermion locations in one chain |
+
+All of the above build `self.sites`, the list of per-site type codes
+passed to `Many_Body_Chain.__init__`, from a **uniform** repetition of a
+single type code (e.g. `[0]*n` for `Fermionic_Chain`). Nothing in
+`sites.py`/the C++ or pyitensor `Chain` constructors actually requires
+this — the site-construction layer (`mpscppN/get_sites.h`'s
+`SpinX(std::vector<int> const&)`, `pyitensor/sites/siteset.py::SiteX`)
+already accepts an arbitrary, heterogeneous per-site type-code list.
+`bosonchain.py::SpinBoson_Chain` and `mixedchain.py::Mixed_Spin_Fermion_Chain`
+are the two model classes that build such a heterogeneous list directly
+(spin+boson and spin+spinful-fermion respectively), each following the
+same pattern: build every operator that could be meaningful at *any*
+site, then mask the invalid combinations to the literal int `0` per
+site. `Mixed_Spin_Fermion_Chain` represents a spinful-fermion location as
+a pair of physical spinless-fermion (type-code 0) sites, exactly like
+`fermionchain.Spinful_Fermionic_Chain`, so it reuses the existing
+`C`/`Cdag`/`A`/`Adag`/`F` operator vocabulary and Jordan-Wigner code
+unchanged. It currently only supports `itensor_version` `3` and
+`"python"`: a Jordan-Wigner string that has to cross a non-fermionic
+(spin) site relies on `SiteSet::op()`'s "unrecognized `F` request
+resolves to identity" fallback, present in ITensor v3
+(`mpscpp3/ITensor/itensor/mps/siteset.h`) and in pyitensor's own
+`SiteType.matrix()` (`pyitensor/sites/base.py`), but not in ITensor v2
+(`mpscpp2/ITensor/itensor/mps/siteset.h`), which would hard-abort
+instead.
 
 ### 4.2 Operator representation: `MultiOperator`
 

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -152,6 +152,7 @@ evolution, entanglement entropy, and more. Model modules just define the
 local Hilbert space and convenience operators for that statistics:
 
 \begin{center}
+\footnotesize
 \begin{tabular}{lll}
 \toprule
 Module & Class & Notes \\
@@ -161,9 +162,40 @@ Module & Class & Notes \\
 \texttt{spinfermionchain.py} & \texttt{Spin\_Fermionic\_Chain} & spinful fermions \\
 \texttt{bosonchain.py} & \texttt{Boson\_Chain} & bosonic sites \\
 \texttt{parafermionchain.py} & \texttt{Parafermion\_Chain} & parafermion sites \\
+\texttt{mixedchain.py} & \texttt{Mixed\_Spin\_\allowbreak Fermion\_Chain} & spin \& spinful-fermion mix \\
 \bottomrule
 \end{tabular}
+\normalsize
 \end{center}
+
+All of the above build \texttt{self.sites}, the list of per-site type
+codes passed to \texttt{Many\_Body\_Chain.\_\_init\_\_}, from a
+\emph{uniform} repetition of a single type code (e.g.\ \texttt{[0]*n}
+for \texttt{Fermionic\_Chain}). Nothing in \texttt{sites.py}/the C++ or
+pyitensor \texttt{Chain} constructors actually requires this --- the
+site-construction layer (\texttt{mpscppN/get\_sites.h}'s
+\texttt{SpinX(std::vector<int> const\&)},
+\texttt{pyitensor/sites/siteset.py::SiteX}) already accepts an
+arbitrary, heterogeneous per-site type-code list.
+\texttt{bosonchain.py::SpinBoson\_Chain} and
+\texttt{mixedchain.py::Mixed\_Spin\_Fermion\_Chain} are the two model
+classes that build such a heterogeneous list directly (spin+boson and
+spin+spinful-fermion respectively), each following the same pattern:
+build every operator that could be meaningful at \emph{any} site, then
+mask the invalid combinations to the literal int 0 per site.
+\texttt{Mixed\_Spin\_Fermion\_Chain} represents a spinful-fermion
+location as a pair of physical spinless-fermion (type-code 0) sites,
+exactly like \texttt{fermionchain.Spinful\_Fermionic\_Chain}, so it
+reuses the existing C/Cdag/A/Adag/F operator vocabulary and
+Jordan-Wigner code unchanged. It currently only supports
+\texttt{itensor\_version} \texttt{3} and \texttt{"python"}: a
+Jordan-Wigner string that has to cross a non-fermionic (spin) site
+relies on \texttt{SiteSet::op()}'s ``unrecognized F request resolves to
+identity'' fallback, present in ITensor v3
+(\texttt{mpscpp3/ITensor/itensor/mps/siteset.h}) and in pyitensor's own
+\texttt{SiteType.matrix()} (\texttt{pyitensor/sites/base.py}), but not
+in ITensor v2 (\texttt{mpscpp2/ITensor/itensor/mps/siteset.h}), which
+would hard-abort instead.
 
 \subsection{Operator representation: \texttt{MultiOperator}}
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -41,12 +41,30 @@ Every model is a chain of $n$ local Hilbert spaces $\mathcal H=\bigotimes_{i=1}^
 | `fermionchain.Spinful_Fermionic_Chain` | spin-$\tfrac12$ fermion (4 states: $0,\uparrow,\downarrow,\uparrow\downarrow$), built from two interleaved spinless sites per physical site | $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$, plus derived $S^x_i,S^y_i,S^z_i=\tfrac12(n_{i\uparrow}-n_{i\downarrow})$, onsite pairing $\Delta_i=\tfrac12 c_{i\uparrow}c_{i\downarrow}$ |
 | `bosonchain.Bosonic_Chain` | truncated boson Fock space, $n_i\in\{0,\ldots,n_{\max}\}$ (default $n_{\max}=4$) | $a_i,a_i^\dagger,n_i$, occupation projectors $\hat n_i^{(k)}=\lvert k\rangle\langle k\rvert$ |
 | `parafermionchain.Parafermionic_Chain` | $\mathbb Z_N$ parafermion (clock model), $N\in\{2,3,4\}$ | clock/shift operators $\sigma_i,\tau_i$ and composite parafermion operators $\chi_i,\psi_i$ built as $\tau$-string $\times\sigma_i$ |
+| `mixedchain.Mixed_Spin_Fermion_Chain` | mixes genuine spin-$S$ sites and spinful-fermion locations *in the same chain*, one entry per logical location | at a spin location: native $S^x_i,S^y_i,S^z_i$; at a fermion location: $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$ plus derived $S^x_i,S^y_i,S^z_i,\Delta_i$ as in `Spinful_Fermionic_Chain` |
 
 Spinful fermionic chains are built by *interleaving* two spinless
 fermionic sites per physical site (site $2i$ = spin up, site $2i+1$ =
 spin down) rather than by a genuinely 4-dimensional local space, so that
 the same Jordan-Wigner machinery used for spinless fermions applies
 unchanged; `Spinful_Fermionic_Chain` wraps this bookkeeping for you.
+
+`Mixed_Spin_Fermion_Chain` is for models that need a literal local
+moment next to a conduction-electron site (e.g. Kondo-lattice-like
+Hamiltonians), rather than the large-$U$ two-fermion-site trick
+`Spinful_Fermionic_Chain`/`spinfermionchain.py` use to emulate a spin.
+Its `sitesin` constructor argument is a list with one entry per logical
+location, each either a spin label (`"1/2"`, `"1"`, ... as in
+`Spin_Chain`) or a fermion marker (`"F"`); a fermion location expands
+internally to a spin-up/spin-down site pair, exactly like
+`Spinful_Fermionic_Chain`. All operator lists (`Sx`/`Sy`/`Sz`,
+`Cup`/`Cdagup`/`Cdn`/`Cdagdn`/`Nup`/`Ndn`/`Ntot`/`Delta`) are indexed by
+*logical* location, not by physical site — the fermion-only operators
+read as the literal integer `0` at spin locations, since they have no
+meaning there. Currently only `itensor_version=3` (and `"python"`) are
+supported; see `mixedchain.py`'s module docstring for why
+`itensor_version=2` isn't yet, and `examples/mixed_spin_fermion_chain`
+for a worked Kondo-lattice example.
 
 ## 2. Building a Hamiltonian and observables
 

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -62,6 +62,7 @@ Chain class & Local Hilbert space & Key operators \\
 \texttt{fermionchain.\allowbreak Spinful\_\allowbreak Fermionic\_Chain} & spin-$\tfrac12$ fermion (4 states), two interleaved spinless sites per physical site & $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$; derived spin and pairing operators (see text) \\
 \texttt{bosonchain.\allowbreak Bosonic\_Chain} & truncated boson Fock space, $n_i\le n_{\max}$ (default 4) & $a_i,a_i^\dagger,n_i$, occupation projectors \\
 \texttt{parafermionchain.\allowbreak Parafermionic\_\allowbreak Chain} & $\mathbb Z_N$ parafermion (clock model), $N\in\{2,3,4\}$ & clock/shift operators $\sigma_i,\tau_i$, composite $\chi_i,\psi_i$ \\
+\texttt{mixedchain.\allowbreak Mixed\_Spin\_\allowbreak Fermion\_Chain} & mixes spin-$S$ sites and spinful-fermion locations in the same chain & spin location: native $S^x_i,S^y_i,S^z_i$; fermion location: $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$ plus derived spin/pairing operators \\
 \bottomrule
 \end{tabular}
 \normalsize
@@ -73,6 +74,26 @@ spin down) rather than by a genuinely 4-dimensional local space, so that
 the same Jordan-Wigner machinery used for spinless fermions applies
 unchanged; \texttt{Spinful\_Fermionic\_Chain} wraps this bookkeeping for
 you.
+
+\texttt{Mixed\_Spin\_Fermion\_Chain} is for models that need a literal
+local moment next to a conduction-electron site (e.g.\ Kondo-lattice-like
+Hamiltonians), rather than the large-$U$ two-fermion-site trick
+\texttt{Spinful\_Fermionic\_Chain}/\texttt{spinfermionchain.py} use to
+emulate a spin. Its \texttt{sitesin} constructor argument is a list with
+one entry per logical location, each either a spin label (\texttt{"1/2"},
+\texttt{"1"}, \ldots{} as in \texttt{Spin\_Chain}) or a fermion marker
+(\texttt{"F"}); a fermion location expands internally to a spin-up/spin-down
+site pair, exactly like \texttt{Spinful\_Fermionic\_Chain}. All operator
+lists (\texttt{Sx}/\texttt{Sy}/\texttt{Sz},
+\texttt{Cup}/\texttt{Cdagup}/\texttt{Cdn}/\texttt{Cdagdn}/\texttt{Nup}/
+\texttt{Ndn}/\texttt{Ntot}/\texttt{Delta}) are indexed by \emph{logical}
+location, not by physical site -- the fermion-only operators read as the
+literal integer 0 at spin locations, since they have no meaning there.
+Currently only \texttt{itensor\_version=3} (and \texttt{"python"}) are
+supported; see \texttt{mixedchain.py}'s module docstring for why
+\texttt{itensor\_version=2} isn't yet, and
+\texttt{examples/mixed\_spin\_fermion\_chain} for a worked Kondo-lattice
+example.
 
 \section{Building a Hamiltonian and observables}
 

--- a/examples/mixed_spin_fermion_chain/main.py
+++ b/examples/mixed_spin_fermion_chain/main.py
@@ -1,0 +1,86 @@
+# Add the root path of the dmrgpy library, and of tests/ for the shared
+# dense Jordan-Wigner reference oracle (tests/_dense_jw_reference.py) --
+# kept in one place rather than duplicated here, since it's the
+# physics-critical part of the cross-check.
+import os ; import sys
+sys.path.append(os.getcwd()+'/../../src')
+sys.path.append(os.getcwd()+'/../../tests')
+
+# Regression test / demo for mixedchain.Mixed_Spin_Fermion_Chain: a chain
+# mixing a genuine spin-1/2 site and spinful-fermion locations (paired
+# spinless-fermion up/down sites, see mixedchain.py), used here for a
+# small Kondo-lattice-like model -- a local moment (real spin site)
+# exchange-coupled to two conduction-electron sites, with a direct
+# hopping between the two fermion sites that has the spin site physically
+# in between (exercising the Jordan-Wigner string crossing a
+# non-fermionic site, see mixedchain.py's docstring).
+#
+# Ground-state energy and a couple of expectation values are checked
+# against the same dense Jordan-Wigner reference tests/test_mixed_chain.py
+# uses, since there is no dedicated ED backend for this chain type yet.
+import numpy as np
+from dmrgpy import mixedchain
+from _dense_jw_reference import SX, SY, SZ, fermion_ops, embed
+
+labels = ["F", "1/2", "F"] # fermion - spin - fermion
+mc = mixedchain.Mixed_Spin_Fermion_Chain(labels, itensor_version=3)
+mc.maxm = 60
+mc.nsweeps = 20
+assert mc.sites == [0, 0, 2, 0, 0] # 2 fermion sites, 1 spin site, 2 fermion sites
+assert mc.phys_index == [(0, 1), 2, (3, 4)]
+
+# Same parameters as tests/test_mixed_chain.py's KONDO_PARAMS. `hf` is a
+# small longitudinal field: lifts the SU(2) ground-multiplet degeneracy
+# so per-site Sz has a single, reproducible value (see
+# tests/test_mixed_chain.py's KONDO_PARAMS docstring for why).
+K1, K2, t, muA, muB, hf = 0.5, 0.35, 0.4, 0.15, -0.2, 0.13
+h = K1*mc.SS(0, 1) + K2*mc.SS(1, 2) + muA*mc.Ntot[0] + muB*mc.Ntot[2]
+hop = t*(mc.Cdagup[0]*mc.Cup[2] + mc.Cdagdn[0]*mc.Cdn[2]) # crosses the spin site
+h = h + hop + hop.get_dagger()
+h = h + hf*(mc.Sz[0] + mc.Sz[1] + mc.Sz[2])
+
+mc.set_hamiltonian(h)
+e_dmrg = mc.gs_energy(mode="DMRG")
+sz_spin_dmrg = mc.vev(mc.Sz[1]).real
+ntot_fermA_dmrg = mc.vev(mc.Ntot[0]).real
+
+print("DMRG ground-state energy", e_dmrg)
+print("<Sz> at the spin location", sz_spin_dmrg)
+print("<Ntot> at the first fermion location", ntot_fermA_dmrg)
+
+# --- independent dense Jordan-Wigner reference ---
+nsites = 5 # fAup, fAdn, spin, fBup, fBdn
+fermionic_mask = [True, True, False, True, True]
+C, Cdag, N = fermion_ops(fermionic_mask)
+Sx_s, Sy_s, Sz_s = embed(SX,2,nsites), embed(SY,2,nsites), embed(SZ,2,nsites)
+
+def ferm_spin_ops(up, dn):
+    sx = 0.5*(Cdag[up]@C[dn]) + 0.5*(Cdag[dn]@C[up])
+    sy = -0.5j*(Cdag[up]@C[dn]) + 0.5j*(Cdag[dn]@C[up])
+    sz = 0.5*N[up] - 0.5*N[dn]
+    ntot = N[up] + N[dn]
+    return sx, sy, sz, ntot
+
+sxA, syA, szA, ntotA = ferm_spin_ops(0, 1)
+sxB, syB, szB, ntotB = ferm_spin_ops(3, 4)
+
+H = (K1*(sxA@Sx_s + syA@Sy_s + szA@Sz_s)
+     + K2*(Sx_s@sxB + Sy_s@syB + Sz_s@szB)
+     + muA*ntotA + muB*ntotB + hf*(szA + Sz_s + szB))
+hopref = t*(Cdag[0]@C[3] + Cdag[1]@C[4])
+H = H + hopref + hopref.conj().T
+
+es, vs = np.linalg.eigh(H)
+e_ref = es[0]
+gs = vs[:, 0]
+sz_ref = np.vdot(gs, Sz_s@gs).real
+ntot_ref = np.vdot(gs, ntotA@gs).real
+
+print("Reference ground-state energy", e_ref)
+print("Reference <Sz> at the spin location", sz_ref)
+print("Reference <Ntot> at the first fermion location", ntot_ref)
+
+assert abs(e_dmrg-e_ref) < 1e-5
+assert abs(sz_spin_dmrg-sz_ref) < 1e-4
+assert abs(ntot_fermA_dmrg-ntot_ref) < 1e-4
+print("OK")

--- a/src/dmrgpy/densitymatrix.py
+++ b/src/dmrgpy/densitymatrix.py
@@ -25,18 +25,22 @@ def reduced_dm_projective(self,wf,i=0,j=None):
               # we need to project on up/dn and rotate to up!
               return [Szk+0.5,P01] 
           elif site==3: # S=1 site
-              raise # not finished
+              raise NotImplementedError("reduced_dm_projective: S=1 "
+                      "site projectors are not finished")
               Szk = self.Sz[k]
-              return [Szk*(Szk+1)/2.,-(Szk-1)*(Szk+1),Szk*(1-Szk)/2.] 
-          else: raise # not implemented
+              return [Szk*(Szk+1)/2.,-(Szk-1)*(Szk+1),Szk*(1-Szk)/2.]
+          else: raise NotImplementedError("reduced_dm_projective: no "
+                  "projectors for site type "+str(site))
         elif type(self)==Fermionic_Chain: # spin chain object
           N = self.N[k] # density operator
           P01 = self.Cdag[k] # create an electron
           # we need to project on up/dn and rotate to up!
           return [N,P01] # return the projectors
         elif type(self)==Spinful_Fermionic_Chain: # spin chain object
-          raise # not implemented yet
-        else: raise # not implemented
+          raise NotImplementedError("reduced_dm_projective: not "
+                  "implemented yet for Spinful_Fermionic_Chain")
+        else: raise NotImplementedError("reduced_dm_projective: not "
+                "implemented for chain type "+type(self).__name__)
     Pi = projectors(i) # projectors for site i
     if j is not None: Pj = projectors(j) # projectors for site j
     else: Pj = [1] # workaround for a single site

--- a/src/dmrgpy/manybodychain.py
+++ b/src/dmrgpy/manybodychain.py
@@ -312,8 +312,15 @@ class Many_Body_Chain():
   def generate_bilinear(self,fun,A,B):
       """Generic bilinear term"""
       fun = funtk.obj2fun(fun) # set function
+      # Index by len(A)/len(B), not self.ns: for chain classes whose
+      # per-site operator lists are indexed by logical location rather
+      # than physical site (e.g. Spinful_Fermionic_Chain,
+      # Mixed_Spin_Fermion_Chain), len(A)/len(B) < self.ns, and indexing
+      # up to self.ns would raise IndexError. For every chain whose
+      # lists are physical-site-indexed already, len(A)==len(B)==self.ns,
+      # so this is unchanged there.
       h = multioperator.msum(fun(i,j)*A[i]*B[j]
-              for i in range(self.ns) for j in range(self.ns))
+              for i in range(len(A)) for j in range(len(B)))
       return 0.5*(h + h.get_dagger()) # Hermitian
   def update_hamiltonian(self):
       h = self.hopping + self.hubbard + self.pairing

--- a/src/dmrgpy/mixedchain.py
+++ b/src/dmrgpy/mixedchain.py
@@ -1,0 +1,181 @@
+from .manybodychain import Many_Body_Chain
+from .spinchain import label2site
+
+_fermion_labels = ("F", "f", "fermion", "Fermion")
+
+
+def is_fermion_label(label):
+    """Check if a mixed-chain site label denotes a spinful-fermion
+    location (as opposed to a spin location)"""
+    return label in _fermion_labels
+
+
+def get_site_label(label):
+    """Classify a mixed-chain site label as "spin" or "fermion" """
+    if is_fermion_label(label): return "fermion"
+    elif label in label2site: return "spin"
+    else: raise ValueError("Unrecognized mixed-chain site label "+str(label))
+
+
+class Mixed_Spin_Fermion_Chain(Many_Body_Chain):
+    """
+    Chain mixing genuine spin sites and spinful-fermion locations in the
+    same chain (e.g. for Kondo-lattice-like models coupling a literal
+    local moment to a conduction-electron site, instead of the
+    large-U two-fermion-site trick used by
+    fermionchain.Spinful_Fermionic_Chain/spinfermionchain.py).
+
+    `sitesin` is a list with one entry per logical location, each either
+    a spin label recognized by spinchain.label2site ("1/2","1","3/2",...)
+    or a fermion marker ("F"/"f"/"fermion"). A fermion location is built,
+    exactly like fermionchain.Spinful_Fermionic_Chain, as a pair of
+    physical spinless-fermion (type-code 0) sites for the up/down
+    channels; a spin label is a single physical site of the
+    corresponding spin type. This reuses the existing C/Cdag/A/Adag/F
+    operator vocabulary and multioperatortk/jordanwigner.py unchanged.
+
+    Operator lists are indexed by *logical* location (length
+    len(sitesin)), not by physical site (self.ns, which counts each
+    fermion location twice) -- the same convention
+    Spinful_Fermionic_Chain already uses for its own Sx/Sy/Sz/Cup/Cdn/...
+
+    Sx/Sy/Sz are defined at every location: at a spin location they are
+    the native spin operators, at a fermion location they are the usual
+    spin-density bilinear (0.5*Cdagup*Cdn + h.c., etc, same formula as
+    Spinful_Fermionic_Chain). The fermionic operators (Cup/Cdagup/Cdn/
+    Cdagdn/Nup/Ndn/Ntot/Delta) are only meaningful at fermion locations
+    and are set to the literal int 0 at spin locations (same masking
+    pattern bosonchain.py::SpinBoson_Chain uses for its boson/spin mix).
+
+    For itensor_version=3, a Jordan-Wigner string that has to cross a
+    spin location (e.g. a hopping term between two fermion locations
+    with a spin location in between) is handled correctly because
+    ITensor v3's SiteSet::op() (mpscpp3/ITensor/itensor/mps/siteset.h)
+    resolves an unrecognized "F" request -- which is what a spin site
+    receives, since it defines no "F" operator -- to the identity,
+    rather than erroring; see tests/test_mixed_chain.py for a
+    regression test exercising this directly. itensor_version=2 has no
+    such fallback and hard-aborts the whole process on the same input,
+    so it is rejected up front in __init__; this class only supports
+    itensor_version in (3,"python").
+
+    There is no ED backend for this chain type yet (get_ED_obj() raises
+    NotImplementedError): building one needs to combine genuine
+    fermionic Fock-space statistics with tensor-product spin operators,
+    which no existing EDchain subclass does today (see
+    pyboson.boson.SpinBosonChain, the closest analogue for spin+boson,
+    which is itself an unfinished stub). Because of this,
+    itensor_version=3's automatic ns<3 -> ED fallback (mode.py, worked
+    around for every other chain type) will raise that same
+    NotImplementedError for a mixed chain with fewer than 3 physical
+    sites -- use a larger chain or itensor_version="python" instead.
+
+    The generic Many_Body_Chain._MB Hamiltonian-building helpers
+    (set_hoppings_MB/set_hubbard_MB/set_pairings_MB) are not usable
+    here: they reference self.C/self.Cdag/self.N, which this class does
+    not define (a single-species "C" is not well-defined at a spinful
+    fermion location) -- build the Hamiltonian directly from
+    Cup/Cdagup/Cdn/Cdagdn/Nup/Ndn/Ntot/Delta and Sx/Sy/Sz instead, as
+    tests/test_mixed_chain.py and examples/mixed_spin_fermion_chain do.
+    """
+    def __init__(self, sitesin, **kwargs):
+        itensor_version = kwargs.get("itensor_version", None)
+        if itensor_version is None:
+            from .cppext import DEFAULT_ITENSOR_VERSION
+            itensor_version = DEFAULT_ITENSOR_VERSION
+        if itensor_version not in (3, "python"):
+            raise ValueError("Mixed_Spin_Fermion_Chain only supports "
+                    "itensor_version in (3,'python'), got "
+                    +str(itensor_version)+" -- itensor_version=2 has no "
+                    "fallback for a Jordan-Wigner string crossing a spin "
+                    "site and hard-aborts the process (see this class's "
+                    "docstring)")
+        kinds = [get_site_label(s) for s in sitesin]
+        phys_types = [] # flat physical type-code list
+        phys_index = [] # per logical location: int (spin) or (up,dn) tuple (fermion)
+        for label, kind in zip(sitesin, kinds):
+            if kind=="fermion":
+                up = len(phys_types)
+                phys_types.append(0)
+                phys_types.append(0)
+                phys_index.append((up, up+1))
+            else: # spin
+                i = len(phys_types)
+                phys_types.append(label2site[label])
+                phys_index.append(i)
+        Many_Body_Chain.__init__(self, phys_types, **kwargs)
+        self.kind = kinds # "spin" or "fermion" per logical location
+        self.phys_index = phys_index
+        self.use_ampo_hamiltonian = True # use ampo
+        n = len(sitesin)
+        # per-physical-site fermionic operators (only meaningful at the
+        # physical sites belonging to a fermion location)
+        Cp = [self.get_operator("C",i) for i in range(self.ns)]
+        Cdagp = [self.get_operator("Cdag",i) for i in range(self.ns)]
+        Np = [self.get_operator("N",i) for i in range(self.ns)]
+        # Masked-out entries are real (numerically zero) MultiOperator
+        # instances, not the literal int 0: a plain 0 would degrade to a
+        # bare Python int the moment two masked entries at spin locations
+        # get multiplied together (0*0==0, an int with none of
+        # MultiOperator's API, e.g. no .get_dagger()), and would also
+        # break vev() on a masked entry, since MultiOperator.obj2MO's
+        # bare-number branch does not use the target vev name (see
+        # multioperator.py). "0*self.Id" builds a fresh, independent,
+        # properly-typed zero operator per list entry.
+        self.Sx = [0 for i in range(n)]
+        self.Sy = [0 for i in range(n)]
+        self.Sz = [0 for i in range(n)]
+        self.Cup = [0*self.Id for i in range(n)]
+        self.Cdagup = [0*self.Id for i in range(n)]
+        self.Cdn = [0*self.Id for i in range(n)]
+        self.Cdagdn = [0*self.Id for i in range(n)]
+        self.Nup = [0*self.Id for i in range(n)]
+        self.Ndn = [0*self.Id for i in range(n)]
+        self.Ntot = [0*self.Id for i in range(n)]
+        self.Delta = [0*self.Id for i in range(n)]
+        for loc in range(n):
+            if kinds[loc]=="spin":
+                i = phys_index[loc]
+                self.Sx[loc] = self.get_operator("Sx",i)
+                self.Sy[loc] = self.get_operator("Sy",i)
+                self.Sz[loc] = self.get_operator("Sz",i)
+            else: # fermion
+                up,dn = phys_index[loc]
+                self.Cup[loc] = Cp[up]
+                self.Cdagup[loc] = Cdagp[up]
+                self.Cdn[loc] = Cp[dn]
+                self.Cdagdn[loc] = Cdagp[dn]
+                self.Nup[loc] = Np[up]
+                self.Ndn[loc] = Np[dn]
+                self.Ntot[loc] = Np[up] + Np[dn]
+                self.Delta[loc] = 0.5*Cp[up]*Cp[dn]
+                self.Sx[loc] = 0.5*Cdagp[up]*Cp[dn] + 0.5*Cdagp[dn]*Cp[up]
+                self.Sy[loc] = -0.5*1j*Cdagp[up]*Cp[dn] + 1j*0.5*Cdagp[dn]*Cp[up]
+                self.Sz[loc] = 0.5*Np[up] - 0.5*Np[dn]
+        self.Si = [self.Sx, self.Sy, self.Sz]
+    def SS(self,i,j):
+        """Spin-spin coupling between two locations (either kind)"""
+        return self.Sx[i]*self.Sx[j] + self.Sy[i]*self.Sy[j] + self.Sz[i]*self.Sz[j]
+    def setup_cpp(self,version=3):
+        """Switch the C++ DMRG backend -- only version=3 is supported
+        here (see this class's docstring)."""
+        if version!=3:
+            raise ValueError("Mixed_Spin_Fermion_Chain only supports "
+                    "itensor_version=3, got "+str(version))
+        Many_Body_Chain.setup_cpp(self,version)
+    def get_ED_obj(self):
+        """
+        There is no ED backend for a mixed spin/spinful-fermion Hilbert
+        space yet (see this class's docstring): unlike the pure-spin or
+        pure-fermion chains, that needs a chain-of-tensor-product spin
+        operators combined with genuine Fock-space fermion statistics,
+        which no existing EDchain subclass implements. Raising here
+        (instead of leaving get_ED_obj undefined) turns mode.py's
+        automatic DMRG->ED fallback for itensor_version==3 chains with
+        self.ns<3 into a clear error instead of an unrelated
+        AttributeError.
+        """
+        raise NotImplementedError("Mixed_Spin_Fermion_Chain has no ED "
+                "backend yet; use itensor_version=3 or \"python\" DMRG "
+                "on a chain with self.ns>=3 physical sites instead of "
+                "mode=\"ED\"")

--- a/src/dmrgpy/multioperator.py
+++ b/src/dmrgpy/multioperator.py
@@ -270,7 +270,10 @@ def obj2MO(a,name="multioperator"):
     elif type(a)==MultiOperator:
         a.name = name
         return a
-    elif isnumber(a): return a*identity() 
+    elif isnumber(a):
+        out = a*identity()
+        out.name = name # a bare number has no name of its own to keep
+        return out
     else: raise # unidentified input
 
 

--- a/tests/_dense_jw_reference.py
+++ b/tests/_dense_jw_reference.py
@@ -1,0 +1,59 @@
+"""Small, from-scratch, dense NumPy Jordan-Wigner reference (local
+dimension 2 everywhere), independent of multioperatortk/jordanwigner.py.
+
+Used as an ED ground-truth oracle for mixedchain.Mixed_Spin_Fermion_Chain
+(no dedicated ED backend exists for a mixed spin/spinful-fermion Hilbert
+space yet, see mixedchain.py's docstring), shared between
+test_mixed_chain.py and examples/mixed_spin_fermion_chain/main.py so the
+Jordan-Wigner-string construction is only maintained in one place."""
+import numpy as np
+
+I2 = np.eye(2, dtype=complex)
+SX = 0.5*np.array([[0, 1], [1, 0]], dtype=complex)
+SY = 0.5*np.array([[0, -1j], [1j, 0]], dtype=complex)
+SZ = 0.5*np.array([[1, 0], [0, -1]], dtype=complex)
+_A = np.array([[0, 1], [0, 0]], dtype=complex)   # annihilation, basis (|0>,|1>)
+_ADAG = _A.T.conj()
+_Z = I2 - 2*(_ADAG @ _A)                          # fermion parity
+
+
+def kron_all(mats):
+    out = np.array([[1.0]], dtype=complex)
+    for m in mats: out = np.kron(out, m)
+    return out
+
+
+def embed(mat, pos, nsites):
+    """Embed a 2x2 operator at physical site `pos` (0-based) of an
+    nsites chain, identity elsewhere."""
+    mats = [I2]*nsites
+    mats[pos] = mat
+    return kron_all(mats)
+
+
+def fermion_ops(fermionic_mask):
+    """Dense C/Cdag/N with an explicit Jordan-Wigner string, for a chain
+    of local dimension 2 where fermionic_mask[i] is True at a
+    fermionic-mode physical site and False at a bosonic/spin site (whose
+    parity contribution is the identity -- the same physics
+    itensor_version=3's "F"-at-non-fermionic-site fallback implements)."""
+    nsites = len(fermionic_mask)
+    C, Cdag, N = [None]*nsites, [None]*nsites, [None]*nsites
+    for p in range(nsites):
+        mats_c, mats_cdag = [I2]*nsites, [I2]*nsites
+        for k in range(p):
+            if fermionic_mask[k]:
+                mats_c[k] = _Z
+                mats_cdag[k] = _Z
+        mats_c[p] = _A
+        mats_cdag[p] = _ADAG
+        C[p] = kron_all(mats_c)
+        Cdag[p] = kron_all(mats_cdag)
+        N[p] = Cdag[p] @ C[p]
+    return C, Cdag, N
+
+
+def gs(H):
+    """Ground-state energy and eigenvector of a dense Hermitian matrix"""
+    es, vs = np.linalg.eigh(H)
+    return es[0], vs[:, 0]

--- a/tests/test_mixed_chain.py
+++ b/tests/test_mixed_chain.py
@@ -1,0 +1,272 @@
+"""Functional coverage for mixedchain.Mixed_Spin_Fermion_Chain, a chain
+that mixes genuine spin sites and spinful-fermion locations (paired
+spinless-fermion up/down sites, exactly like
+fermionchain.Spinful_Fermionic_Chain) in the same chain.
+
+Degenerate cases (all-spin / all-fermion sitesin) are cross-checked
+against the existing, dedicated ED backends of spinchain.Spin_Chain /
+fermionchain.Spinful_Fermionic_Chain. The genuinely mixed case has no
+existing ED backend (see CLAUDE.md's mixed-chain notes), so it is
+cross-checked against a small, from-scratch, dense NumPy Jordan-Wigner
+reference built directly in this file (independent of
+multioperatortk/jordanwigner.py) -- this is also what exercises the
+case a Jordan-Wigner string has to cross a non-fermionic (spin) site,
+which itensor_version=3 handles via ITensor's own SiteSet::op()
+"F"-at-non-fermionic-site -> identity fallback (see mixedchain.py's
+docstring).
+
+Only itensor_version=3 (and, for one cross-check, "python") is
+exercised: itensor_version=2 is not supported for this chain type (no
+"F"-fallback) and is rejected at construction time, see mixedchain.py."""
+import numpy as np
+import pytest
+
+from dmrgpy import mixedchain, spinchain, fermionchain
+
+from _dense_jw_reference import SX, SY, SZ, embed, fermion_ops, gs as _gs
+
+DMRG_TOL = 1e-6
+
+# ---------------------------------------------------------------------
+# Degenerate cases: mixed chain reduces to the existing pure classes
+# ---------------------------------------------------------------------
+
+def test_pure_spin_degenerate_case_matches_spin_chain_ed():
+    """All-spin sitesin, non-uniform exchange/field: Mixed_Spin_Fermion_Chain
+    DMRG (v3) must agree with spinchain.Spin_Chain's own ED backend."""
+    labels = ["1/2", "1", "1/2"]
+
+    sc = spinchain.Spin_Chain(labels)
+    h_sc = (0.7*sc.SS(0, 1) + 1.3*sc.SS(1, 2)
+            + 0.4*sc.Sz[0] - 0.9*sc.Sz[1] + 0.2*sc.Sz[2])
+    sc.set_hamiltonian(h_sc)
+    e_ed = sc.gs_energy(mode="ED")
+
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(labels, itensor_version=3)
+    h_mc = (0.7*mc.SS(0, 1) + 1.3*mc.SS(1, 2)
+            + 0.4*mc.Sz[0] - 0.9*mc.Sz[1] + 0.2*mc.Sz[2])
+    mc.set_hamiltonian(h_mc)
+    e_dmrg = mc.gs_energy(mode="DMRG")
+
+    assert e_dmrg == pytest.approx(e_ed, abs=DMRG_TOL)
+
+
+def test_pure_fermion_degenerate_case_matches_spinful_fermionic_chain_ed():
+    """All-fermion sitesin, non-uniform hopping/on-site terms:
+    Mixed_Spin_Fermion_Chain DMRG (v3) must agree with
+    fermionchain.Spinful_Fermionic_Chain's own ED backend."""
+    n = 3
+
+    fc = fermionchain.Spinful_Fermionic_Chain(n)
+    h_fc = 0
+    for i in range(n-1):
+        t = 0.6 + 0.3*i
+        h_fc = h_fc + t*(fc.Cdagup[i]*fc.Cup[i+1] + fc.Cdagdn[i]*fc.Cdn[i+1])
+    h_fc = h_fc + h_fc.get_dagger()
+    for i in range(n):
+        h_fc = h_fc + (0.2*i - 0.1)*fc.Ntot[i]
+    fc.set_hamiltonian(h_fc)
+    e_ed = fc.gs_energy(mode="ED")
+
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(["F"]*n, itensor_version=3)
+    mc.maxm = 60
+    mc.nsweeps = 20
+    h_mc = 0
+    for i in range(n-1):
+        t = 0.6 + 0.3*i
+        h_mc = h_mc + t*(mc.Cdagup[i]*mc.Cup[i+1] + mc.Cdagdn[i]*mc.Cdn[i+1])
+    h_mc = h_mc + h_mc.get_dagger()
+    for i in range(n):
+        h_mc = h_mc + (0.2*i - 0.1)*mc.Ntot[i]
+    mc.set_hamiltonian(h_mc)
+    e_dmrg = mc.gs_energy(mode="DMRG")
+
+    assert e_dmrg == pytest.approx(e_ed, abs=DMRG_TOL)
+
+
+# ---------------------------------------------------------------------
+# Genuine mixed chain, cross-checked against the dense JW reference
+# ---------------------------------------------------------------------
+
+# Kondo-like model parameters shared by _build_kondo_mc() and
+# _build_kondo_reference(), so the two Hamiltonians they build can never
+# silently drift apart. `hf` is a small longitudinal field breaking the
+# model's full SU(2) spin-rotation symmetry -- the ground state is
+# otherwise part of a degenerate spin multiplet, so individual per-site
+# Sz expectation values (unlike the energy or the SU(2)-invariant Ntot)
+# would depend on which arbitrary member of the multiplet DMRG/eigh
+# happens to converge to, making them impossible to cross-check
+# reproducibly.
+KONDO_PARAMS = dict(K1=0.5, K2=0.35, t=0.4, muA=0.15, muB=-0.2, hf=0.13)
+
+
+def _build_kondo_reference(nsites, fermionic_mask, spin_pos, fermA, fermB):
+    """Dense reference Hamiltonian/observables for the fermion-spin-fermion
+    Kondo-like model used below. `fermA`=(up,dn) physical indices of the
+    first fermion location, `fermB`=(up,dn) of the second, `spin_pos` the
+    physical index of the spin location in between."""
+    C, Cdag, N = fermion_ops(fermionic_mask)
+    Sx_s = embed(SX, spin_pos, nsites)
+    Sy_s = embed(SY, spin_pos, nsites)
+    Sz_s = embed(SZ, spin_pos, nsites)
+
+    def ferm_spin_ops(up, dn):
+        sx = 0.5*(Cdag[up]@C[dn]) + 0.5*(Cdag[dn]@C[up])
+        sy = -0.5j*(Cdag[up]@C[dn]) + 0.5j*(Cdag[dn]@C[up])
+        sz = 0.5*N[up] - 0.5*N[dn]
+        ntot = N[up] + N[dn]
+        return sx, sy, sz, ntot
+
+    sxA, syA, szA, ntotA = ferm_spin_ops(*fermA)
+    sxB, syB, szB, ntotB = ferm_spin_ops(*fermB)
+
+    p = KONDO_PARAMS
+    H = (p["K1"]*(sxA@Sx_s + syA@Sy_s + szA@Sz_s)
+         + p["K2"]*(Sx_s@sxB + Sy_s@syB + Sz_s@szB)
+         + p["muA"]*ntotA + p["muB"]*ntotB
+         + p["hf"]*(szA + Sz_s + szB))
+    hop = p["t"]*(Cdag[fermA[0]]@C[fermB[0]] + Cdag[fermA[1]]@C[fermB[1]])
+    H = H + hop + hop.conj().T
+
+    observables = {"Sz_spin": Sz_s, "Ntot_A": ntotA, "Ntot_B": ntotB}
+    return H, observables
+
+
+def _build_kondo_mc(mc):
+    """Same Kondo-like model, built with Mixed_Spin_Fermion_Chain's own
+    operator lists (logical locations 0="F", 1="1/2", 2="F"), from the
+    same KONDO_PARAMS as _build_kondo_reference()."""
+    p = KONDO_PARAMS
+    h = (p["K1"]*mc.SS(0, 1) + p["K2"]*mc.SS(1, 2)
+            + p["muA"]*mc.Ntot[0] + p["muB"]*mc.Ntot[2])
+    hop = p["t"]*(mc.Cdagup[0]*mc.Cup[2] + mc.Cdagdn[0]*mc.Cdn[2])
+    h = h + hop + hop.get_dagger()
+    h = h + p["hf"]*(mc.Sz[0] + mc.Sz[1] + mc.Sz[2])
+    return h
+
+
+def test_mixed_chain_kondo_energy_and_vev_vs_dense_jw_reference():
+    """fermion-spin-fermion chain (['F','1/2','F']): the hopping term
+    between the two fermion locations has the spin location physically
+    in between, so its Jordan-Wigner string must correctly pass through
+    (no sign, since a spin site carries no fermionic parity) -- this is
+    exactly the case flagged in mixedchain.py's docstring as relying on
+    ITensor v3's "F"-at-non-fermionic-site fallback."""
+    labels = ["F", "1/2", "F"]
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(labels, itensor_version=3)
+    mc.maxm = 60
+    mc.nsweeps = 20
+    assert mc.sites == [0, 0, 2, 0, 0]
+    assert mc.phys_index == [(0, 1), 2, (3, 4)]
+
+    h_mc = _build_kondo_mc(mc)
+    mc.set_hamiltonian(h_mc)
+    e_dmrg = mc.gs_energy(mode="DMRG")
+    sz_dmrg = mc.vev(mc.Sz[1]).real
+    ntot_dmrg = mc.vev(mc.Ntot[0]).real
+
+    fermionic_mask = [True, True, False, True, True]
+    H_ref, obs = _build_kondo_reference(5, fermionic_mask, spin_pos=2,
+            fermA=(0, 1), fermB=(3, 4))
+    e_ref, gs = _gs(H_ref)
+    sz_ref = np.vdot(gs, obs["Sz_spin"] @ gs).real
+    ntot_ref = np.vdot(gs, obs["Ntot_A"] @ gs).real
+
+    assert e_dmrg == pytest.approx(e_ref, abs=DMRG_TOL)
+    assert sz_dmrg == pytest.approx(sz_ref, abs=1e-4)
+    assert ntot_dmrg == pytest.approx(ntot_ref, abs=1e-4)
+
+
+def test_mixed_chain_kondo_v3_vs_python_backend():
+    """Same Kondo-like model, cross-checked between the ITensor v3 C++
+    backend and the pure-Python pyitensor backend -- both already
+    support heterogeneous per-site type lists (see mixedchain.py)."""
+    labels = ["F", "1/2", "F"]
+
+    mc3 = mixedchain.Mixed_Spin_Fermion_Chain(labels, itensor_version=3)
+    mc3.maxm = 60
+    mc3.nsweeps = 20
+    mc3.set_hamiltonian(_build_kondo_mc(mc3))
+    e3 = mc3.gs_energy(mode="DMRG")
+
+    mcp = mixedchain.Mixed_Spin_Fermion_Chain(labels, itensor_version="python")
+    mcp.maxm = 60
+    mcp.nsweeps = 20
+    mcp.set_hamiltonian(_build_kondo_mc(mcp))
+    ep = mcp.gs_energy(mode="DMRG")
+
+    assert e3 == pytest.approx(ep, abs=DMRG_TOL)
+
+
+# ---------------------------------------------------------------------
+# Robustness: itensor_version=2 guard, ED-not-implemented, masked-zero
+# operators, and the shared generate_bilinear() indexing fix
+# ---------------------------------------------------------------------
+
+def test_itensor_version_2_rejected_at_construction():
+    """itensor_version=2 has no fallback for a Jordan-Wigner string that
+    crosses a spin site and hard-aborts the whole process; the
+    constructor must reject it with a clean Python exception instead."""
+    with pytest.raises(ValueError):
+        mixedchain.Mixed_Spin_Fermion_Chain(["F", "1/2", "F"], itensor_version=2)
+
+
+def test_itensor_version_2_rejected_by_setup_cpp():
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(["F", "1/2", "F"], itensor_version=3)
+    with pytest.raises(ValueError):
+        mc.setup_cpp(2)
+
+
+def test_get_ED_obj_raises_clear_error():
+    """No ED backend exists yet for a mixed Hilbert space; gs_energy/vev
+    with mode="ED" (or the automatic itensor_version==3, ns<3 fallback in
+    mode.py) must fail with a clear NotImplementedError, not an
+    AttributeError several call frames away."""
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(["F", "1/2", "F"], itensor_version=3)
+    with pytest.raises(NotImplementedError):
+        mc.get_ED_obj()
+
+    small = mixedchain.Mixed_Spin_Fermion_Chain(["F"], itensor_version=3)
+    assert small.ns < 3 # triggers mode.py's automatic DMRG->ED fallback
+    small.set_hamiltonian(0.3*small.Ntot[0])
+    with pytest.raises(NotImplementedError):
+        small.gs_energy(mode="DMRG")
+
+
+def test_masked_operators_are_multioperators_not_plain_zero():
+    """Fermion-only operators at spin locations must be real (zero)
+    MultiOperator instances, not the literal Python int 0: multiplying
+    two such masked entries (e.g. both operands at spin locations) used
+    to degrade to a plain int (0*0==0), breaking any later
+    MultiOperator-only method call."""
+    # 3 spin locations (ns=3) so the chain is large enough to avoid
+    # mode.py's separate itensor_version==3/ns<3 automatic ED fallback
+    # (see test_get_ED_obj_raises_clear_error) and isolate this bug.
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(["1/2", "1/2", "1/2"], itensor_version=3)
+    term = mc.Cdagup[0]*mc.Cup[1] # both operands are masked (spin locations)
+    dagger = term.get_dagger() # must not raise AttributeError
+    mc.set_hamiltonian(mc.SS(0, 1) + term + dagger)
+    e = mc.gs_energy(mode="DMRG") # the masked term contributes nothing
+    e_ss_only = pytest.approx(-0.75, abs=DMRG_TOL) # Heisenberg dimer singlet, site 2 decoupled
+    assert e == e_ss_only
+
+
+def test_vev_on_masked_operator_returns_zero():
+    """vev() on a masked (fermion-only) operator at a spin location must
+    cleanly return 0.0 instead of raising a confusing RuntimeError from
+    obj2MO silently dropping the requested MultiOperator name."""
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(["1/2", "F"], itensor_version=3)
+    mc.set_hamiltonian(mc.SS(0, 1))
+    mc.gs_energy(mode="DMRG")
+    assert mc.vev(mc.Ntot[0]) == pytest.approx(0.0, abs=1e-10) # location 0 is spin
+
+
+def test_generate_bilinear_works_on_logical_location_lists():
+    """generate_bilinear() used to index unconditionally up to self.ns
+    (physical sites), crashing with IndexError whenever the operator
+    lists passed in are shorter (logical-location-indexed, as for any
+    chain with a fermion location)."""
+    mc = mixedchain.Mixed_Spin_Fermion_Chain(["F", "1/2", "F"], itensor_version=3)
+    assert len(mc.Sx) < mc.ns
+    h = mc.generate_bilinear(lambda i, j: 1.0 if i == j else 0.0, mc.Sx, mc.Sx)
+    assert h is not None


### PR DESCRIPTION
Adds mixedchain.Mixed_Spin_Fermion_Chain, letting a single MPS chain mix genuine spin sites and spinful-fermion locations (paired spinless-fermion up/down sites, like Spinful_Fermionic_Chain) -- e.g. for Kondo-lattice models with a literal local moment next to a conduction-electron site, rather than the large-U two-fermion-site trick. Supported on itensor_version=3 and "python" for now (v2 lacks the Jordan-Wigner "F"-at-non-fermionic-site fallback this relies on, and is rejected at construction).

Also fixes several correctness bugs surfaced during review, mostly in shared infrastructure this new class exercises for the first time:
- generate_bilinear() indexed by self.ns instead of the operator list's own length, crashing for any chain whose per-site lists are indexed by logical location rather than physical site (also affects the pre-existing Spinful_Fermionic_Chain).
- obj2MO()'s bare-number branch silently dropped the requested MultiOperator name, breaking vev() on a zero-valued operator.
- reduced_dm_projective's bare `raise` fallbacks produced a confusing "No active exception to reraise" instead of a clear NotImplementedError.
- Mixed_Spin_Fermion_Chain's masked ("not applicable here") operators are now real zero MultiOperators instead of the literal int 0, so multiplying two masked entries no longer degrades to a plain int.
- get_ED_obj() now raises a clear NotImplementedError instead of being missing entirely, since mode.py can silently route small chains to ED.


Claude-Session: https://claude.ai/code/session_012dnq8GKFEXthmpF5P38Z8X