### PR TITLE
Migrate the Julia backend to juliacall and bring it to feature parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@ __pycache__
 *.a
 setup.py
 julia*
+# the pattern above is meant for locally-downloaded Julia binaries (e.g.
+# the old install_julia.py's src/julia/ tarball extraction target), but
+# being unanchored it also matches legitimate source files anywhere in
+# the tree whose name happens to start with "julia" -- un-ignore those
+!src/dmrgpy/juliapkg.json
+!src/dmrgpy/mpsjulialive/juliasession.py
 .mpsfolder
 ERROR
 maxenttk

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -522,6 +522,36 @@ for parity but not actually functional on *any* backend right now —
 `itensor_version` — a pre-existing, cross-backend gap, not something
 introduced or left broken by this work.
 
+The fermionic 4-point correlator tensor (`MPS.get_four_correlation_tensor`,
+`<Cdag_i C_j Cdag_k C_l>`) was missing the same way bond entropy was — no
+`get_four_correlation_tensor` method at all on `mpsjulialive/mps.py`'s
+`MPS` class — and needed the same fix: just add the method, delegating
+to `entropytk/correlationentropy.py`'s default `ctmode="explicit"` (a
+Python loop of `MultiOperator` products + `.aMb()`/`.dot()`, already
+generic; `ctmode="full"`, a native per-element AutoMPO build, mirrors
+`pyitensor/chain.py`'s own `four_correlation_tensor` but isn't ported to
+Julia). Validated directly against ED on the same well-gapped free-fermion
+model `tests/test_four_point_correlator.py` uses (agreement to `~2e-15`).
+
+Investigated whether `get_correlation_matrix`'s default `dmmode="fast"`
+(`entropytk/correlationentropy.py::correlation_matrix_fast`, `n` MPO
+applications total rather than `explicit`'s `n(n+1)/2` two-operator
+products) could also work on `julia_live` — `mpsjulialive/mps.py`'s
+`get_correlation_entropy`/`get_correlation_entropy_density` already
+force `dmmode="explicit"`, and this turned out to be necessary, not an
+arbitrary choice: `dmmode="fast"` builds an MPO for a single bare
+fermionic operator (`Cdag[i]`, odd particle-number parity) before
+combining it with another, and `ITensorMPS.jl`'s OpSum-to-MPO compiler
+rejects that outright ("Parity-odd fermionic terms not yet supported by
+OpSum to MPO conversion", confirmed directly) — `explicit` avoids the
+problem by always building the two-operator *product* (`Cdag_i C_j`,
+even parity) before ever converting to an MPO. Not pursued further: it's
+a real `ITensorMPS.jl` limitation, not a bug on this side, and
+`explicit` is already fast in absolute terms (0.29s for a 10-site
+chain's full correlation matrix) — a from-scratch fermionic-JW-string
+MPO builder to work around it would be a disproportionate amount of new
+code for a performance-only win on an already-cheap operation.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -502,6 +502,26 @@ same golden test `tests/test_dynamical_correlator.py` uses for the other
 backends: peak within `0.03` of the exact 4-site Heisenberg gap
 (`0.658919`) — landed at `0.68`.
 
+The last two dynamical-correlator submodes needed no new Julia code at
+all, only dispatch routing: `dcex.py` (submode `"EX"`, correlator via
+exact diagonalization in the excited-state subspace) only calls
+`self.get_excited_states()` (already backend-agnostic, see above) and
+generic `MultiOperator`/MPS algebra (`.dot()`, `A*wf`) before dropping
+into plain NumPy/SciPy (`eigh`); `distribution.py`'s maxent path
+(submode `"maxent"`) is built the same way on top of
+`vev.py::power_vev`. Validated `"EX"` the same way
+`tests/test_dynamical_correlator.py` already does for the other
+backends — cross-checked directly against `"KPM"` and `"CVM"` on the
+same chain/operator/frequency grid, landing on the exact same peak
+(diff `0.0`) rather than just the analytic gap. `"maxent"` is wired up
+for parity but not actually functional on *any* backend right now —
+`distribution.py::get_distribution_maxent` imports
+`dmrgpy.maxenttk.pymaxent`, which doesn't exist in this checkout
+(confirmed directly: `ModuleNotFoundError`), so it hits the same
+`except: print("Not functional yet"); exit()` regardless of
+`itensor_version` — a pre-existing, cross-backend gap, not something
+introduced or left broken by this work.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -402,6 +402,27 @@ Both paths were validated directly against exact diagonalization
 ED to ~8e-7 on a 4-site chain, and `evolution_DC`'s quench correlator
 agreed to ~9e-11 on a 6-site chain.
 
+Excited states (`get_excited_states`/`get_excited`, `n>1`, Hermitian) and
+the single-site reduced density matrix (`get_rdm`) are implemented the
+same way: `mpsjulialive/excited.jl`'s `excited_states_dmrg` runs the
+whole *n*-state loop in one Julia call (one new random-start warm state
+per additional excited state, deflated against every wavefunction found
+so far via `ITensorMPS.jl`'s own orthogonality-penalty
+`dmrg(H, wfs, psi0, sweeps; weight)`, mirroring
+`mpscpp3/chain_session.h`'s `Chain::excited_states` and
+`pyitensor/chain.py`'s `excited_states`); `mpsjulialive/densitymatrix.jl`'s
+`reduced_dm` is a direct Julia port of `pyitensor/chain.py`'s
+`reduced_dm` (itself a port of `Chain::reduced_dm`), including its
+"divide by the norm squared, not its square root" quirk, preserved for
+cross-backend consistency (in practice a no-op, since the ground state
+is essentially always already unit-norm). Validated directly: excited
+energies match the golden regression values in
+`tests/test_excited_states.py` to ~3e-15 on a 4-site chain, and
+`get_rdm` matches the existing backend-agnostic `reduced_dm_projective`
+to ~1e-15. `n==1` and non-Hermitian excited states already worked before
+this — they route through `gs_energy()`/the generic Arnoldi method
+(`mpsalgebra.mpsarnoldi`), neither of which is backend-specific.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -180,7 +180,7 @@ between the two solver families.
 | `2` | ITensor v2, in-process C++ (`mpscpp2`) | compiled pybind11 extension | ED |
 | `3` (default) | ITensor v3, in-process C++ (`mpscpp3`) | compiled pybind11 extension | ED |
 | `"python"` | pure-Python `pyitensor/` | NumPy/SciPy only | none |
-| `"julia_live"` | live in-process Julia session (`mpsjulialive/`), ITensors.jl | `pyjulia` + Julia install | none (feature-by-feature; missing methods simply aren't implemented) |
+| `"julia_live"` | live in-process Julia session (`mpsjulialive/`), ITensors.jl | `juliacall`/PythonCall.jl (self-provisions Julia) | none (feature-by-feature; missing methods simply aren't implemented) |
 
 Regardless of `itensor_version`, if `self.mode` is forced to `"ED"`, or
 the requested backend isn't available, calculations run through
@@ -322,11 +322,47 @@ block-sparsity, no JIT) — see §5 for how much slower in practice, and how
 ### 4.6 The Julia backend (`mpsjulialive/`)
 
 `itensor_version="julia_live"` drives a live, in-process Julia session
-(via `pyjulia`) with its own set of modules mirroring the top-level ones
-(`mpsjulialive/groundstate.py`, `vev.py`, `mps.py`, `mpo.py`, ...) that
-talk to Julia's ITensors.jl instead of the C++ pybind11 extension. This
-is an independent implementation, not a shared protocol with the C++
-path — a feature missing on one side simply isn't implemented there yet.
+(via [`juliacall`/PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl),
+`mpsjulialive/juliasession.py`) with its own set of modules mirroring the
+top-level ones (`mpsjulialive/groundstate.py`, `vev.py`, `mps.py`,
+`mpo.py`, `dynamics.py`, ...) that talk to Julia's ITensors.jl instead of
+the C++ pybind11 extension. This is an independent implementation, not a
+shared protocol with the C++ path — a feature missing on one side simply
+isn't implemented there yet.
+
+`juliacall` replaced an earlier PyJulia-based bridge: PyJulia requires the
+Julia build's PyCall to be linked against a matching libpython (the same
+class of ABI landmine documented in §2 for the C++ extension) and needs a
+`compiled_modules=False` workaround for slow/broken precompilation.
+`juliacall` avoids both, and self-provisions Julia plus the required
+packages (`ITensors`, `ITensorMPS`, `ITensorNHDMRG`, pinned in
+`src/dmrgpy/juliapkg.json`) into its own managed project the first time
+`mpsjulialive` is imported — no manual Julia download step. One porting
+detail worth knowing: unlike PyJulia, `juliacall` does *not* implicitly
+convert a Python `list` of `str` into a Julia `Vector{String}` (it wraps
+it as a lazy `PyList{Any}`, which fails to dispatch against
+strictly-typed Julia functions like `sites.jl`'s `get_sites`); every call
+site that used to rely on that now goes through
+`juliasession.to_julia_strvec()`, which forces the conversion explicitly
+via `juliacall.convert`.
+
+The KPM dynamical correlator's Chebyshev-moment recursion runs natively
+in Julia (`mpsjulialive/kpm.jl`'s `kpm_moments_full`/
+`kpm_moments_accelerated`, driven through `mpsalgebra.jl`'s own
+`applyoperator`/`summps`), one call per correlator rather than one
+Python↔Julia round trip per Chebyshev step. `mpsjulialive/dynamics.py`
+only builds the scaled-Hamiltonian MPO and the two seed wavefunctions in
+Python (mirroring `pyitensor/chain.py`'s own pure-Python KPM algorithm,
+since `julia_live` has no single `Chain` session object comparable to
+`self._session` on the C++/pure-Python backends for `kpmdmrg.py` to
+dispatch to directly), then hands the whole moment loop to Julia in one
+call. Measured directly on a 30-site Heisenberg chain: eliminating the
+per-step round trip only closed part of the gap to the compiled ITensor
+v3 backend (v3: 23.4s, Julia native loop warm: 34.0s, vs. 37.7s for the
+earlier per-step Python loop) — most of the remaining time is genuine
+Julia-side tensor-contraction/truncation cost (`alg="densitymatrix"`
+SVD-based `add`/`contract`), not Python↔Julia marshaling overhead.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -423,6 +423,23 @@ to ~1e-15. `n==1` and non-Hermitian excited states already worked before
 this — they route through `gs_energy()`/the generic Arnoldi method
 (`mpsalgebra.mpsarnoldi`), neither of which is backend-specific.
 
+Bond entanglement entropy (`MPS.get_bond_entropy`, used e.g. by
+`entropy.py`'s `central_charge`) was missing entirely on the Julia
+backend (`mpsjulialive/mps.py`'s `MPS` class had no `get_bond_entropy`/
+`get_site_entropy` methods at all — a plain `AttributeError`, not a
+crash inside a dispatch branch). `mpsjulialive/entropy.jl`'s
+`bond_entropy` computes it the standard MPS way, via SVD of the two-site
+tensor at that bond (mirrors `pyitensor/chain.py`'s `bond_entropy`,
+itself a port of `Chain::bond_entropy`) — much cheaper than the generic
+`get_correlation_entropy`/`"explicit"`-dmmode fallback the Julia backend
+already had (still the only option for multi-site correlation entropy,
+just not for a single bond). Validated directly: a 2-site Heisenberg
+singlet gives exactly ln 2 (the analytically known Bell-pair
+entanglement), and on a 6-site chain the bond entropy at the first bond
+exactly matches the existing generic `get_site_entropy` (which computes
+the same quantity a completely different way, through
+`reduced_dm_projective`).
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -440,6 +440,40 @@ exactly matches the existing generic `get_site_entropy` (which computes
 the same quantity a completely different way, through
 `reduced_dm_projective`).
 
+The CVM dynamical-correlator submode (`get_dynamical_correlator(...,
+submode="CVM")`, `cvm.py`) needed almost no Julia-specific code at all:
+its correction-vector CG solve (`cvm.py::cvm_correction_vector`) is
+already implemented purely with backend-agnostic MPS/MPO algebra
+(`self.toMPO()`, MPS `+`/`-`/scalar-`*`, `.dot()`), which already works
+against `julia_live`'s `mpsjulialive.mpo.MPO`/`mpsjulialive.mps.MPS`
+classes without any changes. The only thing standing in the way was that
+`cvm.py` unconditionally called `self._session.set_sweep_params(...)` to
+point every MPO application at `cvm_maxm` rather than the DMRG `maxm`
+(no `_session` object exists for `julia_live` to call this on);
+`cvm.py::_set_cvm_sweep_params` now temporarily overrides `self.maxm`
+instead for that backend, since that's what
+`mpsjulialive/mpo.py`/`mps.py` actually read. Validated against ED with
+the same tolerance `examples/dynamical_correlator_VS_ED/main.py` uses
+for the C++/pure-Python backends (`1e-6`) — matched to `~2e-15` here, in
+3 CG iterations per frequency point.
+
+Wiring this up surfaced a real bug in
+`mpsjulialive/dynamics.py::get_dynamical_correlator`: its first version
+declared `name=`/`delta=`/`es=` as its own named parameters (with
+KPM-flavored defaults) purely so it could compute the KPM moments
+directly in the same function, which silently captured a caller's
+`es=`/`name=`/`delta=` kwargs out of `**kwargs` before they could reach
+`cvm.dynamical_correlator` — confirmed directly, `submode="CVM"` ran on
+a completely different, wrong frequency grid as a result (CVM's own
+`np.linspace(0.,10.0,100)` default instead of the caller's requested
+window). Fixed by splitting the KPM implementation out into its own
+`_kpm_dynamical_correlator` and making the public
+`get_dynamical_correlator(self,submode="KPM",**kwargs)` take no named
+parameters of its own — mirroring the top-level
+`dynamics.py::get_dynamical_correlator`'s own signature, which was never
+vulnerable to this because it never declared submode-specific parameters
+either.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -363,6 +363,45 @@ earlier per-step Python loop) — most of the remaining time is genuine
 Julia-side tensor-contraction/truncation cost (`alg="densitymatrix"`
 SVD-based `add`/`contract`), not Python↔Julia marshaling overhead.
 
+Real-time TDVP evolution (`timedependent.py`'s `evolve_and_measure_dmrg`/
+`evolution_dmrg_DC`, submode `"TD"`) is implemented the same way —
+`mpsjulialive/tdvp.jl`'s `evolve_and_measure_tdvp`/`quench_tdvp` run the
+whole nt-step trajectory in one Julia call, driving `ITensorMPS.jl`'s own
+`tdvp()` (already exported by the `ITensorMPS` dependency; no separate
+`ITensorTDVP.jl` package needed). One real-time step is `exp(-i·dt·H)`,
+i.e. `tdvp()`'s complex evolution parameter is `-im*dt`. Two real,
+non-obvious `ITensorMPS`/`ITensors` bugs had to be worked around to get
+this correct, both confirmed by direct inspection of the intermediate
+tensors' index structure rather than guessed at from the stack trace
+alone:
+
+- `mpsalgebra.jl`'s `applyoperator()` (`contract(A,psi)` plus a
+  second contraction against an identity MPO, "this fixes a bug" — a
+  *Site*-index priming issue) leaves the *Link* indices of its result
+  carrying a stale nonzero prime level. This is invisible to KPM (which
+  only ever feeds `applyoperator()`'s output back into more
+  `applyoperator`/`summps`/`inner` calls), but `tdvp()`'s internal
+  environment bookkeeping (`ProjMPO`) cannot handle it: it aborts deep
+  inside `KrylovKit.expintegrator` with "... but the indices are not
+  permutations of each other" on the affected Link index. `tdvp.jl`'s
+  `apply_clean()` uses `ITensorMPS`'s higher-level `apply()` instead
+  (`contract()` is the lower-level primitive both `applyoperator()` and
+  `apply()` are built on, but only `apply()` avoids the stale prime).
+- Whenever `tdvp()`'s input MPS did not come straight from `dmrg()`
+  (e.g. `evolution_ABA()` first applies an operator via
+  `mpsjulialive/mpo.py`'s `MPO.__mul__`, which still goes through
+  `applyoperator()` for other callers' sake), the same stale Link prime
+  reappears — and, confirmed directly, `orthogonalize!()` alone does
+  *not* clear it. `evolve_and_measure_tdvp()` therefore explicitly
+  `noprime(copy(wf),"Link")`s (never mutating the caller's own MPS) before
+  `orthogonalize!()`-ing and starting the TDVP loop.
+
+Both paths were validated directly against exact diagonalization
+(quench from a Néel-favoring field to a Heisenberg chain, mirroring
+`examples/tdvp_VS_ED_time_evolution`): `evolve_and_measure` agreed with
+ED to ~8e-7 on a 4-site chain, and `evolution_DC`'s quench correlator
+agreed to ~9e-11 on a 6-site chain.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -552,6 +552,44 @@ chain's full correlation matrix) — a from-scratch fermionic-JW-string
 MPO builder to work around it would be a disproportionate amount of new
 code for a performance-only win on an already-cheap operation.
 
+A final sweep of every remaining `self._session.` call site reachable
+from `julia_live` (`grep -rl "self\._session\." *.py`, checked against
+what each call site's own top-level dispatcher actually routes for that
+`itensor_version`) turned up two more real gaps, deliberately left
+unfixed rather than pursued further, since both fall outside the
+"already-generic code, just needs a dispatch branch or a small native
+Julia primitive" pattern every fix above followed:
+
+- **`vev.py`'s `npow=` kwarg** (`sc.vev(op, npow=2)`, computes
+  `<X^2>`/`<X^n>` via repeated MPO application instead of building the
+  `O(n^2)`-term squared operator directly) — `mpsjulialive/vev.py`'s
+  `vev(MBO,MO)` takes no `**kwargs` at all, so this raises a plain
+  `TypeError` for `julia_live` rather than silently misbehaving. The one
+  example exercising it, `examples/power_vev/main.py`, sets
+  `sc.itensor_version = "julia"` directly (bypassing
+  `setup_julia()`/`_reset_dmrg_state()` entirely) — the legacy,
+  already-inert subprocess-based backend documented below, not
+  `julia_live` — so it wouldn't validate this fix even if made.
+- **`get_distribution`/`kpmdmrg.py::general_kpm`** (spectral distribution
+  of an arbitrary operator, not just the Hamiltonian; has example
+  coverage in four `examples/magnetization_distribution*` scripts and
+  `examples/dynamical_correlator/dynamical_correlator_shift`, but no
+  `pytest` coverage) — unlike everything above, this is not a
+  wire-up-already-generic-code fix: `kpmdmrg.py::general_kpm_moments`
+  depends on `scale_operator()`, which calls `self.lowest_eigenvalue()`/
+  `self.bandwidth()` (`manybodychain.py`), both of which route through
+  `self.clone()` → `deepcopy(self)` — and `julia_live`'s live Julia
+  session handles (`self.jlsites`, every `MPS.jlmps`/`MPO.jlmpo`) are not
+  established to be deepcopy-safe (this is exactly why
+  `dynamics.py::_max_energy_bound`/`excited.py`'s energy-bound helpers
+  were written as their own mutate-and-restore functions instead of
+  calling `bandwidth()`/`lowest_eigenvalue()` directly, see their
+  docstrings). Doing this properly means generalizing that same
+  mutate-and-restore pattern from "the Hamiltonian, negated" to "an
+  arbitrary caller-supplied operator" — real, but new design work rather
+  than a small addition, so left as a documented follow-up rather than
+  implemented here.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -474,6 +474,34 @@ parameters of its own — mirroring the top-level
 vulnerable to this because it never declared submode-specific parameters
 either.
 
+The TDZ dynamical-correlator submode (complex-time evolution +
+perturbative real-axis reconstruction, `tdz.py`, arXiv:2311.10909) needed
+only one new backend primitive, same as CVM: the whole algorithm is
+otherwise generic MPS/MPO algebra (`self.toMPO()`, `.dot()`) already
+working on `julia_live`. That one primitive is a single complex-time-step
+propagator (`tdz.py::_advance_complex_time_step`, formerly gated to
+`itensor_version in (3,"python")`) — `mpsjulialive/tdvp.jl`'s `tdvp_step`
+already generalizes to it with **no changes**, since `-im*dz` is exactly
+the right formula whether `dz` is real (the `evolve_and_measure_tdvp`/
+`quench_tdvp` case) or genuinely complex (TDZ's per-step contour
+increment); only a thin Python wrapper
+(`mpsjulialive/timedependent.py::advance_complex_time_step`) was needed.
+
+Wiring TDZ up caught a second occurrence of the same stale-Link-prime bug
+documented above for TDVP: `tdz.py`'s first evolved state,
+`self.toMPO(A)*wf_g`, goes through the same `applyoperator()` path
+`evolution_ABA()` does, and `tdvp_step` had only been sanitized against
+that inside `evolve_and_measure_tdvp`'s own wrapper loop, not inside
+`tdvp_step` itself — so any *other* direct caller (TDZ's driver loop in
+`_complex_time_correlator`) hit the identical failure. Fixed by moving
+the `noprime(copy(psi),"Link")` + `orthogonalize!()` sanitization into
+`tdvp_step` itself, so it runs on every step regardless of caller,
+instead of relying on each call site to remember to pre-clean its input
+— a small, one-time cost next to the sweep itself. Validated against the
+same golden test `tests/test_dynamical_correlator.py` uses for the other
+backends: peak within `0.03` of the exact 4-site Heisenberg gap
+(`0.658919`) — landed at `0.68`.
+
 (A separate, older subprocess-based Julia path, `itensor_version="julia"`
 via `juliarun.py`, is not reachable through the normal public API and
 should be treated as legacy/inert.)

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -646,6 +646,43 @@ the same \texttt{except: print("Not functional yet"); exit()} regardless
 of \texttt{itensor\_version} --- a pre-existing, cross-backend gap, not
 something introduced or left broken by this work.
 
+The fermionic 4-point correlator tensor
+(\texttt{MPS.get\_four\_correlation\_tensor}, $\langle
+C^\dagger_i C_j C^\dagger_k C_l \rangle$) was missing the same way bond
+entropy was --- no \texttt{get\_four\_correlation\_tensor} method at all
+on \texttt{mpsjulialive/mps.py}'s \texttt{MPS} class --- and needed the
+same fix: just add the method, delegating to
+\texttt{entropytk/correlationentropy.py}'s default
+\texttt{ctmode="explicit"} (a Python loop of \texttt{MultiOperator}
+products + \texttt{.aMb()}/\texttt{.dot()}, already generic;
+\texttt{ctmode="full"}, a native per-element AutoMPO build, mirrors
+\texttt{pyitensor/chain.py}'s own \texttt{four\_correlation\_tensor} but
+isn't ported to Julia). Validated directly against ED on the same
+well-gapped free-fermion model \texttt{tests/test\_four\_point\_correlator.py}
+uses (agreement to $\sim 2 \times 10^{-15}$).
+
+Investigated whether \texttt{get\_correlation\_matrix}'s default
+\texttt{dmmode="fast"}
+(\texttt{entropytk/correlationentropy.py::correlation\_matrix\_fast}, $n$
+MPO applications total rather than \texttt{explicit}'s $n(n+1)/2$
+two-operator products) could also work on \texttt{julia\_live} ---
+\texttt{mpsjulialive/mps.py}'s \texttt{get\_correlation\_entropy}/
+\texttt{get\_correlation\_entropy\_density} already force
+\texttt{dmmode="explicit"}, and this turned out to be necessary, not an
+arbitrary choice: \texttt{dmmode="fast"} builds an MPO for a single bare
+fermionic operator (\texttt{Cdag[i]}, odd particle-number parity) before
+combining it with another, and \texttt{ITensorMPS.jl}'s OpSum-to-MPO
+compiler rejects that outright ("Parity-odd fermionic terms not yet
+supported by OpSum to MPO conversion", confirmed directly) ---
+\texttt{explicit} avoids the problem by always building the two-operator
+\emph{product} ($C^\dagger_i C_j$, even parity) before ever converting
+to an MPO. Not pursued further: it's a real \texttt{ITensorMPS.jl}
+limitation, not a bug on this side, and \texttt{explicit} is already
+fast in absolute terms (0.29s for a 10-site chain's full correlation
+matrix) --- a from-scratch fermionic-JW-string MPO builder to work
+around it would be a disproportionate amount of new code for a
+performance-only win on an already-cheap operation.
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -508,6 +508,31 @@ from a N\'eel-favoring field to a Heisenberg chain, mirroring
 on a 4-site chain, and \texttt{evolution\_DC}'s quench correlator agreed
 to $\sim 9 \times 10^{-11}$ on a 6-site chain.
 
+Excited states (\texttt{get\_excited\_states}/\texttt{get\_excited},
+$n>1$, Hermitian) and the single-site reduced density matrix
+(\texttt{get\_rdm}) are implemented the same way:
+\texttt{mpsjulialive/excited.jl}'s \texttt{excited\_states\_dmrg} runs
+the whole $n$-state loop in one Julia call (one new random-start warm
+state per additional excited state, deflated against every wavefunction
+found so far via \texttt{ITensorMPS.jl}'s own orthogonality-penalty
+\texttt{dmrg(H, wfs, psi0, sweeps; weight)}, mirroring
+\texttt{mpscpp3/chain\_session.h}'s \texttt{Chain::excited\_states} and
+\texttt{pyitensor/chain.py}'s \texttt{excited\_states});
+\texttt{mpsjulialive/densitymatrix.jl}'s \texttt{reduced\_dm} is a
+direct Julia port of \texttt{pyitensor/chain.py}'s \texttt{reduced\_dm}
+(itself a port of \texttt{Chain::reduced\_dm}), including its "divide by
+the norm squared, not its square root" quirk, preserved for
+cross-backend consistency (in practice a no-op, since the ground state
+is essentially always already unit-norm). Validated directly: excited
+energies match the golden regression values in
+\texttt{tests/test\_excited\_states.py} to $\sim 3 \times 10^{-15}$ on a
+4-site chain, and \texttt{get\_rdm} matches the existing
+backend-agnostic \texttt{reduced\_dm\_projective} to
+$\sim 1 \times 10^{-15}$. $n=1$ and non-Hermitian excited states already
+worked before this --- they route through \texttt{gs\_energy()}/the
+generic Arnoldi method (\texttt{mpsalgebra.mpsarnoldi}), neither of
+which is backend-specific.
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -591,6 +591,40 @@ named parameters of its own --- mirroring the top-level
 was never vulnerable to this because it never declared submode-specific
 parameters either.
 
+The TDZ dynamical-correlator submode (complex-time evolution + perturbative
+real-axis reconstruction, \texttt{tdz.py}, arXiv:2311.10909) needed only
+one new backend primitive, same as CVM: the whole algorithm is otherwise
+generic MPS/MPO algebra (\texttt{self.toMPO()}, \texttt{.dot()}) already
+working on \texttt{julia\_live}. That one primitive is a single
+complex-time-step propagator
+(\texttt{tdz.py::\_advance\_complex\_time\_step}, formerly gated to
+\texttt{itensor\_version in (3,"python")}) ---
+\texttt{mpsjulialive/tdvp.jl}'s \texttt{tdvp\_step} already generalizes
+to it with \emph{no changes}, since \texttt{-im*dz} is exactly the right
+formula whether \texttt{dz} is real (the
+\texttt{evolve\_and\_measure\_tdvp}/\texttt{quench\_tdvp} case) or
+genuinely complex (TDZ's per-step contour increment); only a thin Python
+wrapper
+(\texttt{mpsjulialive/timedependent.py::advance\_complex\_time\_step})
+was needed.
+
+Wiring TDZ up caught a second occurrence of the same stale-Link-prime bug
+documented above for TDVP: \texttt{tdz.py}'s first evolved state,
+\texttt{self.toMPO(A)*wf\_g}, goes through the same
+\texttt{applyoperator()} path \texttt{evolution\_ABA()} does, and
+\texttt{tdvp\_step} had only been sanitized against that inside
+\texttt{evolve\_and\_measure\_tdvp}'s own wrapper loop, not inside
+\texttt{tdvp\_step} itself --- so any \emph{other} direct caller (TDZ's
+driver loop in \texttt{\_complex\_time\_correlator}) hit the identical
+failure. Fixed by moving the \texttt{noprime(copy(psi),"Link")} +
+\texttt{orthogonalize!()} sanitization into \texttt{tdvp\_step} itself,
+so it runs on every step regardless of caller, instead of relying on
+each call site to remember to pre-clean its input --- a small, one-time
+cost next to the sweep itself. Validated against the same golden test
+\texttt{tests/test\_dynamical\_correlator.py} uses for the other
+backends: peak within $0.03$ of the exact 4-site Heisenberg gap
+($0.658919$) --- landed at $0.68$.
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -533,6 +533,24 @@ worked before this --- they route through \texttt{gs\_energy()}/the
 generic Arnoldi method (\texttt{mpsalgebra.mpsarnoldi}), neither of
 which is backend-specific.
 
+Bond entanglement entropy (\texttt{MPS.get\_bond\_entropy}, used e.g.\ by
+\texttt{entropy.py}'s \texttt{central\_charge}) was missing entirely on
+the Julia backend (\texttt{mpsjulialive/mps.py}'s \texttt{MPS} class had
+no \texttt{get\_bond\_entropy}/\texttt{get\_site\_entropy} methods at
+all --- a plain \texttt{AttributeError}, not a crash inside a dispatch
+branch). \texttt{mpsjulialive/entropy.jl}'s \texttt{bond\_entropy}
+computes it the standard MPS way, via SVD of the two-site tensor at that
+bond (mirrors \texttt{pyitensor/chain.py}'s \texttt{bond\_entropy},
+itself a port of \texttt{Chain::bond\_entropy}) --- much cheaper than
+the generic \texttt{get\_correlation\_entropy}/\texttt{"explicit"}-dmmode
+fallback the Julia backend already had (still the only option for
+multi-site correlation entropy, just not for a single bond). Validated
+directly: a 2-site Heisenberg singlet gives exactly $\ln 2$ (the
+analytically known Bell-pair entanglement), and on a 6-site chain the
+bond entropy at the first bond exactly matches the existing generic
+\texttt{get\_site\_entropy} (which computes the same quantity a
+completely different way, through \texttt{reduced\_dm\_projective}).
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -65,6 +65,7 @@ work to whichever solver is requested or available:
 \end{itemize}
 
 \section{Installation}
+\label{sec:install}
 
 There is no \texttt{setup.py}/\texttt{pyproject.toml}; DMRGPY is used
 directly from \texttt{src/}, added to \texttt{PYTHONPATH} (or symlinked
@@ -411,13 +412,54 @@ slower in practice, and how \texttt{numba}/\texttt{jax} narrow that gap.
 \subsection{The Julia backend (\texttt{mpsjulialive/})}
 
 \texttt{itensor\_version="julia\_live"} drives a live, in-process Julia
-session (via \texttt{pyjulia}) with its own set of modules mirroring the
-top-level ones (\texttt{mpsjulialive/groundstate.py}, \texttt{vev.py},
-\texttt{mps.py}, \texttt{mpo.py}, \ldots) that talk to Julia's
-ITensors.jl instead of the C++ pybind11 extension. This is an
-independent implementation, not a shared protocol with the C++ path --- a
-feature missing on one side simply isn't implemented there yet. (A
-separate, older subprocess-based Julia path,
+session (via
+\href{https://github.com/JuliaPy/PythonCall.jl}{\texttt{juliacall}/PythonCall.jl},
+\texttt{mpsjulialive/juliasession.py}) with its own set of modules
+mirroring the top-level ones (\texttt{mpsjulialive/groundstate.py},
+\texttt{vev.py}, \texttt{mps.py}, \texttt{mpo.py}, \texttt{dynamics.py},
+\ldots) that talk to Julia's ITensors.jl instead of the C++ pybind11
+extension. This is an independent implementation, not a shared protocol
+with the C++ path --- a feature missing on one side simply isn't
+implemented there yet.
+
+\texttt{juliacall} replaced an earlier PyJulia-based bridge: PyJulia
+requires the Julia build's PyCall to be linked against a matching
+libpython (the same class of ABI landmine documented in
+Section~\ref{sec:install} for the C++ extension) and needs a
+\texttt{compiled\_modules=False} workaround for slow/broken
+precompilation. \texttt{juliacall} avoids both, and self-provisions Julia
+plus the required packages (\texttt{ITensors}, \texttt{ITensorMPS},
+\texttt{ITensorNHDMRG}, pinned in \texttt{src/dmrgpy/juliapkg.json}) into
+its own managed project the first time \texttt{mpsjulialive} is imported
+--- no manual Julia download step. One porting detail worth knowing:
+unlike PyJulia, \texttt{juliacall} does \emph{not} implicitly convert a
+Python \texttt{list} of \texttt{str} into a Julia \texttt{Vector\{String\}}
+(it wraps it as a lazy \texttt{PyList\{Any\}}, which fails to dispatch
+against strictly-typed Julia functions like \texttt{sites.jl}'s
+\texttt{get\_sites}); every call site that used to rely on that now goes
+through \texttt{juliasession.to\_julia\_strvec()}, which forces the
+conversion explicitly via \texttt{juliacall.convert}.
+
+The KPM dynamical correlator's Chebyshev-moment recursion runs natively
+in Julia (\texttt{mpsjulialive/kpm.jl}'s \texttt{kpm\_moments\_full}/
+\texttt{kpm\_moments\_accelerated}, driven through \texttt{mpsalgebra.jl}'s
+own \texttt{applyoperator}/\texttt{summps}), one call per correlator
+rather than one Python$\leftrightarrow$Julia round trip per Chebyshev
+step. \texttt{mpsjulialive/dynamics.py} only builds the scaled-Hamiltonian
+MPO and the two seed wavefunctions in Python (mirroring
+\texttt{pyitensor/chain.py}'s own pure-Python KPM algorithm, since
+\texttt{julia\_live} has no single \texttt{Chain} session object
+comparable to \texttt{self.\_session} on the C++/pure-Python backends for
+\texttt{kpmdmrg.py} to dispatch to directly), then hands the whole moment
+loop to Julia in one call. Measured directly on a 30-site Heisenberg
+chain: eliminating the per-step round trip only closed part of the gap
+to the compiled ITensor v3 backend (v3: 23.4s, Julia native loop warm:
+34.0s, vs.\ 37.7s for the earlier per-step Python loop) --- most of the
+remaining time is genuine Julia-side tensor-contraction/truncation cost
+(\texttt{alg="densitymatrix"} SVD-based \texttt{add}/\texttt{contract}),
+not Python$\leftrightarrow$Julia marshaling overhead.
+
+(A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as
 legacy/inert.)

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -683,6 +683,53 @@ matrix) --- a from-scratch fermionic-JW-string MPO builder to work
 around it would be a disproportionate amount of new code for a
 performance-only win on an already-cheap operation.
 
+A final sweep of every remaining \texttt{self.\_session} call site
+reachable from \texttt{julia\_live} (grepped across the package, checked
+against what each call site's own top-level dispatcher actually routes
+for that \texttt{itensor\_version}) turned up two more real gaps,
+deliberately left unfixed rather than pursued further, since both fall
+outside the "already-generic code, just needs a dispatch branch or a
+small native Julia primitive" pattern every fix above followed:
+
+\begin{itemize}
+\item \textbf{\texttt{vev.py}'s \texttt{npow=} kwarg}
+  (\texttt{sc.vev(op, npow=2)}, computes $\langle X^2\rangle$/$\langle
+  X^n\rangle$ via repeated MPO application instead of building the
+  $O(n^2)$-term squared operator directly) --- \texttt{mpsjulialive/vev.py}'s
+  \texttt{vev(MBO,MO)} takes no \texttt{**kwargs} at all, so this raises
+  a plain \texttt{TypeError} for \texttt{julia\_live} rather than
+  silently misbehaving. The one example exercising it,
+  \texttt{examples/power\_vev/main.py}, sets
+  \texttt{sc.itensor\_version = "julia"} directly (bypassing
+  \texttt{setup\_julia()}/\texttt{\_reset\_dmrg\_state()} entirely) ---
+  the legacy, already-inert subprocess-based backend documented below,
+  not \texttt{julia\_live} --- so it wouldn't validate this fix even if
+  made.
+\item \textbf{\texttt{get\_distribution}/\texttt{kpmdmrg.py::general\_kpm}}
+  (spectral distribution of an arbitrary operator, not just the
+  Hamiltonian; has example coverage in four
+  \texttt{examples/magnetization\_distribution*} scripts and
+  \texttt{examples/dynamical\_correlator/dynamical\_correlator\_shift},
+  but no \texttt{pytest} coverage) --- unlike everything above, this is
+  not a wire-up-already-generic-code fix:
+  \texttt{kpmdmrg.py::general\_kpm\_moments} depends on
+  \texttt{scale\_operator()}, which calls
+  \texttt{self.lowest\_eigenvalue()}/\texttt{self.bandwidth()}
+  (\texttt{manybodychain.py}), both of which route through
+  \texttt{self.clone()} $\to$ \texttt{deepcopy(self)} --- and
+  \texttt{julia\_live}'s live Julia session handles
+  (\texttt{self.jlsites}, every \texttt{MPS.jlmps}/\texttt{MPO.jlmpo})
+  are not established to be deepcopy-safe (this is exactly why
+  \texttt{dynamics.py::\_max\_energy\_bound}/\texttt{excited.py}'s
+  energy-bound helpers were written as their own mutate-and-restore
+  functions instead of calling \texttt{bandwidth()}/
+  \texttt{lowest\_eigenvalue()} directly, see their docstrings). Doing
+  this properly means generalizing that same mutate-and-restore pattern
+  from "the Hamiltonian, negated" to "an arbitrary caller-supplied
+  operator" --- real, but new design work rather than a small addition,
+  so left as a documented follow-up rather than implemented here.
+\end{itemize}
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -459,6 +459,55 @@ remaining time is genuine Julia-side tensor-contraction/truncation cost
 (\texttt{alg="densitymatrix"} SVD-based \texttt{add}/\texttt{contract}),
 not Python$\leftrightarrow$Julia marshaling overhead.
 
+Real-time TDVP evolution (\texttt{timedependent.py}'s
+\texttt{evolve\_and\_measure\_dmrg}/\texttt{evolution\_dmrg\_DC}, submode
+\texttt{"TD"}) is implemented the same way ---
+\texttt{mpsjulialive/tdvp.jl}'s \texttt{evolve\_and\_measure\_tdvp}/
+\texttt{quench\_tdvp} run the whole nt-step trajectory in one Julia call,
+driving \texttt{ITensorMPS.jl}'s own \texttt{tdvp()} (already exported by
+the \texttt{ITensorMPS} dependency; no separate \texttt{ITensorTDVP.jl}
+package needed). One real-time step is $\exp(-i \cdot dt \cdot H)$, i.e.\
+\texttt{tdvp()}'s complex evolution parameter is \texttt{-im*dt}. Two
+real, non-obvious \texttt{ITensorMPS}/\texttt{ITensors} bugs had to be
+worked around to get this correct, both confirmed by direct inspection
+of the intermediate tensors' index structure rather than guessed at from
+the stack trace alone:
+
+\begin{itemize}
+\item \texttt{mpsalgebra.jl}'s \texttt{applyoperator()}
+  (\texttt{contract(A,psi)} plus a second contraction against an
+  identity MPO, "this fixes a bug" --- a \emph{Site}-index priming
+  issue) leaves the \emph{Link} indices of its result carrying a stale
+  nonzero prime level. This is invisible to KPM (which only ever feeds
+  \texttt{applyoperator()}'s output back into more
+  \texttt{applyoperator}/\texttt{summps}/\texttt{inner} calls), but
+  \texttt{tdvp()}'s internal environment bookkeeping (\texttt{ProjMPO})
+  cannot handle it: it aborts deep inside
+  \texttt{KrylovKit.expintegrator} with "... but the indices are not
+  permutations of each other" on the affected Link index.
+  \texttt{tdvp.jl}'s \texttt{apply\_clean()} uses \texttt{ITensorMPS}'s
+  higher-level \texttt{apply()} instead (\texttt{contract()} is the
+  lower-level primitive both \texttt{applyoperator()} and
+  \texttt{apply()} are built on, but only \texttt{apply()} avoids the
+  stale prime).
+\item Whenever \texttt{tdvp()}'s input MPS did not come straight from
+  \texttt{dmrg()} (e.g.\ \texttt{evolution\_ABA()} first applies an
+  operator via \texttt{mpsjulialive/mpo.py}'s \texttt{MPO.\_\_mul\_\_},
+  which still goes through \texttt{applyoperator()} for other callers'
+  sake), the same stale Link prime reappears --- and, confirmed
+  directly, \texttt{orthogonalize!()} alone does \emph{not} clear it.
+  \texttt{evolve\_and\_measure\_tdvp()} therefore explicitly
+  \texttt{noprime(copy(wf),"Link")}s (never mutating the caller's own
+  MPS) before \texttt{orthogonalize!()}-ing and starting the TDVP loop.
+\end{itemize}
+
+Both paths were validated directly against exact diagonalization (quench
+from a N\'eel-favoring field to a Heisenberg chain, mirroring
+\texttt{examples/tdvp\_VS\_ED\_time\_evolution}):
+\texttt{evolve\_and\_measure} agreed with ED to $\sim 8 \times 10^{-7}$
+on a 4-site chain, and \texttt{evolution\_DC}'s quench correlator agreed
+to $\sim 9 \times 10^{-11}$ on a 6-site chain.
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -625,6 +625,27 @@ cost next to the sweep itself. Validated against the same golden test
 backends: peak within $0.03$ of the exact 4-site Heisenberg gap
 ($0.658919$) --- landed at $0.68$.
 
+The last two dynamical-correlator submodes needed no new Julia code at
+all, only dispatch routing: \texttt{dcex.py} (submode \texttt{"EX"},
+correlator via exact diagonalization in the excited-state subspace) only
+calls \texttt{self.get\_excited\_states()} (already backend-agnostic,
+see above) and generic \texttt{MultiOperator}/MPS algebra
+(\texttt{.dot()}, \texttt{A*wf}) before dropping into plain NumPy/SciPy
+(\texttt{eigh}); \texttt{distribution.py}'s maxent path (submode
+\texttt{"maxent"}) is built the same way on top of
+\texttt{vev.py::power\_vev}. Validated \texttt{"EX"} the same way
+\texttt{tests/test\_dynamical\_correlator.py} already does for the other
+backends --- cross-checked directly against \texttt{"KPM"} and
+\texttt{"CVM"} on the same chain/operator/frequency grid, landing on the
+exact same peak (diff $0.0$) rather than just the analytic gap.
+\texttt{"maxent"} is wired up for parity but not actually functional on
+\emph{any} backend right now --- \texttt{distribution.py::get\_distribution\_maxent}
+imports \texttt{dmrgpy.maxenttk.pymaxent}, which doesn't exist in this
+checkout (confirmed directly: \texttt{ModuleNotFoundError}), so it hits
+the same \texttt{except: print("Not functional yet"); exit()} regardless
+of \texttt{itensor\_version} --- a pre-existing, cross-backend gap, not
+something introduced or left broken by this work.
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -551,6 +551,46 @@ bond entropy at the first bond exactly matches the existing generic
 \texttt{get\_site\_entropy} (which computes the same quantity a
 completely different way, through \texttt{reduced\_dm\_projective}).
 
+The CVM dynamical-correlator submode
+(\texttt{get\_dynamical\_correlator(..., submode="CVM")},
+\texttt{cvm.py}) needed almost no Julia-specific code at all: its
+correction-vector CG solve (\texttt{cvm.py::cvm\_correction\_vector}) is
+already implemented purely with backend-agnostic MPS/MPO algebra
+(\texttt{self.toMPO()}, MPS \texttt{+}/\texttt{-}/scalar-\texttt{*},
+\texttt{.dot()}), which already works against \texttt{julia\_live}'s
+\texttt{mpsjulialive.mpo.MPO}/\texttt{mpsjulialive.mps.MPS} classes
+without any changes. The only thing standing in the way was that
+\texttt{cvm.py} unconditionally called
+\texttt{self.\_session.set\_sweep\_params(...)} to point every MPO
+application at \texttt{cvm\_maxm} rather than the DMRG \texttt{maxm} (no
+\texttt{\_session} object exists for \texttt{julia\_live} to call this
+on); \texttt{cvm.py::\_set\_cvm\_sweep\_params} now temporarily
+overrides \texttt{self.maxm} instead for that backend, since that's what
+\texttt{mpsjulialive/mpo.py}/\texttt{mps.py} actually read. Validated
+against ED with the same tolerance
+\texttt{examples/dynamical\_correlator\_VS\_ED/main.py} uses for the
+C++/pure-Python backends ($10^{-6}$) --- matched to
+$\sim 2 \times 10^{-15}$ here, in 3 CG iterations per frequency point.
+
+Wiring this up surfaced a real bug in
+\texttt{mpsjulialive/dynamics.py::get\_dynamical\_correlator}: its first
+version declared \texttt{name=}/\texttt{delta=}/\texttt{es=} as its own
+named parameters (with KPM-flavored defaults) purely so it could compute
+the KPM moments directly in the same function, which silently captured a
+caller's \texttt{es=}/\texttt{name=}/\texttt{delta=} kwargs out of
+\texttt{**kwargs} before they could reach
+\texttt{cvm.dynamical\_correlator} --- confirmed directly,
+\texttt{submode="CVM"} ran on a completely different, wrong frequency
+grid as a result (CVM's own \texttt{np.linspace(0.,10.0,100)} default
+instead of the caller's requested window). Fixed by splitting the KPM
+implementation out into its own \texttt{\_kpm\_dynamical\_correlator}
+and making the public
+\texttt{get\_dynamical\_correlator(self,submode="KPM",**kwargs)} take no
+named parameters of its own --- mirroring the top-level
+\texttt{dynamics.py::get\_dynamical\_correlator}'s own signature, which
+was never vulnerable to this because it never declared submode-specific
+parameters either.
+
 (A separate, older subprocess-based Julia path,
 \texttt{itensor\_version="julia"} via \texttt{juliarun.py}, is not
 reachable through the normal public API and should be treated as

--- a/install_julia.py
+++ b/install_julia.py
@@ -1,49 +1,34 @@
 #!/usr/bin/python3
 import os
 import sys
-import subprocess
 
 
-mpath = os.path.dirname(os.path.realpath(__file__)) 
-
-
-# main path
-try:
-    out,err = subprocess.Popen(['julia', '--version'],
-           stdout=subprocess.PIPE,
-           stderr=subprocess.STDOUT).communicate()
-except: out = ""
-# check if JUlia has the correct version
-hasjulia = "julia version 1.5" in str(out)
-#print(hasjulia) ; exit()
-
-if not hasjulia: # if the correct Julia version is not present
-    print("Julia not present in path, downloading")
-    os.system("mkdir "+mpath+"/src/julia") # create a subfodler for julia
-    os.chdir(mpath+"/src/julia") # go to the subfolder
-# download julia
-    juliafile = "julia-1.5.0-linux-x86_64.tar.gz" # julia file
-    os.system("wget https://julialang-s3.julialang.org/bin/linux/x64/1.5/"+juliafile)
-    os.system("tar -xvf "+juliafile) # untar the file
-    os.system("rm "+juliafile) # rm the file
-    julia = mpath+"/src/julia/julia-1.5.0/bin/julia" # path for julia
-    os.chdir(mpath) # go back
-
-else: 
-    julia = "julia"
-    print("Correct Julia version found in path")
+mpath = os.path.dirname(os.path.realpath(__file__))
 
 
 # install python dependences
-os.system("pip install julia")
+os.system("pip install juliacall") # bridge to the live Julia session
+                                    # (mpsjulialive/), replacing the old
+                                    # PyJulia ("pip install julia") bridge
 os.system("pip install pmdarima")
 
 
-# install Itensor julia
-import src.dmrgpy.juliarun as juliarun
-juliarun.install() # install Julia dependences
-
-
+# Trigger juliacall/juliapkg to provision Julia (via juliaup, reusing any
+# existing Julia install juliapkg finds; no manual download/tarball dance
+# needed here any more) and resolve+precompile the packages declared in
+# src/dmrgpy/juliapkg.json (ITensors, ITensorMPS, ITensorNHDMRG) into its
+# own managed project. This can take several minutes the first time
+# (registry update + precompilation); later imports reuse the same
+# managed project and are fast.
+print("Setting up the Julia backend (juliacall) -- this may take a few "
+      "minutes the first time")
+sys.path.insert(0,mpath+"/src")
+try:
+    import dmrgpy.mpsjulialive.juliasession
+    print("Julia backend ready")
+except Exception as e:
+    print("Could not set up the Julia backend:",e)
+    print("setup_julia() will not be usable until this is resolved")
 
 
 ##################

--- a/src/dmrgpy/cvm.py
+++ b/src/dmrgpy/cvm.py
@@ -22,9 +22,7 @@ def dynamical_correlator(self,es=np.linspace(0.,10.0,100),
     A,B = AB[0],AB[1]
     wf0 = self.get_gs() # computes or returns the cached GS; also sets self.e0
     # sweep parameters used both by B*wf0 below and by every CG solve
-    self._session.set_sweep_params(self.cvm_maxm,self.nsweeps,self.cutoff,self.noise)
-    self._session.set_verbose(self.verbose)
-    self._session.set_mpomaxm(max(self.cvm_maxm,self.mpomaxm))
+    maxm0 = _set_cvm_sweep_params(self)
     b = (-delta)*(B*wf0) # -eta*B|GS>, identical for every frequency
     out = [] # empty list
     for e in es: # loop over energies
@@ -32,10 +30,30 @@ def dynamical_correlator(self,es=np.linspace(0.,10.0,100),
                 tol=self.cvm_tol,max_it=int(self.cvm_nit),b=b)
         print("CVM in E = ",e," CG iterations = ",nit," residual = ",res)
         out.append(o) # store
+    if self.itensor_version=="julia_live": self.maxm = maxm0
     out = np.array(out)
 #    from .inference import points2function
 #    (es,out) = points2function(es,out)
     return (es,out) # return result
+
+
+def _set_cvm_sweep_params(self):
+    """Point every MPO application/MPS truncation at cvm_maxm rather than
+    the DMRG maxm, for the duration of a CVM computation. The C++
+    backends do this via self._session.set_sweep_params(...) (no
+    _session object exists to call on julia_live), so this temporarily
+    overrides self.maxm instead -- mpsjulialive/mpo.py's MPO.__mul__ and
+    mps.py's MPS.__add__ both read self.MBO.maxm directly, no other
+    channel to override the bond dimension exists for that backend.
+    Returns the maxm value to restore afterward."""
+    maxm0 = self.maxm
+    if self.itensor_version=="julia_live":
+        self.maxm = self.cvm_maxm
+    else:
+        self._session.set_sweep_params(self.cvm_maxm,self.nsweeps,self.cutoff,self.noise)
+        self._session.set_verbose(self.verbose)
+        self._session.set_mpomaxm(max(self.cvm_maxm,self.mpomaxm))
+    return maxm0
 
 
 
@@ -89,9 +107,7 @@ def cvm_correction_vector(self,A,B,omega,eta,tol=1e-5,max_it=1000,
     can report the CG effort and convergence quality per point.
     """
     wf0 = self.get_gs() # ground state (cheap/cached; also sets self.e0)
-    self._session.set_sweep_params(self.cvm_maxm,self.nsweeps,self.cutoff,self.noise)
-    self._session.set_verbose(self.verbose)
-    self._session.set_mpomaxm(max(self.cvm_maxm,self.mpomaxm))
+    _set_cvm_sweep_params(self)
     # (H-omega-E0) as an MPO, rebuilt per omega: measured at ~1 ms, i.e.
     # negligible next to a single CG iteration (~2 MPO applications,
     # ~0.03-0.1 s at 12-20 sites). Applying the shift at MPS level

--- a/src/dmrgpy/densitymatrix.py
+++ b/src/dmrgpy/densitymatrix.py
@@ -6,6 +6,9 @@ def reduced_dm(self,i=0):
     Compute the reduced density matrix
     """
     wf = self.get_gs() # compute ground state
+    if self.itensor_version=="julia_live":
+        from .mpsjulialive import densitymatrix as dmjl
+        return dmjl.reduced_dm(self,wf,i)
     return self._session.reduced_dm(wf.cpp_handle,i+1)
 
 

--- a/src/dmrgpy/entropy.py
+++ b/src/dmrgpy/entropy.py
@@ -29,6 +29,9 @@ def compute_entropy(self,psi,b=1):
 def compute_entropy_single(self,psi,b=1):
     """Compute entanglement entropy in a bond"""
     if b<1 or b>self.ns: raise
+    if self.itensor_version=="julia_live":
+        from .mpsjulialive import entropy as entjl
+        return np.abs(entjl.bond_entropy(psi,b))
     return np.abs(self._session.bond_entropy(psi.cpp_handle,b))
 
 

--- a/src/dmrgpy/excited.py
+++ b/src/dmrgpy/excited.py
@@ -12,6 +12,9 @@ def get_excited_states_dmrg(self,n=2,noise=0.0,scale=10.0):
     that kwarg never actually affected anything even before this backend
     was removed -- not reproducing a pre-existing no-op.
     """
+    if self.itensor_version=="julia_live":
+        from .mpsjulialive import excited as exjl
+        return exjl.get_excited_states_dmrg(self,n=n,noise=noise,scale=scale)
     wf0 = self.get_gs()
     self._session.set_sweep_params(self.maxm,self.nsweeps,self.cutoff,self.noise)
     self._session.set_verbose(self.verbose)

--- a/src/dmrgpy/juliapkg.json
+++ b/src/dmrgpy/juliapkg.json
@@ -1,0 +1,18 @@
+{
+    "julia": "1.10",
+    "packages": {
+        "ITensors": {
+            "uuid": "9136182c-28ba-11e9-034c-db9fb085ebd5",
+            "version": "=0.9.15"
+        },
+        "ITensorMPS": {
+            "uuid": "0d1a4710-d33b-49a5-8f18-73bdf49b47e2",
+            "version": "=0.3.25"
+        },
+        "ITensorNHDMRG": {
+            "uuid": "8eead381-b44f-4c25-a327-91918c5e5257",
+            "url": "https://github.com/tipfom/ITensorNHDMRG.jl",
+            "rev": "main"
+        }
+    }
+}

--- a/src/dmrgpy/juliapkg.json
+++ b/src/dmrgpy/juliapkg.json
@@ -3,11 +3,11 @@
     "packages": {
         "ITensors": {
             "uuid": "9136182c-28ba-11e9-034c-db9fb085ebd5",
-            "version": "=0.9.15"
+            "version": "0.9"
         },
         "ITensorMPS": {
             "uuid": "0d1a4710-d33b-49a5-8f18-73bdf49b47e2",
-            "version": "=0.3.25"
+            "version": "0.3"
         },
         "ITensorNHDMRG": {
             "uuid": "8eead381-b44f-4c25-a327-91918c5e5257",

--- a/src/dmrgpy/mpsjulialive/densitymatrix.jl
+++ b/src/dmrgpy/mpsjulialive/densitymatrix.jl
@@ -1,0 +1,23 @@
+
+# Single-site reduced density matrix, via explicit progressive tracing of
+# every site to the right of `site` -- mirrors pyitensor/chain.py's own
+# reduced_dm(wf,site) (itself a port of mpscpp3/chain_session.h's
+# Chain::reduced_dm), including its "divide by the norm squared, not its
+# square root" quirk (preserved for cross-backend consistency -- in
+# practice a no-op, since wf is essentially always already unit-norm
+# coming out of dmrg()).
+
+function reduced_dm(wf,site)
+	psi = copy(wf)
+	nrm2 = real(inner(psi,psi))
+	psi = psi*(1.0/nrm2)
+	orthogonalize!(psi,site)
+	ir = commonind(psi[site],psi[site+1])
+	s = siteind(psi,site)
+	rho = psi[site]*dag(prime(psi[site],s,ir))
+	for k=site+1:length(psi)
+		rho = rho*psi[k]
+		rho = rho*dag(prime(psi[k],"Link"))
+	end
+	return Array(rho,s,prime(s))
+end

--- a/src/dmrgpy/mpsjulialive/densitymatrix.py
+++ b/src/dmrgpy/mpsjulialive/densitymatrix.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+
+def reduced_dm(self,wf,i):
+    """Single-site reduced density matrix on the Julia backend, via
+    mpsjulialive/densitymatrix.jl's reduced_dm (a native Julia port of
+    pyitensor.chain.Chain.reduced_dm, itself a port of
+    mpscpp3/chain_session.h's Chain::reduced_dm). i is 0-indexed, matching
+    densitymatrix.py::reduced_dm's own convention."""
+    from .juliasession import Main as Mainjl
+    rho = Mainjl.reduced_dm(wf.jlmps,i+1)
+    return np.array(rho)

--- a/src/dmrgpy/mpsjulialive/dynamics.py
+++ b/src/dmrgpy/mpsjulialive/dynamics.py
@@ -59,10 +59,10 @@ def _kpm_moments_accelerated(jlsites,jlmpo,vi,n,kpmmaxm,kpmcutoff):
 
 def get_dynamical_correlator(self,submode="KPM",**kwargs):
     """Dispatch a dynamical correlator computation on the Julia backend.
-    submode="KPM" (see docs/documentation.md §4.6) and submode="CVM" are
-    implemented; other submodes (TD -- use
+    submode="KPM" (see docs/documentation.md §4.6), submode="CVM" and
+    submode="TDZ" are implemented; other submodes (TD -- use
     timedependent.dynamical_correlator/evolution_DC instead, which
-    already dispatch to julia_live -- TDZ, EX, maxent, ...) are only
+    already dispatch to julia_live -- EX, maxent, ...) are only
     implemented for the C++/pure-Python backends (dynamics.py).
 
     Deliberately takes submode + **kwargs only (mirroring the top-level
@@ -84,10 +84,17 @@ def get_dynamical_correlator(self,submode="KPM",**kwargs):
         # cvm.py::_set_cvm_sweep_params.
         from .. import cvm
         return cvm.dynamical_correlator(self,**kwargs)
+    if submode=="TDZ":
+        # tdz.py is already backend-agnostic MPS/MPO algebra too, apart
+        # from one primitive (a single complex-time TDVP step); see
+        # tdz.py::_advance_complex_time_step's julia_live branch and
+        # mpsjulialive/timedependent.py::advance_complex_time_step.
+        from .. import tdz
+        return tdz.dynamical_correlator_tdz(self,**kwargs)
     if submode!="KPM":
         raise NotImplementedError(
             "itensor_version='julia_live' only implements submode='KPM'/"
-            "'CVM' for get_dynamical_correlator, got submode=%r"%submode)
+            "'CVM'/'TDZ' for get_dynamical_correlator, got submode=%r"%submode)
     return _kpm_dynamical_correlator(self,**kwargs)
 
 

--- a/src/dmrgpy/mpsjulialive/dynamics.py
+++ b/src/dmrgpy/mpsjulialive/dynamics.py
@@ -57,23 +57,52 @@ def _kpm_moments_accelerated(jlsites,jlmpo,vi,n,kpmmaxm,kpmcutoff):
     return list(out)
 
 
-def get_dynamical_correlator(self,n=1000,submode="KPM",
+def get_dynamical_correlator(self,submode="KPM",**kwargs):
+    """Dispatch a dynamical correlator computation on the Julia backend.
+    submode="KPM" (see docs/documentation.md §4.6) and submode="CVM" are
+    implemented; other submodes (TD -- use
+    timedependent.dynamical_correlator/evolution_DC instead, which
+    already dispatch to julia_live -- TDZ, EX, maxent, ...) are only
+    implemented for the C++/pure-Python backends (dynamics.py).
+
+    Deliberately takes submode + **kwargs only (mirroring the top-level
+    dynamics.py::get_dynamical_correlator's own signature), not named
+    parameters like name=/es=/delta=: an earlier version of this function
+    declared those as its own named parameters with KPM-flavored
+    defaults, which silently captured the caller's es=/name=/delta=
+    kwargs out of **kwargs before they could reach cvm.dynamical_correlator
+    (whose own, different defaults would then be used unless the caller's
+    values happened to be explicitly re-forwarded) -- confirmed directly,
+    this caused CVM to silently run on a totally different frequency grid
+    than the one requested. Each submode's own function applies its own
+    defaults now, exactly as the C++/pure-Python dispatch already does."""
+    if submode=="CVM":
+        # cvm.py's CG solve is already backend-agnostic MPS/MPO algebra
+        # (self.toMPO()/MPS +,-,scalar-*,.dot()), which already works for
+        # julia_live -- the only thing that needed fixing was its own
+        # self._session.set_sweep_params(...) calls, see
+        # cvm.py::_set_cvm_sweep_params.
+        from .. import cvm
+        return cvm.dynamical_correlator(self,**kwargs)
+    if submode!="KPM":
+        raise NotImplementedError(
+            "itensor_version='julia_live' only implements submode='KPM'/"
+            "'CVM' for get_dynamical_correlator, got submode=%r"%submode)
+    return _kpm_dynamical_correlator(self,**kwargs)
+
+
+def _kpm_dynamical_correlator(self,n=1000,
              name=None,delta=1e-1,kernel="jackson",
              es=np.linspace(-1.,10,500),deconvolve=None,
              **kwargs):
-    """Compute a dynamical correlator on the Julia backend. Only
-    submode="KPM" is implemented so far (see docs/documentation.md
-    §4.6); other submodes (TD, TDZ, CVM, EX, maxent, ...) are only
-    implemented for the C++/pure-Python backends (dynamics.py). Mirrors
-    kpmdmrg.py::get_dynamical_correlator (the C++/pure-Python KPM entry
-    point) and its Chebyshev-moment post-processing exactly, but computes
-    the moments with the mpsjulialive Julia MPS/MPO primitives instead of
-    self._session.kpm_dynamical_correlator (julia_live has no such
-    session object)."""
-    if submode!="KPM":
-        raise NotImplementedError(
-            "itensor_version='julia_live' only implements submode='KPM' "
-            "for get_dynamical_correlator, got submode=%r"%submode)
+    """The submode="KPM" implementation, factored out of
+    get_dynamical_correlator so its own named-parameter defaults can't
+    shadow another submode's kwargs (see that function's docstring).
+    Mirrors kpmdmrg.py::get_dynamical_correlator (the C++/pure-Python KPM
+    entry point) and its Chebyshev-moment post-processing exactly, but
+    computes the moments with the mpsjulialive Julia MPS/MPO primitives
+    instead of self._session.kpm_dynamical_correlator (julia_live has no
+    such session object)."""
     if delta<0.0: raise
     if self.kpm_extrapolate: delta = delta*self.kpm_extrapolate_factor
     if type(name[0])!=multioperator.MultiOperator: raise

--- a/src/dmrgpy/mpsjulialive/dynamics.py
+++ b/src/dmrgpy/mpsjulialive/dynamics.py
@@ -91,10 +91,25 @@ def get_dynamical_correlator(self,submode="KPM",**kwargs):
         # mpsjulialive/timedependent.py::advance_complex_time_step.
         from .. import tdz
         return tdz.dynamical_correlator_tdz(self,**kwargs)
+    if submode=="EX":
+        # dcex.py needs no julia_live-specific code at all: it only calls
+        # self.get_excited_states() (already fixed, see excited.py) and
+        # generic MultiOperator/MPS algebra (.dot(), A*wf) plus plain
+        # numpy/scipy (eigh) from there on.
+        from .. import dcex
+        return dcex.dynamical_correlator(self,**kwargs)
+    if submode=="maxent":
+        # distribution.py's maxent path is also already backend-agnostic
+        # (vev.py::power_vev only uses MultiOperator*MPS/.dot(), then
+        # pure numpy/scipy maxent reconstruction) -- needs no
+        # julia_live-specific code either.
+        from ..distribution import dynamical_correlator_positive_defined
+        return dynamical_correlator_positive_defined(self,**kwargs)
     if submode!="KPM":
         raise NotImplementedError(
             "itensor_version='julia_live' only implements submode='KPM'/"
-            "'CVM'/'TDZ' for get_dynamical_correlator, got submode=%r"%submode)
+            "'CVM'/'TDZ'/'EX'/'maxent' for get_dynamical_correlator, "
+            "got submode=%r"%submode)
     return _kpm_dynamical_correlator(self,**kwargs)
 
 

--- a/src/dmrgpy/mpsjulialive/dynamics.py
+++ b/src/dmrgpy/mpsjulialive/dynamics.py
@@ -1,7 +1,119 @@
+import numpy as np
+
+from .. import multioperator
+from ..algebra import kpm
+from ..algebra.kpm import generate_profile
 
 
+def _max_energy_bound(self,H):
+    """Variational upper bound on H's spectrum, from a reduced-effort
+    ground-state search on -H (mirrors pyitensor.chain.Chain's own
+    _maximum_energy: a Chebyshev-window bound, never a physical result).
+    Runs in place on `self` and restores its Hamiltonian/ground-state
+    cache afterward -- julia_live has no deepcopy-safe clone() for its
+    live Julia session handles (self.jlsites/self.wf0.jlmps aren't part
+    of Python's copy protocol, see manybodychain.py's __deepcopy__), so
+    this can't go through bandwidth()/lowest_eigenvalue() the way the
+    C++/pure-Python backends do."""
+    maxm0,nsweeps0 = self.maxm,self.nsweeps
+    self.maxm = min(self.maxm,20)
+    self.nsweeps = min(self.nsweeps,5)
+    self.restart()
+    self.set_hamiltonian(-1*H,restart=False)
+    emax = -self.gs_energy()
+    self.maxm,self.nsweeps = maxm0,nsweeps0
+    self.restart()
+    self.set_hamiltonian(H,restart=False)
+    return emax
 
-def get_dynamical_correlator(self,**kwargs):
-    """Return a dynamical correlator"""
-    print("Not implemented")
-    raise
+
+def _same_mps(jlsites,vi,vj,maxm):
+    from .juliasession import Main as Mainjl
+    return bool(Mainjl.same_mps(vi,vj,maxm))
+
+
+def _kpm_moments_full(jlsites,jlmpo,vi,vj,n,kpmmaxm,kpmcutoff):
+    """Chebyshev moments <vj|T_k(scaledH)|vi>, via the standard three-term
+    recursion T_{k+1} = 2*scaledH*T_k - T_{k-1}. The whole loop runs
+    natively in Julia (kpm.jl's kpm_moments_full, driven through
+    mpsalgebra.jl's applyoperator/summps) rather than one Python<->Julia
+    round trip per Chebyshev step -- confirmed directly that the
+    per-step-round-trip version this replaced was ~1.7x slower than the
+    compiled ITensor v3 backend even with a warm Julia session (30-site
+    Heisenberg chain), which this closes."""
+    from .juliasession import Main as Mainjl
+    out = Mainjl.kpm_moments_full(jlsites,jlmpo,vi,vj,n,kpmmaxm,kpmcutoff)
+    return list(out)
+
+
+def _kpm_moments_accelerated(jlsites,jlmpo,vi,n,kpmmaxm,kpmcutoff):
+    """Same recursion as _kpm_moments_full, specialized for vi==vj (a
+    diagonal correlator): the even/odd moment pair at each step is read
+    off two consecutive Chebyshev vectors instead of two separate
+    recursions, roughly halving the MPO applications. Native Julia loop,
+    see _kpm_moments_full's note."""
+    from .juliasession import Main as Mainjl
+    out = Mainjl.kpm_moments_accelerated(jlsites,jlmpo,vi,n,kpmmaxm,kpmcutoff)
+    return list(out)
+
+
+def get_dynamical_correlator(self,n=1000,submode="KPM",
+             name=None,delta=1e-1,kernel="jackson",
+             es=np.linspace(-1.,10,500),deconvolve=None,
+             **kwargs):
+    """Compute a dynamical correlator on the Julia backend. Only
+    submode="KPM" is implemented so far (see docs/documentation.md
+    §4.6); other submodes (TD, TDZ, CVM, EX, maxent, ...) are only
+    implemented for the C++/pure-Python backends (dynamics.py). Mirrors
+    kpmdmrg.py::get_dynamical_correlator (the C++/pure-Python KPM entry
+    point) and its Chebyshev-moment post-processing exactly, but computes
+    the moments with the mpsjulialive Julia MPS/MPO primitives instead of
+    self._session.kpm_dynamical_correlator (julia_live has no such
+    session object)."""
+    if submode!="KPM":
+        raise NotImplementedError(
+            "itensor_version='julia_live' only implements submode='KPM' "
+            "for get_dynamical_correlator, got submode=%r"%submode)
+    if delta<0.0: raise
+    if self.kpm_extrapolate: delta = delta*self.kpm_extrapolate_factor
+    if type(name[0])!=multioperator.MultiOperator: raise
+    mi = name[1] # first operator
+    mj = name[0].get_dagger() # second operator
+    H = self.hamiltonian
+    e0 = self.gs_energy() # compute ground state (also sets self.e0/self.wf0)
+    wf0 = self.wf0
+    emin = self.e0
+    emax = _max_energy_bound(self,H)
+    self.wf0,self.e0,self.computed_gs = wf0,e0,True # restore GS cache
+    shift = -(emin+emax)/2.0
+    scale = 1.0/((emax-emin)*self.kpm_scale)
+    n = int(round((emax-emin)/delta))*self.kpm_n_scale
+    Hscaled_MO = (H+shift*multioperator.identity())*scale
+    from .mpo import MPO
+    from .juliasession import Main as Mainjl
+    Hscaled = MPO(Hscaled_MO,MBO=self)
+    Aop = MPO(mi,MBO=self)
+    Bop = MPO(mj,MBO=self)
+    psi1 = Mainjl.applyoperator(self.jlsites,Aop.jlmpo,wf0.jlmps,
+            self.kpmmaxm,self.kpmcutoff)
+    psi2 = Mainjl.applyoperator(self.jlsites,Bop.jlmpo,wf0.jlmps,
+            self.kpmmaxm,self.kpmcutoff)
+    if self.kpm_accelerate and _same_mps(self.jlsites,psi1,psi2,self.kpmmaxm):
+        moments = _kpm_moments_accelerated(self.jlsites,Hscaled.jlmpo,psi1,
+                n,self.kpmmaxm,self.kpmcutoff)
+    else:
+        moments = _kpm_moments_full(self.jlsites,Hscaled.jlmpo,psi1,psi2,
+                n,self.kpmmaxm,self.kpmcutoff)
+    mus = np.array(moments)
+    if self.kpm_extrapolate:
+        mus = kpm.extrapolate_moments(mus,fac=self.kpm_extrapolate_factor,
+                extrapolation_mode=self.kpm_extrapolate_mode)
+    xs = 0.99*np.linspace(-1.0,1.0,int(n*10),endpoint=False) # energies
+    ys = generate_profile(mus,xs,use_fortran=False,kernel=kernel) # generate the DOS
+    xs /= scale # scale back the energies
+    xs += (emin+emax)/2. -emin # shift the energies
+    ys *= scale # renormalize the y values
+    from scipy.interpolate import interp1d
+    fr = interp1d(xs, ys.real,fill_value=0.0,bounds_error=False)
+    fi = interp1d(xs, ys.imag,fill_value=0.0,bounds_error=False)
+    return (es,fr(es)+1j*fi(es)) # interpolate

--- a/src/dmrgpy/mpsjulialive/entropy.jl
+++ b/src/dmrgpy/mpsjulialive/entropy.jl
@@ -1,0 +1,26 @@
+
+# Von Neumann entanglement entropy at a bond, via SVD of the two-site
+# tensor there -- the standard MPS way to compute it, and much cheaper
+# than reconstructing an explicit density matrix. Mirrors
+# pyitensor/chain.py's bond_entropy(wf,b) (itself a port of
+# mpscpp3/chain_session.h's Chain::bond_entropy).
+
+function bond_entropy(wf,b)
+	psi = copy(wf) # orthogonalize! is in-place; don't mutate the caller's MPS
+	orthogonalize!(psi,b)
+	twosite = psi[b]*psi[b+1]
+	s_b = siteind(psi,b)
+	if b>1
+		left_link = commonind(psi[b],psi[b-1])
+		_,_,_,spec = svd(twosite,left_link,s_b;cutoff=0.0)
+	else
+		_,_,_,spec = svd(twosite,s_b;cutoff=0.0)
+	end
+	SvN = 0.0
+	for p in eigs(spec)
+		if p>1e-12
+			SvN += -p*log(p)
+		end
+	end
+	return SvN
+end

--- a/src/dmrgpy/mpsjulialive/entropy.py
+++ b/src/dmrgpy/mpsjulialive/entropy.py
@@ -1,0 +1,6 @@
+def bond_entropy(psi,b):
+    """Von Neumann entanglement entropy at bond b (1-indexed, between
+    sites b and b+1), on the Julia backend -- mpsjulialive/entropy.jl's
+    bond_entropy, a native SVD-based computation."""
+    from .juliasession import Main as Mainjl
+    return Mainjl.bond_entropy(psi.jlmps,b)

--- a/src/dmrgpy/mpsjulialive/excited.jl
+++ b/src/dmrgpy/mpsjulialive/excited.jl
@@ -1,0 +1,35 @@
+
+# Excited states via ITensorMPS.jl's own orthogonality-penalty dmrg()
+# method (dmrg(H::MPO, Ms::Vector{MPS}, psi0::MPS, sweeps; weight)) --
+# mirrors pyitensor/chain.py's excited_states()/dmrg_excited(), which in
+# turn mirrors mpscpp3/chain_session.h's Chain::excited_states().
+
+function excited_state_dmrg(H,wfs,psi0,weight,nsweeps,cutoff,maxm)
+	sweeps = Sweeps(nsweeps)
+	maxdim!(sweeps,maxm)
+	cutoff!(sweeps,cutoff)
+	open("/dev/null","w") do devnull
+		redirect_stdout(devnull) do
+			return dmrg(H,wfs,psi0,sweeps;weight=weight)
+		end
+	end
+end
+
+
+function excited_states_dmrg(H,psi0_gs,n,weight,sites,nsweeps,cutoff,maxm)
+	# whole n-state loop runs in one Julia call, same design as
+	# kpm.jl/tdvp.jl -- one new random-start warm state per additional
+	# excited state, deflated against every wavefunction found so far
+	# via dmrg()'s own orthogonality-penalty weight
+	wfs = MPS[psi0_gs]
+	for i=2:n
+		psi0 = random_state(sites)
+		e1,psi1 = excited_state_dmrg(H,wfs,psi0,weight,nsweeps,cutoff,maxm)
+		push!(wfs,psi1)
+	end
+	# re-evaluate exact <wf|H|wf> for every state (including the ground
+	# state) rather than reusing dmrg()'s own penalized eigenvalue
+	# estimate -- mirrors mpscpp3/chain_session.h's Chain::excited_states
+	energies = ComplexF64[inner(w,H,w) for w in wfs]
+	return energies,wfs
+end

--- a/src/dmrgpy/mpsjulialive/excited.py
+++ b/src/dmrgpy/mpsjulialive/excited.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from .mpo import MPO
+
+
+def get_excited_states_dmrg(self,n=2,noise=0.0,scale=10.0):
+    """Excited states on the Julia backend, via ITensorMPS.jl's own
+    orthogonality-penalty dmrg() (mpsjulialive/excited.jl's
+    excited_states_dmrg -- the whole n-state loop runs in one Julia
+    call). Mirrors excited.py::get_excited_states_dmrg's C++ path
+    (mpscpp2/mpscpp3's Chain::excited_states) and
+    pyitensor.chain.Chain.excited_states()."""
+    wf0 = self.get_gs()
+    H = self.hamiltonian
+    e0 = self.e0
+    from .dynamics import _max_energy_bound
+    emax = _max_energy_bound(self,H) # mutates self.wf0/self.e0, see below
+    self.wf0,self.e0,self.computed_gs = wf0,e0,True # restore GS cache
+    weight = (emax-e0)*scale
+    Hop = MPO(H,MBO=self)
+    from .juliasession import Main as Mainjl
+    energies_jl,wfs_jl = Mainjl.excited_states_dmrg(Hop.jlmpo,wf0.jlmps,
+            int(n),weight,self.jlsites,self.nsweeps,self.cutoff,self.maxm)
+    from .mps import MPS
+    wfs = [MPS(w,MBO=self) for w in wfs_jl]
+    energies = np.array([complex(e).real for e in energies_jl])
+    return energies,wfs

--- a/src/dmrgpy/mpsjulialive/juliasession.py
+++ b/src/dmrgpy/mpsjulialive/juliasession.py
@@ -42,6 +42,7 @@ def initialize():
                           # mpsalgebra.jl's applyoperator, must load after it
     files += ["excited.jl"] # orthogonality-penalty excited-state dmrg()
     files += ["densitymatrix.jl"] # single-site reduced density matrix
+    files += ["entropy.jl"] # SVD-based bond entanglement entropy
     for name in files: # loop over files
         Main.seval(open(path+"/"+name).read()) # execute this file
 

--- a/src/dmrgpy/mpsjulialive/juliasession.py
+++ b/src/dmrgpy/mpsjulialive/juliasession.py
@@ -1,0 +1,45 @@
+## Bridge to a live, in-process Julia session (ITensors.jl).
+#
+# Uses juliacall/PythonCall.jl rather than PyJulia: no libpython-matching
+# precondition, no compiled_modules=False startup workaround, and the
+# required Julia packages (ITensors, ITensorMPS, ITensorNHDMRG) are
+# declared in ../juliapkg.json and auto-installed/precompiled into a
+# juliacall-managed project the first time this module is imported --
+# reusing whatever Julia install juliapkg finds (or provisioning its own
+# via juliaup if none is found).
+
+import os
+from juliacall import Main
+from juliacall import convert as jlconvert
+
+
+def to_julia_strvec(ls):
+    """Convert a Python list of str into a genuine Julia Vector{String}.
+    juliacall wraps a plain Python list as a lazy PyList{Any} by default,
+    which fails to dispatch against Julia functions declared with a typed
+    Vector{String} argument (sites.jl's get_sites, read_operator.jl's
+    read_operator/toMPO) -- unlike PyJulia, which converted a homogeneous
+    list of str to Vector{String} implicitly."""
+    return jlconvert(Main.Vector[Main.String], ls)
+
+
+# current path
+path = os.path.dirname(os.path.realpath(__file__))
+
+
+# now execute the Julia code
+
+# list of all the source files
+
+def initialize():
+    files = ["sites.jl"]
+    files += ["get_gs.jl"]
+    files += ["read_operator.jl"]
+    files += ["mpsalgebra.jl"]
+    files += ["kpm.jl"] # KPM moment recursion; calls mpsalgebra.jl's own
+                         # applyoperator/summps, so must load after it
+    for name in files: # loop over files
+        Main.seval(open(path+"/"+name).read()) # execute this file
+
+
+initialize() # initialize all the functions

--- a/src/dmrgpy/mpsjulialive/juliasession.py
+++ b/src/dmrgpy/mpsjulialive/juliasession.py
@@ -38,6 +38,8 @@ def initialize():
     files += ["mpsalgebra.jl"]
     files += ["kpm.jl"] # KPM moment recursion; calls mpsalgebra.jl's own
                          # applyoperator/summps, so must load after it
+    files += ["tdvp.jl"] # real-time TDVP evolution; also calls
+                          # mpsalgebra.jl's applyoperator, must load after it
     for name in files: # loop over files
         Main.seval(open(path+"/"+name).read()) # execute this file
 

--- a/src/dmrgpy/mpsjulialive/juliasession.py
+++ b/src/dmrgpy/mpsjulialive/juliasession.py
@@ -40,6 +40,8 @@ def initialize():
                          # applyoperator/summps, so must load after it
     files += ["tdvp.jl"] # real-time TDVP evolution; also calls
                           # mpsalgebra.jl's applyoperator, must load after it
+    files += ["excited.jl"] # orthogonality-penalty excited-state dmrg()
+    files += ["densitymatrix.jl"] # single-site reduced density matrix
     for name in files: # loop over files
         Main.seval(open(path+"/"+name).read()) # execute this file
 

--- a/src/dmrgpy/mpsjulialive/kpm.jl
+++ b/src/dmrgpy/mpsjulialive/kpm.jl
@@ -1,0 +1,73 @@
+
+# Kernel Polynomial Method: Chebyshev-moment recursion run entirely in
+# Julia (no per-step Python round trip), driven through the existing
+# applyoperator/summps/overlap primitives from mpsalgebra.jl. Mirrors
+# pyitensor/chain.py's own pure-Python _kpm_moments_full/_accelerated,
+# and mpsjulialive/dynamics.py's earlier per-step Python orchestration of
+# the same recursion (kept only as the Python-level fallback semantics --
+# this file replaces the hot loop itself).
+
+function check_kpm_moment(lastmoment,bound)
+	# Chebyshev moments of a correctly scaled Hamiltonian (spectrum
+	# inside [-1,1]) satisfy |<vj|T_k|vi>| <= ||vi||*||vj|| = bound;
+	# exponential growth beyond it means the scaled spectrum leaked
+	# outside [-1,1] (band-edge estimate too tight for the chosen
+	# kpm_scale) and every subsequent moment is garbage.
+	if abs(lastmoment) > 1e3*(bound+1.0)
+		error("KPM moments diverging: scaled spectrum outside [-1,1] "*
+		      "(band-edge estimate too tight; increasing kpm_scale "*
+		      "widens the safety margin)")
+	end
+end
+
+
+function kpm_moments_full(sites,jlmpo,vi,vj,n,kpmmaxm,kpmcutoff)
+	v = 1.0*vi
+	am = 1.0*vi
+	a = applyoperator(sites,jlmpo,v,kpmmaxm,kpmcutoff)
+	# legitimate moments <vj|T_k|vi> are bounded by ||vi||*||vj|| (NOT by
+	# the zeroth moment <vj|vi>, which can be ~0 for a near-orthogonal
+	# cross-correlator pair)
+	bound = sqrt(abs(real(inner(vi,vi))*real(inner(vj,vj))))
+	out = ComplexF64[]
+	push!(out,inner(vj,v))
+	push!(out,inner(vj,a))
+	for k=1:n
+		ap = applyoperator(sites,jlmpo,a,kpmmaxm,kpmcutoff)
+		ap = summps(2.0*ap,(-1.0)*am,kpmmaxm)
+		push!(out,inner(vj,ap))
+		check_kpm_moment(out[end],bound)
+		am = 1.0*a
+		a = 1.0*ap
+	end
+	return out
+end
+
+
+function kpm_moments_accelerated(sites,jlmpo,vi,n,kpmmaxm,kpmcutoff)
+	a = applyoperator(sites,jlmpo,vi,kpmmaxm,kpmcutoff)
+	am = 1.0*vi
+	mu0 = inner(vi,vi)
+	mu1 = inner(vi,a)
+	bound = abs(mu0) # here vi==vj, so the moment bound ||vi||*||vj|| is just mu0
+	out = ComplexF64[mu0,mu1]
+	for k=1:div(n,2)
+		ap = applyoperator(sites,jlmpo,a,kpmmaxm,kpmcutoff)
+		ap = summps(2.0*ap,(-1.0)*am,kpmmaxm)
+		bk = 2.0*inner(a,a)-mu0
+		bk1 = 2.0*inner(a,ap)-mu1
+		push!(out,bk)
+		push!(out,bk1)
+		check_kpm_moment(out[end],bound)
+		am = 1.0*a
+		a = 1.0*ap
+	end
+	return out
+end
+
+
+function same_mps(vi,vj,maxm)
+	d = summps(1.0*vi,(-1.0)*vj,maxm)
+	dd = sqrt(abs(real(inner(d,d))))
+	return dd<1e-10
+end

--- a/src/dmrgpy/mpsjulialive/mpo.py
+++ b/src/dmrgpy/mpsjulialive/mpo.py
@@ -21,14 +21,8 @@ def text_mpo(MO):
 def get_MPO(MO,MBO):
     """Transform a multioperator into a matrix product operator"""
     ls = text_mpo(MO)
-#    print(ls) ; exit()
-    from .juliasession import Main
-    Main.mpo_ls = ls
-#    print(type(Main.mpo_ls),type(MBO.jlsites))
-#    Main.mpo_ls = Main.eval('convert(Vector{String}, mpo_ls)')
-#    MPO = Main.eval('toMPO(mpo_ls)')
-    MPO = Main.toMPO(Main.mpo_ls,MBO.jlsites)
-#    print(MPO)
+    from .juliasession import Main, to_julia_strvec
+    MPO = Main.toMPO(to_julia_strvec(ls),MBO.jlsites)
     return MPO
 
 import numpy as np

--- a/src/dmrgpy/mpsjulialive/mps.py
+++ b/src/dmrgpy/mpsjulialive/mps.py
@@ -47,6 +47,14 @@ class MPS():
         if j is None: j = i + 1
         if self.MBO is not None: return self.MBO.get_bond_entropy(self,i,j)
         else: raise # not implemented
+    def get_four_correlation_tensor(self,**kwargs):
+        """<Cdag_i C_j Cdag_k C_l>, via entropytk/correlationentropy.py's
+        default ctmode="explicit" (a Python loop of MultiOperator products
+        + generic aMb()/.dot() -- no julia_live-specific code needed,
+        unlike ctmode="full" which needs a native per-element AutoMPO
+        build and is not implemented for this backend)."""
+        from .. import entanglement
+        return entanglement.get_four_correlation_tensor(self,**kwargs)
     def get_correlation_entropy(self,**kwargs):
         from .. import entanglement
         return entanglement.get_correlation_entropy_from_wf(self,

--- a/src/dmrgpy/mpsjulialive/mps.py
+++ b/src/dmrgpy/mpsjulialive/mps.py
@@ -40,6 +40,13 @@ class MPS():
         return MPS(self.jlmps,MBO=self.MBO)
     def write(self,name=None,path=None):
         return # dummy method
+    def get_site_entropy(self,i):
+        if self.MBO is not None: return self.MBO.get_site_entropy(self,i)
+        else: raise # not implemented
+    def get_bond_entropy(self,i,j=None):
+        if j is None: j = i + 1
+        if self.MBO is not None: return self.MBO.get_bond_entropy(self,i,j)
+        else: raise # not implemented
     def get_correlation_entropy(self,**kwargs):
         from .. import entanglement
         return entanglement.get_correlation_entropy_from_wf(self,

--- a/src/dmrgpy/mpsjulialive/sites.jl
+++ b/src/dmrgpy/mpsjulialive/sites.jl
@@ -1,7 +1,7 @@
 
 function get_sites(ls::Vector{String})
   n = parse(Int,ls[1]) # number of sites
-  sites = []
+  sites = Index[]
   for i=1:n
     ni = parse(Int,ls[i+1]) # index of the site
     if ni==0 

--- a/src/dmrgpy/mpsjulialive/sites.py
+++ b/src/dmrgpy/mpsjulialive/sites.py
@@ -11,8 +11,6 @@ def sites_text(self):
 def initialize(self):
     """Initialize the sites for the Julia calculation"""
     ls = sites_text(self)
-    from .juliasession import Main
-    Main.sites_string = ls
-#    jlsites = Main.get_sites(Main.sites_string)
-    jlsites = Main.eval('get_sites(sites_string)')
+    from .juliasession import Main, to_julia_strvec
+    jlsites = Main.get_sites(to_julia_strvec(ls))
     self.jlsites = jlsites

--- a/src/dmrgpy/mpsjulialive/tdvp.jl
+++ b/src/dmrgpy/mpsjulialive/tdvp.jl
@@ -8,25 +8,30 @@
 # exp(-i*dt*H), i.e. tdvp's evolution parameter is -im*dt.
 
 function tdvp_step(H,psi,dt,cutoff,maxdim)
-	# mindim=2 is a cheap defensive floor against degenerate dim-1 bonds;
-	# kept even though the actual bug hit here (see apply_clean() below)
-	# turned out to be elsewhere.
+	# psi isn't always straight out of dmrg() or a previous tdvp_step()
+	# call (e.g. evolution_ABA()/tdz.py's first step both start from an
+	# operator applied via mpsjulialive/mpo.py's MPO.__mul__, which goes
+	# through mpsalgebra.jl's applyoperator() -- confirmed directly to
+	# leave a stale nonzero prime level on the result's Link indices).
+	# tdvp()'s internal environment bookkeeping (ProjMPO) can't handle
+	# that: it aborts deep inside KrylovKit's expintegrator ("... but the
+	# indices are not permutations of each other", or a related
+	# broadcast-shape failure in the same call chain). orthogonalize!()
+	# alone does NOT clear the stale prime (confirmed directly), so the
+	# Link indices need an explicit noprime() first; copy() so this never
+	# mutates the caller's own MPS in place. Sanitizing on every step
+	# rather than just the first is deliberate -- cheap next to the sweep
+	# itself, and keeps every caller of tdvp_step correct by construction
+	# instead of relying on each call site to remember to pre-clean.
+	psi = noprime(copy(psi),"Link")
+	orthogonalize!(psi,1)
+	# mindim=2 is a cheap defensive floor against degenerate dim-1 bonds.
 	return tdvp(H,-im*dt,psi;time_step=-im*dt,cutoff=cutoff,maxdim=maxdim,
 	            mindim=2,normalize=false,outputlevel=0)
 end
 
 function evolve_and_measure_tdvp(Hmpo,Aop,wf,nt,dt,cutoff,maxdim)
-	# wf isn't always straight out of dmrg() (e.g. evolution_ABA() first
-	# applies an operator via mpsjulialive/mpo.py's MPO.__mul__, which
-	# goes through mpsalgebra.jl's applyoperator() -- confirmed directly
-	# to leave a stale nonzero prime level on the result's Link indices,
-	# same as apply_clean()'s docstring below explains for quench_tdvp's
-	# inputs. orthogonalize!() alone does NOT clear this -- confirmed
-	# directly, the stale prime survives it -- so the Link indices need
-	# an explicit noprime() first. copy() first so this doesn't mutate
-	# the caller's own wf in place.
-	psi = noprime(copy(wf),"Link")
-	orthogonalize!(psi,1)
+	psi = wf
 	correlator = ComplexF64[]
 	for it=1:nt
 		psi = tdvp_step(Hmpo,psi,dt,cutoff,maxdim)

--- a/src/dmrgpy/mpsjulialive/tdvp.jl
+++ b/src/dmrgpy/mpsjulialive/tdvp.jl
@@ -1,0 +1,68 @@
+
+# Real-time TDVP evolution, run natively in Julia (ITensorMPS.jl already
+# exports tdvp() -- no separate ITensorTDVP.jl dependency needed). One
+# call per full nt-step trajectory (not one Python<->Julia round trip per
+# step), same design as kpm.jl's moment recursion. Mirrors
+# pyitensor/chain.py's evolve_and_measure_tdvp()/quench_tdvp() (which in
+# turn mirror mpscpp3/chain_session.h's C++ TDVP): one real-time step is
+# exp(-i*dt*H), i.e. tdvp's evolution parameter is -im*dt.
+
+function tdvp_step(H,psi,dt,cutoff,maxdim)
+	# mindim=2 is a cheap defensive floor against degenerate dim-1 bonds;
+	# kept even though the actual bug hit here (see apply_clean() below)
+	# turned out to be elsewhere.
+	return tdvp(H,-im*dt,psi;time_step=-im*dt,cutoff=cutoff,maxdim=maxdim,
+	            mindim=2,normalize=false,outputlevel=0)
+end
+
+function evolve_and_measure_tdvp(Hmpo,Aop,wf,nt,dt,cutoff,maxdim)
+	# wf isn't always straight out of dmrg() (e.g. evolution_ABA() first
+	# applies an operator via mpsjulialive/mpo.py's MPO.__mul__, which
+	# goes through mpsalgebra.jl's applyoperator() -- confirmed directly
+	# to leave a stale nonzero prime level on the result's Link indices,
+	# same as apply_clean()'s docstring below explains for quench_tdvp's
+	# inputs. orthogonalize!() alone does NOT clear this -- confirmed
+	# directly, the stale prime survives it -- so the Link indices need
+	# an explicit noprime() first. copy() first so this doesn't mutate
+	# the caller's own wf in place.
+	psi = noprime(copy(wf),"Link")
+	orthogonalize!(psi,1)
+	correlator = ComplexF64[]
+	for it=1:nt
+		psi = tdvp_step(Hmpo,psi,dt,cutoff,maxdim)
+		push!(correlator,inner(psi,Aop,psi))
+	end
+	return correlator,psi
+end
+
+function apply_clean(A,psi0,maxdim,cutoff;alg="densitymatrix")
+	# Deliberately NOT mpsalgebra.jl's applyoperator(), and deliberately
+	# apply() rather than contract(): confirmed directly (linkinds(...)
+	# checked explicitly) that contract(A,psi0) -- what applyoperator()
+	# and its "iden_op fixes a bug" follow-up both build on -- leaves a
+	# stale nonzero prime level on the result's Link indices, which
+	# tdvp()'s internal environment bookkeeping (ProjMPO) can't handle:
+	# it aborts deep inside KrylovKit's expintegrator with "... but the
+	# indices are not permutations of each other" on the affected Link
+	# index. apply() is ITensorMPS's own higher-level MPO-application
+	# function (contract() is the lower-level primitive it and
+	# applyoperator() are both built on) and does not have this problem.
+	# orthogonalize!() gives the result a well-defined orthogonality
+	# center, which tdvp() (like dmrg()) requires of its input MPS.
+	psi1 = apply(A,psi0;maxdim=maxdim,cutoff=cutoff,alg=alg)
+	orthogonalize!(psi1,1)
+	return psi1
+end
+
+function quench_tdvp(Hshiftmpo,A1mpo,A2mpo,wf0,nt,dt,cutoff,maxdim)
+	psi1 = apply_clean(A1mpo,wf0,maxdim,cutoff)
+	psi2 = apply_clean(A2mpo,wf0,maxdim,cutoff)
+	norm0 = sqrt(abs(inner(psi1,psi1)))
+	correlator = ComplexF64[]
+	for it=1:nt
+		psi1 = tdvp_step(Hshiftmpo,psi1,dt,cutoff,maxdim)
+		psi1 = psi1*(norm0/sqrt(abs(inner(psi1,psi1))))
+		push!(correlator,inner(psi2,psi1))
+	end
+	return correlator,psi1
+end

--- a/src/dmrgpy/mpsjulialive/timedependent.py
+++ b/src/dmrgpy/mpsjulialive/timedependent.py
@@ -51,3 +51,17 @@ def evolve_and_measure_dmrg(self,operator=None,nt=1000,h=None,
         wf_final = MPS(wf_final_jl,MBO=self)
         return ts,cs.real-1j*cs.imag,wf_final
     return ts,cs.real-1j*cs.imag
+
+
+def advance_complex_time_step(self,Hop,wf,dz):
+    """One complex-time TDVP step exp(-i*dz*Hop) on the Julia backend --
+    used by tdz.py's submode="TDZ" (arXiv:2311.10909). Reuses
+    tdvp.jl's tdvp_step completely unchanged: -im*dz is already the
+    correct generalization for a complex dz (real dt, used by
+    evolve_and_measure_tdvp/quench_tdvp above, is just the dz.imag==0
+    special case) -- Julia's `-im*dz` doesn't care whether dz is real or
+    complex."""
+    from .juliasession import Main as Mainjl
+    from .mps import MPS
+    psi = Mainjl.tdvp_step(Hop.jlmpo,wf.jlmps,dz,self.cutoff,self.maxm)
+    return MPS(psi,MBO=self)

--- a/src/dmrgpy/mpsjulialive/timedependent.py
+++ b/src/dmrgpy/mpsjulialive/timedependent.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+from .. import operatornames
+from .. import multioperator
+from .mpo import MPO
+
+
+def evolution_dmrg_DC(self,name="XX",nt=10000,dt=0.1,**kwargs):
+    """Real-time quench dynamical correlator on the Julia backend, via
+    native TDVP (mpsjulialive/tdvp.jl's quench_tdvp -- the whole nt-step
+    trajectory runs in one Julia call, same design as kpm.jl). Mirrors
+    timedependent.py::evolution_dmrg_DC's TDVP branch (itensor_version=3/
+    "python"); only TDVP is implemented here, there is no MPO-Taylor
+    fallback for julia_live."""
+    name = operatornames.str2MO(self,name,**kwargs)
+    name[0] = name[0].get_dagger()
+    A,B = name[0],name[1]
+    wf0 = self.get_gs() # also sets self.e0
+    H = self.hamiltonian
+    # shift H by the ground-state energy so psi1's trivial overall phase
+    # exp(-i*e0*t) cancels in the <psi2|psi1(t)> correlator, mirroring
+    # pyitensor.chain.Chain.quench_tdvp()/quench()
+    Hshift_MO = H-self.e0*multioperator.identity()
+    Hshift = MPO(Hshift_MO,MBO=self)
+    A1 = MPO(A,MBO=self)
+    A2 = MPO(B,MBO=self)
+    from .juliasession import Main as Mainjl
+    correlator,_wf = Mainjl.quench_tdvp(Hshift.jlmpo,
+            A1.jlmpo,A2.jlmpo,wf0.jlmps,int(nt),dt,self.cutoff,self.maxm)
+    cs = np.array(correlator)
+    ts = np.array([dt*ii for ii in range(int(nt))])
+    return ts,cs.real-1j*cs.imag
+
+
+def evolve_and_measure_dmrg(self,operator=None,nt=1000,h=None,
+        dt=1e-2,wf=None,return_wf=False,**kwargs):
+    """Real-time evolution + measurement on the Julia backend, via native
+    TDVP (mpsjulialive/tdvp.jl's evolve_and_measure_tdvp). Mirrors
+    timedependent.py::evolve_and_measure_dmrg's TDVP branch."""
+    if h is None: h = self.hamiltonian # Hamiltonian
+    if wf is None: wf = self.wf0 # get ground state
+    Hop = MPO(h,MBO=self)
+    Aop = MPO(operator,MBO=self)
+    from .juliasession import Main as Mainjl
+    correlator,wf_final_jl = Mainjl.evolve_and_measure_tdvp(Hop.jlmpo,
+            Aop.jlmpo,wf.jlmps,int(nt),dt,self.cutoff,self.maxm)
+    cs = np.array(correlator)
+    ts = np.array([dt*ii for ii in range(int(nt))])
+    if return_wf:
+        from .mps import MPS
+        wf_final = MPS(wf_final_jl,MBO=self)
+        return ts,cs.real-1j*cs.imag,wf_final
+    return ts,cs.real-1j*cs.imag

--- a/src/dmrgpy/tdz.py
+++ b/src/dmrgpy/tdz.py
@@ -130,7 +130,16 @@ def _advance_complex_time_step(self, Hop, wf, dz, do_gse=False):
     loop instead of a C++ one like those two. Same itensor_version support
     as plain "TDVP" (3 or "python" only) -- see evolution_dmrg_DC's
     docstring for why a v2 port isn't available here.
+
+    julia_live always takes the plain two-site TDVP branch below (its
+    default self.tevol_method is "TDVP"; there is no TDVP_GSE or
+    MPO-Taylor fallback wired up for this backend) -- see
+    mpsjulialive/tdvp.jl's tdvp_step, which already generalizes cleanly
+    to a complex dz with no changes needed.
     """
+    if self.itensor_version=="julia_live":
+        from .mpsjulialive.timedependent import advance_complex_time_step
+        return advance_complex_time_step(self,Hop,wf,dz)
     if self.itensor_version in (3, "python") and self.tevol_method == "TDVP":
         handle = self._session.tdvp_step(Hop.cpp_handle, wf.cpp_handle, dz)
     elif self.itensor_version in (3, "python") and self.tevol_method == "TDVP_GSE":

--- a/src/dmrgpy/timedependent.py
+++ b/src/dmrgpy/timedependent.py
@@ -47,6 +47,9 @@ def evolution_dmrg_DC(self,name="XX",nt=10000,dt=0.1,restart=True,**kwargs):
     "restart" has no effect: quench()'s C++ implementation always starts
     from get_gs() regardless of its value.
     """
+    if self.itensor_version=="julia_live":
+        from .mpsjulialive import timedependent as tdjl
+        return tdjl.evolution_dmrg_DC(self,name=name,nt=nt,dt=dt,**kwargs)
     name = operatornames.str2MO(self,name,**kwargs)
     name[0] = name[0].get_dagger()
     A,B = name[0],name[1]
@@ -109,6 +112,10 @@ def evolve_and_measure_dmrg(self,operator=None,nt=1000,h=None,
     fidelity check where ED isn't feasible (see
     examples/tdvp_VS_ED_time_evolution/benchmark_scaling.py).
     """
+    if self.itensor_version=="julia_live":
+        from .mpsjulialive import timedependent as tdjl
+        return tdjl.evolve_and_measure_dmrg(self,operator=operator,nt=nt,
+                h=h,dt=dt,wf=wf,return_wf=return_wf,**kwargs)
     if h is None: h = self.hamiltonian # Hamiltonian
     if wf is None: wf = self.wf0 # get ground state
     self._session.set_sweep_params(self.maxm,self.nsweeps,self.cutoff,self.noise)


### PR DESCRIPTION
## Summary

- Replaces the PyJulia bridge (`itensor_version="julia_live"`) with `juliacall`/PythonCall.jl: no libpython-matching precondition, no `compiled_modules=False` workaround, and the required Julia packages (`ITensors`, `ITensorMPS`, `ITensorNHDMRG`) self-provision via `src/dmrgpy/juliapkg.json` on first import.
- Brings the Julia backend from a mostly-stub implementation to feature parity with the C++/pure-Python backends: all five dynamical-correlator submodes (KPM, TD/TDVP, CVM, TDZ, EX; maxent wired for parity though inert on every backend), real-time TDVP evolution, excited states, `reduced_dm`, bond entanglement entropy, and the fermionic 4-point correlator tensor.
- Fixes several real, pre-existing bugs found along the way (a `sites.jl` typed-dispatch bug, a `.gitignore` rule that silently excluded real source files from version control, a stale-Link-index-prime issue in `mpsalgebra.jl`'s `applyoperator`, and a kwarg-shadowing bug that silently ran CVM on the wrong frequency grid) — see `docs/documentation.md`/`.tex` §4.6 for the full account of each, including what was measured/confirmed directly rather than assumed.
- Documents two remaining, deliberately-unfixed gaps (`vev(npow=)`, `get_distribution`) for future reference.

## Test plan

- [x] `python run_tests.py` (75/75 passed) after every commit
- [x] KPM, TDVP, CVM, TDZ, EX validated against ED / existing golden regression values / cross-checks with the other DMRG backends, matching to ~1e-7–1e-15 depending on the check
- [x] Excited states matched `tests/test_excited_states.py`'s golden values to ~3e-15
- [x] Bond entropy matched the analytic Bell-pair value (ln 2) and the existing generic `get_site_entropy` computation
- [x] 4-point correlator tensor matched ED to ~2e-15 on the same well-gapped model `tests/test_four_point_correlator.py` uses
- [x] `docs/documentation.tex` recompiles cleanly with `pdflatex` after every doc update (no errors, no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dnq8GKFEXthmpF5P38Z8X