### PR TITLE
Add docstrings to all bound methods in Many_Body_Chain, Fermionic_Chain, Spin_Chain

### DIFF
--- a/src/dmrgpy/fermionchain.py
+++ b/src/dmrgpy/fermionchain.py
@@ -12,6 +12,7 @@ from . import multioperator
 class Fermionic_Chain(Many_Body_Chain):
     """Class for fermionic Hamiltonians"""
     def __init__(self,n,**kwargs):
+        """Build a spinless fermionic chain of n sites"""
         self.F = [self.get_operator("F",i) for i in range(n)] # Fermi string
         self.C = [self.get_operator("C",i) for i in range(n)]
         self.Cdag = [self.get_operator("Cdag",i) for i in range(n)]
@@ -30,6 +31,7 @@ class Fermionic_Chain(Many_Body_Chain):
         """Add the spin independent hoppings"""
         self.set_hoppings_MB(fun)
     def get_logdimension(self):
+        """Return the logarithm of the Hilbert space dimension"""
         return len(self.C)*np.log(2) # log dimension
     def get_density_spinless(self,**kwargs):
         """Return the electronic density"""
@@ -61,7 +63,8 @@ class Fermionic_Chain(Many_Body_Chain):
         """ Return a vaccum expectation value"""
         if mode=="DMRG": return self.excited_vev_MB(MO,**kwargs)
         elif mode=="ED": return self.get_ED_obj().excited_vev(MO,**kwargs) 
-    def excited_vev(self,MO,**kwargs): 
+    def excited_vev(self,MO,**kwargs):
+        """Compute a vacuum expectation value using excited states"""
         return self.excited_vev_spinless(MO,**kwargs)
     def hamiltonian_free(self,pairs=[[]]):
         """
@@ -104,8 +107,10 @@ class Fermionic_Chain(Many_Body_Chain):
         es = lg.eigvalsh(m) # get the energies
         return np.sum(es[es<0.0]) # return energies
     def get_gr(self,**kwargs):
+        """Return the retarded Green's function"""
         return get_gr(self,**kwargs)
     def get_gr_free(self,**kwargs):
+        """Return the retarded Green's function for free fermions"""
         return get_gr_free(self,**kwargs)
     def gs_energy(self,mode="DMRG",**kwargs):
         """Compute ground state energy, overrriding the method"""
@@ -216,7 +221,9 @@ class Spinful_Fermionic_Chain(Fermionic_Chain):
     spin degree of freedom
     """
     def __init__(self,n):
-        """ Rewrite the init method to take twice as many sites"""
+        """ Rewrite the init method to take twice as many sites (n
+        orbitals, each represented by two interleaved spinless-fermion
+        sites for the up/down flavors)"""
         super().__init__(2*n) # initialize the Hamiltonian
         self.Sx = [0.5*self.Cdag[2*i]*self.C[2*i+1] +
                 0.5*self.Cdag[2*i+1]*self.C[2*i] for i in range(n)]
@@ -563,6 +570,7 @@ class Spinon_Chain(Spinful_Fermionic_Chain):
         self.wf0 = wf # store ground state
         return wf
     def gs_energy(self,**kwargs):
+        """Return the projected ground-state energy"""
         wf = self.get_gs(**kwargs) # ground state
         return wf.dot(self.hamiltonian*wf).real # return energy
 

--- a/src/dmrgpy/manybodychain.py
+++ b/src/dmrgpy/manybodychain.py
@@ -27,6 +27,7 @@ one = np.matrix(np.identity(3))
 
 class Coupling():
   def __init__(self,i,j,g):
+    """Store a two-site coupling constant g between sites i and j"""
     self.i = i
     self.j = j
     self.g = g
@@ -36,6 +37,8 @@ class Coupling():
 
 class Many_Body_Chain():
   def __init__(self,sites,itensor_version=DEFAULT_ITENSOR_VERSION,**kwargs):
+      """Create a many-body chain over the given list of sites, and
+      initialize its DMRG/ED backend (itensor_version selects which one)"""
       self.sites = sites # list of the sites
       self.Id = self.get_operator("Id",0)
 #      self.path = id_generator() # random ID in dmrgpy_tmp
@@ -206,6 +209,8 @@ class Many_Body_Chain():
       self._reset_dmrg_state()
       self.initialize()
   def get_mode(self,**kwargs):
+      """Resolve the effective calculation mode ("DMRG" or "ED") for this
+      chain, see mode.py"""
       from .mode import get_mode
       return get_mode(self,**kwargs)
   def to_folder(self):
@@ -213,6 +218,7 @@ class Many_Body_Chain():
 #      self.inipath = os.getcwd() # record the folder
       os.chdir(self.path) # go to calculation folder
   def copy(self):
+      """Return a copy of the chain (alias for clone())"""
       return self.clone() # clone and create a new one
       from copy import deepcopy
       return deepcopy(self)
@@ -250,7 +256,9 @@ class Many_Body_Chain():
       mbc = self.clone() # clone the object
       mbc.set_hamiltonian(X) 
       return mbc.gs_energy(**kwargs)
-  def to_origin(self): 
+  def to_origin(self):
+      """Go back to the original folder, raising if the calculation
+      left an ERROR file behind"""
       if os.path.isfile(self.path+"/ERROR"): raise # something wrong
       os.chdir(self.inipath) # go to original folder
   def restart(self):
@@ -282,9 +290,12 @@ class Many_Body_Chain():
       """
       return vev.vev(self,MO,**kwargs)
   def get_gs_degeneracy(self,**kwargs):
+      """Return the degeneracy of the ground state"""
       from . import degeneracy
       return degeneracy.gs_degeneracy(self,**kwargs)
-  def vev(self,MO,mode="DMRG",**kwargs): 
+  def vev(self,MO,mode="DMRG",**kwargs):
+      """Compute the vacuum expectation value <GS|MO|GS> of an operator,
+      dispatching between DMRG and ED"""
       mode = self.get_mode(mode=mode) # overwrite mode
       if mode=="DMRG":
           if self.itensor_version in (2,3,"python"): # C++ or pure-Python version
@@ -308,7 +319,9 @@ class Many_Body_Chain():
       Compute a vacuum expectation value
       """
       return vev.excited_vev(self,MO,**kwargs)
-  def excited_vev(self,MO,**kwargs): return self.excited_vev_MB(MO,**kwargs)
+  def excited_vev(self,MO,**kwargs):
+      """Compute a vacuum expectation value using excited states"""
+      return self.excited_vev_MB(MO,**kwargs)
   def generate_bilinear(self,fun,A,B):
       """Generic bilinear term"""
       fun = funtk.obj2fun(fun) # set function
@@ -323,10 +336,14 @@ class Many_Body_Chain():
               for i in range(len(A)) for j in range(len(B)))
       return 0.5*(h + h.get_dagger()) # Hermitian
   def update_hamiltonian(self):
+      """Rebuild the Hamiltonian from the stored hopping/hubbard/pairing/
+      exchange terms"""
       h = self.hopping + self.hubbard + self.pairing
       h = h + self.exchange
       self.set_hamiltonian(h)
-  def get_dagger(self,m): return m.get_dagger() # dummy method
+  def get_dagger(self,m):
+      """Return the Hermitian conjugate of an operator"""
+      return m.get_dagger() # dummy method
   def overlap(self,wf1,wf2,**kwargs):
       """Compute the overlap"""
       return mpsalgebra.overlap(self,wf1,wf2,**kwargs)
@@ -353,8 +370,10 @@ class Many_Body_Chain():
       """Apply an operator"""
       return mpsalgebra.summps(self,wf1,wf2,**kwargs)
   def trace(self,A,**kwargs):
+      """Compute the trace of an operator"""
       return mpsalgebra.trace(self,A,**kwargs)
   def inverse_trace(self,A,**kwargs):
+      """Compute the trace of the inverse of an operator"""
       return mpsalgebra.inverse_trace(self,A,**kwargs)
   def set_pairings_MB(self,fun):
       """Generic pairing term"""
@@ -372,6 +391,7 @@ class Many_Body_Chain():
       self.hopping = h # store
       self.update_hamiltonian()
   def run(self,**kwargs):
+      """Run the calculation, dispatching through mode.py"""
       from .mode import run
       return run(self,**kwargs)
   def get_bond_entropy(self,wf,i,j):
@@ -388,25 +408,34 @@ class Many_Body_Chain():
       rest of the system"""
       return entropy.pair_entropy(self,wf,i,j)
   def get_correlation_matrix(self,**kwargs):
+      """Return the correlation matrix"""
       return entanglement.get_correlation_matrix(self,**kwargs)
   def get_correlation_eigenvalues(self,**kwargs):
+      """Return the eigenvalues of the correlation matrix"""
       return entanglement.get_correlation_eigenvalues(self,**kwargs)
   def get_correlation_entropy(self,**kwargs):
+      """Return the entanglement entropy computed from the correlation
+      matrix"""
       return entanglement.get_correlation_entropy(self,**kwargs)
   def get_correlated_orbitals(self,**kwargs):
+      """Return the correlated orbitals"""
       return entanglement.get_correlated_orbitals(self,**kwargs)
   def get_correlated_density(self,**kwargs):
+      """Return the correlated density"""
       return entanglement.get_correlated_density(self,**kwargs)
   def get_dynamical_correlator_MB(self,**kwargs):
+      """Return a dynamical correlator, computed with DMRG"""
       return dynamics.get_dynamical_correlator(self,**kwargs)
   def get_dynamical_correlator(self,mode="DMRG",**kwargs):
+      """Return a dynamical correlator, dispatching between DMRG and ED"""
       mode = self.get_mode(mode=mode) # overwrite mode
-      if mode=="DMRG": 
+      if mode=="DMRG":
           return dynamics.get_dynamical_correlator(self,**kwargs)
-      elif mode=="ED": 
+      elif mode=="ED":
           return self.get_ED_obj().get_dynamical_correlator(**kwargs)
   def get_distribution(self,mode="DMRG",**kwargs):
-      if mode=="DMRG": 
+      """Return the distribution of an operator's spectrum"""
+      if mode=="DMRG":
           from . import distribution
           return distribution.get_distribution(self,**kwargs)
      #     raise # not implemented
@@ -415,6 +444,7 @@ class Many_Body_Chain():
           return self.get_ED_obj().get_distribution(**kwargs)
       else: raise
   def get_distribution_moments(self,mode="DMRG",**kwargs):
+      """Return the moments of the distribution of an operator's spectrum"""
       if mode=="DMRG":
           from . import distribution
           return distribution.get_distribution_moments(self,**kwargs)
@@ -429,6 +459,7 @@ class Many_Body_Chain():
       elif mode=="ED": 
           return self.get_ED_obj().get_excited(**kwargs) # ED
   def get_full_matrix(self,name):
+      """Return the full matrix of a named operator, via ED"""
       return self.get_ED_obj().get_operator(name) # get the full operator
   def get_excited_states(self,mode="DMRG",**kwargs):
       """Return excitation energies"""
@@ -441,7 +472,9 @@ class Many_Body_Chain():
     """Return the gap"""
     es = self.get_excited(n=2,**kwargs)
     return es[1] -es[0]
-  def get_hamiltonian(): return self.hamiltonian
+  def get_hamiltonian():
+      """Return the Hamiltonian as a multioperator"""
+      return self.hamiltonian
   def nhdmrg(self,**kwargs):
       """Non-Hermitian DMRG (itensor_version 2, 3 or "python"): return
       (energy,psil,psir), the eigenvalue with smallest real part of the
@@ -484,6 +517,7 @@ class Many_Body_Chain():
         return self.wf0 # return wavefunction
       elif mode=="ED": return self.get_ED_obj().get_gs(**kwargs)
   def get_gs_manifold(self,**kwargs):
+      """Return the ground-state manifold"""
       return groundstate.get_gs_manifold(self,**kwargs)
   def gs_energy(self,mode="DMRG",**kwargs):
       """Return the ground state energy"""
@@ -550,7 +584,9 @@ class Many_Body_Chain():
       elif mode=="ED":
           return self.get_ED_obj().random_state()
       else: raise
-  def random_mps(self,**kwargs): return self.random_state(**kwargs)
+  def random_mps(self,**kwargs):
+      """Generate a random MPS (alias for random_state)"""
+      return self.random_state(**kwargs)
   def get_operator(self,name,i=None):
       """Return a certain multioperator"""
       from . import multioperator

--- a/src/dmrgpy/spinchain.py
+++ b/src/dmrgpy/spinchain.py
@@ -7,6 +7,7 @@ from . import multioperator
 
 class Coupling():
   def __init__(self,i,j,g):
+    """Store a two-site coupling constant g between sites i and j"""
     self.i = i
     self.j = j
     self.g = g
@@ -47,6 +48,8 @@ def get_site(label):
 class Spin_Chain(Many_Body_Chain):
     """Class for spin Hamiltonians"""
     def __init__(self,sites,**kwargs):
+        """Build a spin chain from a list of site labels (e.g. "1/2",
+        "1", "3/2", ..., see label2site)"""
         sites = [label2site[s] for s in sites]
         Many_Body_Chain.__init__(self,sites,**kwargs)
         # default exchange constants
@@ -57,8 +60,10 @@ class Spin_Chain(Many_Body_Chain):
         self.Sz = [self.get_operator("Sz",i) for i in range(self.ns)]
         self.Si = [self.Sx,self.Sy,self.Sz]
     def SS(self,i,j):
+        """Return the Heisenberg dot product S_i . S_j"""
         return self.Sx[i]*self.Sx[j] + self.Sy[i]*self.Sy[j] + self.Sz[i]*self.Sz[j]
     def set_fields(self,fun):
+        """Set the local magnetic field term of the Hamiltonian"""
         h = 0
         for i in range(self.ns):
             b = fun(i)
@@ -77,6 +82,7 @@ class Spin_Chain(Many_Body_Chain):
             if i==j: op = op - 1j*Sz[i]
             if not self.is_zero_operator(op,**kwargs): raise
     def get_logdimension(self):
+        """Return the logarithm of the Hilbert space dimension"""
         return get_logdimension(self)
     def set_exchange(self,fun):
         """Set the exchange coupling between sites"""
@@ -94,19 +100,24 @@ class Spin_Chain(Many_Body_Chain):
         self.exchange = h # exchange matrix
         self.hamiltonian = self.exchange + self.fields # update Hamiltonian
     def get_ED_obj(self):
-        if self.has_ED_obj: 
+        """Return the ED object (pychain wrapper), building it if not
+        already cached"""
+        if self.has_ED_obj:
             return self.ED_obj
         else:
             self.ED_obj = pychainwrapper.get_pychain(self)
             self.has_ED_obj = True # store
             return self.ED_obj
     def get_pychain(self):
+        """Return the underlying pychain object"""
         return pychainwrapper.get_pychain(self)
     def get_full_hamiltonian(self):
         """Return the full Hamiltonian"""
         from . import pychainwrapper
         return pychainwrapper.get_full_hamiltonian(self)
     def get_magnetization(self,**kwargs):
+        """Return the magnetization on each site, and save it to
+        MAGNETIZATION.OUT"""
         mx = [self.vev(self.Sx[i],**kwargs) for i in range(self.ns)]
         my = [self.vev(self.Sy[i],**kwargs) for i in range(self.ns)]
         mz = [self.vev(self.Sz[i],**kwargs) for i in range(self.ns)]


### PR DESCRIPTION
## Summary
- Add a docstring to every bound method (and `__init__`/`Coupling`) in `manybodychain.py`, `fermionchain.py`, and `spinchain.py` that was missing one, including subclasses defined in those files (`Spinful_Fermionic_Chain`, `Spinon_Chain`).
- No behavior changes — docstrings only.

## Test plan
- [x] `python3 -m py_compile` on all three edited files
- [x] `pytest tests/test_spin_chain.py tests/test_fermion_chain.py` passes
- [x] Verified via AST walk that no class method in the three files lacks a docstring

https://claude.ai/code/session_01KoVSZ9iq3YDVNtZmxWdw1j