### PR TITLE
Warn on non-converged DMRG excited states via energy fluctuation

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -166,6 +166,20 @@ orthogonalized subspace spanned by the raw excited-state MPS, correcting
 for near-degenerate states that DMRG's iterative solvers can otherwise
 mix.
 
+Excited states beyond the ground state are found with an overlap-penalty
+method (each state is optimized against $H+w\sum_k|\psi_k\rangle\langle\psi_k|$
+for the states already found), which can occasionally converge to a
+spurious, non-eigenstate stationary point instead of the true excited
+state (`itensor_version` 2, 3, and `"python"` are all susceptible). Every
+call to `get_excited_states`/`get_excited` on a DMRG backend checks each
+returned state's energy fluctuation $\langle H^2\rangle-\langle
+H\rangle^2$ against the ground state's own (both already computed as a
+byproduct of the search) and emits a `UserWarning` if a state's
+fluctuation is far above that reference — a cheap, always-on sanity check,
+though not a fix; a warned-about state's energy and wavefunction should
+be treated with caution (e.g. cross-checked against `mode="ED"` on a
+smaller system, or recomputed with a larger `scale`/more sweeps).
+
 **Sector (charge) gaps.** For a conserved quantity $A$ with $[H,A]=0$
 (e.g. total particle number $\hat N=\sum_i n_i$, or total $S^z$), the gap
 to the lowest state with $\langle A\rangle$ shifted by $d$ from the

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -217,6 +217,21 @@ Gram-Schmidt orthogonalized subspace spanned by the raw excited-state
 MPS, correcting for near-degenerate states that DMRG's iterative solvers
 can otherwise mix.
 
+Excited states beyond the ground state are found with an overlap-penalty
+method (each state is optimized against $H+w\sum_k|\psi_k\rangle\langle\psi_k|$
+for the states already found), which can occasionally converge to a
+spurious, non-eigenstate stationary point instead of the true excited
+state (\texttt{itensor\_version} 2, 3, and \texttt{"python"} are all
+susceptible). Every call to \texttt{get\_excited\_states}/\texttt{get\_excited}
+on a DMRG backend checks each returned state's energy fluctuation
+$\langle H^2\rangle-\langle H\rangle^2$ against the ground state's own
+(both already computed as a byproduct of the search) and emits a
+\texttt{UserWarning} if a state's fluctuation is far above that
+reference --- a cheap, always-on sanity check, though not a fix; a
+warned-about state's energy and wavefunction should be treated with
+caution (e.g.\ cross-checked against \texttt{mode="ED"} on a smaller
+system, or recomputed with a larger \texttt{scale}/more sweeps).
+
 \textbf{Sector (charge) gaps.} For a conserved quantity $A$ with
 $[H,A]=0$ (e.g.\ total particle number $\hat N=\sum_i n_i$, or total
 $S^z$), the gap to the lowest state with $\langle A\rangle$ shifted by

--- a/src/dmrgpy/excited.py
+++ b/src/dmrgpy/excited.py
@@ -1,5 +1,34 @@
+import warnings
 import numpy as np
 from . import mps
+
+
+def _warn_unconverged_excited_states(energies,fluctuations,factor=100.0,floor=1e-8):
+    """fluctuations[i] is <H^2>-<H>^2 for the i-th returned state
+    (mpscpp2/mpscpp3's Chain::excited_states and pyitensor's
+    Chain.excited_states both compute this for every state already, at no
+    extra cost -- it was simply discarded by the caller until now).
+    fluctuations[0] is the plain, unpenalized ground state's own
+    fluctuation: a reliable per-Hamiltonian reference for how tight DMRG
+    can make a genuine eigenstate at the current maxm/cutoff/nsweeps.
+    States i>0 come from the overlap-penalty method instead, which has a
+    confirmed failure mode (pyitensor/dmrg.py's dmrg_excited docstring:
+    the penalized local solve can settle into a spurious, wrong-energy
+    stationary point that more sweeps/weight cannot fix) that the plain
+    ground-state solve doesn't share -- so a fluctuation many times above
+    that reference is a cheap, already-computed sign a state is not a
+    clean eigenstate, worth surfacing even though nothing here can fix it
+    automatically."""
+    ref = max(fluctuations[0],floor)
+    for i,f in enumerate(fluctuations):
+        if f>factor*ref:
+            warnings.warn(
+                "excited_states: state {} (E={:.6g}) has energy "
+                "fluctuation <H^2>-<H>^2 = {:.3g}, {:.1f}x the ground "
+                "state's ({:.3g}) -- this excited state may not have "
+                "converged to a genuine eigenstate; treat its energy "
+                "and wavefunction with caution".format(
+                    i,energies[i],f,f/ref,ref))
 
 
 def get_excited_states_dmrg(self,n=2,noise=0.0,scale=10.0):
@@ -21,6 +50,7 @@ def get_excited_states_dmrg(self,n=2,noise=0.0,scale=10.0):
     self._session.set_mpomaxm(max(self.maxm,self.mpomaxm))
     energies,fluctuations,handles = self._session.excited_states(
             n,scale,self.excited_gram_schmidt)
+    _warn_unconverged_excited_states(energies,fluctuations)
     wfs = [mps.MPS(MBO=self,cpp_handle=h).copy() for h in handles]
     return np.array(energies),wfs
 


### PR DESCRIPTION
## Summary
- The v3/v2 C++ backends (`Chain::excited_states`) and the pure-Python `pyitensor` backend already compute each returned excited state's energy fluctuation `<H^2>-<H>^2`, but `excited.py` discarded it after unpacking.
- The overlap-penalty method used for states beyond the ground state has a confirmed failure mode (documented in `pyitensor/dmrg.py`'s `dmrg_excited` docstring): it can settle into a spurious, wrong-energy stationary point that more sweeps/weight don't always fix.
- This adds a cheap, always-on check: compare each state's fluctuation against the ground state's own (trustworthy, unpenalized) fluctuation, and emit a `UserWarning` when a state looks unconverged. No new DMRG calls, no C++/bindings changes — reuses data already computed by every backend.
- Verified against a real reproduction: on the pure-Python backend, the known-flaky 4-site Heisenberg triplet case (see `tests/test_dynamical_correlator.py`'s documented ~10-30% flake rate) now reliably emits warnings on the bad runs instead of silently returning energies off by up to 0.02.
- Documented the new behavior in `docs/user_guide.md`/`.tex` (§4, next to the `purify=True` explanation); verified the `.tex` still compiles cleanly.

## Test plan
- [x] `pytest tests/test_excited_states.py tests/test_julia_live.py` — pass
- [x] `pytest tests -q` — same 9 pre-existing failures as on `master` in this sandbox (all from running without a compiled C++ extension: ED-fallback gaps in `edtk/dynamics.py`'s TDZ submode and `Mixed_Spin_Fermion_Chain`, unrelated to this change — confirmed via isolated traceback)
- [x] Manual check: `itensor_version="python"` on the 4-site Heisenberg triplet correctly emits `UserWarning`s for badly-converged raw excited states
- [x] `pdflatex docs/user_guide.tex` compiles with no new overfull-hbox warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)