### PR TITLE
Give Bosonic_Chain a real, configurable per-site dimension on v3 and pyitensor

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -136,7 +136,7 @@ for that statistics:
 | `spinchain.py` | `Spin_Chain` | alias of `Many_Body_Chain` itself |
 | `fermionchain.py` | `Fermionic_Chain` | spinless fermions; `C`/`Cdag`/`N`, Jordan-Wigner string `F` |
 | `spinfermionchain.py` | `Spin_Fermionic_Chain` | spinful fermions |
-| `bosonchain.py` | `Boson_Chain` | bosonic sites |
+| `bosonchain.py` | `Bosonic_Chain` | bosonic sites |
 | `parafermionchain.py` | `Parafermion_Chain` | parafermion sites |
 | `mixedchain.py` | `Mixed_Spin_Fermion_Chain` | mixes spin sites and spinful-fermion locations in one chain |
 
@@ -180,6 +180,29 @@ implement site-type code 1. See `fermionchain.py`'s class docstring for
 why this alternative isn't a general-purpose speedup over
 `Spinful_Fermionic_Chain` despite the halved site count (a directly
 measured result, not a theoretical claim).
+
+`bosonchain.Bosonic_Chain` uses a *range* of type codes rather than a
+single one: `100+dim` per site, `dim` being the requested local Hilbert
+space dimension (`Bosonic_Chain(n, maxnb=[...])`, default `dim=4`, i.e.
+code `104`). This lets `mpscpp3/get_sites.h`'s `BosonFourSite`
+(`extra/bosonfour.h`, generalized from a hardcoded 4-level site to an
+`Args("MaxOcc",...)`-driven arbitrary occupation cutoff) build a site of
+the actual requested dimension instead of always the fixed 4-level one
+regardless of `maxnb` — previously a real, silent bug: the DMRG session
+only ever saw type code `104` no matter what `maxnb` was, so DMRG and ED
+results silently diverged for any non-default value. `itensor_version=3`
+and `itensor_version="python"` both understand the extended `102..199`
+range today — pyitensor's `siteset.py::_site_class()` routes it to
+`sites/boson.py::get_boson_site(dim)`, a small factory that builds (and
+caches) a `SiteType` subclass per requested dimension the same way
+`BosonFourSite` is generalized on the C++ side, since pyitensor's
+`SiteType` machinery is otherwise entirely class-level (no per-instance
+state) and has no other way to parameterize a site's dimension.
+`mpscpp2` and `mpsjulialive` still only handle the single code `104`, so
+a non-default `maxnb` should be run under `itensor_version=3` (the
+default) or `"python"` for cross-backend agreement. ED
+(`pyboson/boson.py::BosonChain`) always builds the exact requested
+per-site dimension regardless of backend.
 
 ### 4.2 Operator representation: `MultiOperator`
 

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -186,7 +186,7 @@ Module & Class & Notes \\
 \texttt{spinchain.py} & \texttt{Spin\_Chain} & alias of \texttt{Many\_Body\_Chain} itself \\
 \texttt{fermionchain.py} & \texttt{Fermionic\_Chain} & spinless fermions; C/Cdag/N, JW string F \\
 \texttt{spinfermionchain.py} & \texttt{Spin\_Fermionic\_Chain} & spinful fermions \\
-\texttt{bosonchain.py} & \texttt{Boson\_Chain} & bosonic sites \\
+\texttt{bosonchain.py} & \texttt{Bosonic\_Chain} & bosonic sites \\
 \texttt{parafermionchain.py} & \texttt{Parafermion\_Chain} & parafermion sites \\
 \texttt{mixedchain.py} & \texttt{Mixed\_Spin\_\allowbreak Fermion\_Chain} & spin \& spinful-fermion mix \\
 \bottomrule
@@ -242,6 +242,34 @@ See \texttt{fermionchain.py}'s class docstring for why this alternative
 is not a general-purpose speedup over \texttt{Spinful\_Fermionic\_Chain}
 despite the halved site count (a directly measured result, not a
 theoretical claim).
+
+\texttt{bosonchain.Bosonic\_Chain} uses a \emph{range} of type codes
+rather than a single one: $100+\text{dim}$ per site, dim being the
+requested local Hilbert space dimension
+(\texttt{Bosonic\_Chain(n, maxnb=[\ldots])}, default $\text{dim}=4$,
+i.e.\ code 104). This lets \texttt{mpscpp3/get\_sites.h}'s
+\texttt{BosonFourSite} (\texttt{extra/bosonfour.h}, generalized from a
+hardcoded 4-level site to an \texttt{Args("MaxOcc",\ldots)}-driven
+arbitrary occupation cutoff) build a site of the actual requested
+dimension instead of always the fixed 4-level one regardless of
+\texttt{maxnb} --- previously a real, silent bug: the DMRG session only
+ever saw type code 104 no matter what \texttt{maxnb} was, so DMRG and ED
+results silently diverged for any non-default value.
+\texttt{itensor\_version=3} and \texttt{itensor\_version="python"} both
+understand the extended $102..199$ range today --- pyitensor's
+\texttt{siteset.py::\_site\_class()} routes it to
+\texttt{sites/boson.py::get\_boson\_site(dim)}, a small factory that
+builds (and caches) a \texttt{SiteType} subclass per requested dimension
+the same way \texttt{BosonFourSite} is generalized on the C++ side,
+since pyitensor's \texttt{SiteType} machinery is otherwise entirely
+class-level (no per-instance state) and has no other way to
+parameterize a site's dimension. \texttt{mpscpp2} and
+\texttt{mpsjulialive} still only handle the single code 104, so a
+non-default \texttt{maxnb} should be run under
+\texttt{itensor\_version=3} (the default) or \texttt{"python"} for
+cross-backend agreement. ED (\texttt{pyboson/boson.py::BosonChain})
+always builds the exact requested per-site dimension regardless of
+backend.
 
 \subsection{Operator representation: \texttt{MultiOperator}}
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -40,7 +40,7 @@ Every model is a chain of $n$ local Hilbert spaces $\mathcal H=\bigotimes_{i=1}^
 | `fermionchain.Majorana_Chain` | Majorana fermion | Majorana operators built from `Fermionic_Chain` |
 | `fermionchain.Spinful_Fermionic_Chain` | spin-$\tfrac12$ fermion (4 states: $0,\uparrow,\downarrow,\uparrow\downarrow$), built from two interleaved spinless sites per physical site | $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$, plus derived $S^x_i,S^y_i,S^z_i=\tfrac12(n_{i\uparrow}-n_{i\downarrow})$, onsite pairing $\Delta_i=\tfrac12 c_{i\uparrow}c_{i\downarrow}$ |
 | `fermionchain.Spinful_Fermionic_Chain_Native` | same physics as `Spinful_Fermionic_Chain`, but on a genuinely 4-dimensional local space (one tensor-network site per physical site, `itensor_version=3` only) | identical operator lists/formulas as `Spinful_Fermionic_Chain` |
-| `bosonchain.Bosonic_Chain` | truncated boson Fock space, $n_i\in\{0,\ldots,n_{\max}\}$ (default $n_{\max}=4$) | $a_i,a_i^\dagger,n_i$, occupation projectors $\hat n_i^{(k)}=\lvert k\rangle\langle k\rvert$ |
+| `bosonchain.Bosonic_Chain` | truncated boson Fock space, $n_i\in\{0,\ldots,\text{maxnb}_i-1\}$, per-site dimension `maxnb` (default 4, i.e. up to 3 bosons/site) settable via `Bosonic_Chain(n, maxnb=[...])` | $a_i,a_i^\dagger,n_i$, occupation projectors $\hat n_i^{(k)}=\lvert k\rangle\langle k\rvert$ for $k=0,\ldots,\text{maxnb}_i-1$ (`bc.D[i][k]`, plus `bc.D0`..`bc.D3` when every site has `maxnb`$\,\ge 4$) |
 | `parafermionchain.Parafermionic_Chain` | $\mathbb Z_N$ parafermion (clock model), $N\in\{2,3,4\}$ | clock/shift operators $\sigma_i,\tau_i$ and composite parafermion operators $\chi_i,\psi_i$ built as $\tau$-string $\times\sigma_i$ |
 | `mixedchain.Mixed_Spin_Fermion_Chain` | mixes genuine spin-$S$ sites and spinful-fermion locations *in the same chain*, one entry per logical location | at a spin location: native $S^x_i,S^y_i,S^z_i$; at a fermion location: $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$ plus derived $S^x_i,S^y_i,S^z_i,\Delta_i$ as in `Spinful_Fermionic_Chain` |
 
@@ -104,6 +104,19 @@ meaning there. Currently only `itensor_version=3` (and `"python"`) are
 supported; see `mixedchain.py`'s module docstring for why
 `itensor_version=2` isn't yet, and `examples/mixed_spin_fermion_chain`
 for a worked Kondo-lattice example.
+
+`Bosonic_Chain(n, maxnb=[...])` takes a per-site local dimension list
+(defaulting to `[4]*n`, i.e. up to 3 bosons/site); ED always honors it
+exactly (`pyboson/boson.py`). On the DMRG side, `itensor_version=3` and
+`itensor_version="python"` both thread a non-default `maxnb` through to
+the tensor-network site itself (encoded as the site type code
+$100+\text{maxnb}_i$, see `mpscpp3/get_sites.h`/`extra/bosonfour.h` and,
+on the pure-Python side, `pyitensor/sites/boson.py`'s `get_boson_site()`
+factory) — `itensor_version=2` and the Julia backend still only
+understand the single fixed 4-level boson site regardless of what
+`maxnb` requests, so a non-default `maxnb` should be run under
+`itensor_version=3` (the default) or `"python"` for DMRG/ED results to
+actually agree; see `examples/boson_maxnb_v3_VS_ED`.
 
 ## 2. Building a Hamiltonian and observables
 

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -61,7 +61,7 @@ Chain class & Local Hilbert space & Key operators \\
 \texttt{fermionchain.\allowbreak Majorana\_Chain} & Majorana fermion & Majorana operators built from \texttt{Fermionic\_Chain} \\
 \texttt{fermionchain.\allowbreak Spinful\_\allowbreak Fermionic\_Chain} & spin-$\tfrac12$ fermion (4 states), two interleaved spinless sites per physical site & $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$; derived spin and pairing operators (see text) \\
 \texttt{fermionchain.\allowbreak Spinful\_\allowbreak Fermionic\_\allowbreak Chain\_\allowbreak Native} & same physics, genuinely 4-dimensional local space, one site per physical site (\texttt{itensor\_version=3} only) & identical operator lists/formulas as \texttt{Spinful\_Fermionic\_Chain} \\
-\texttt{bosonchain.\allowbreak Bosonic\_Chain} & truncated boson Fock space, $n_i\le n_{\max}$ (default 4) & $a_i,a_i^\dagger,n_i$, occupation projectors \\
+\texttt{bosonchain.\allowbreak Bosonic\_Chain} & truncated boson Fock space, $n_i\in\{0,\ldots,\text{maxnb}_i-1\}$, per-site dimension \texttt{maxnb} (default 4) settable via \texttt{Bosonic\_Chain(n,\allowbreak maxnb=[\ldots])} & $a_i,a_i^\dagger,n_i$, occupation projectors $\hat n_i^{(k)}$ for $k=0,\ldots,\text{maxnb}_i-1$ \\
 \texttt{parafermionchain.\allowbreak Parafermionic\_\allowbreak Chain} & $\mathbb Z_N$ parafermion (clock model), $N\in\{2,3,4\}$ & clock/shift operators $\sigma_i,\tau_i$, composite $\chi_i,\psi_i$ \\
 \texttt{mixedchain.\allowbreak Mixed\_Spin\_\allowbreak Fermion\_Chain} & mixes spin-$S$ sites and spinful-fermion locations in the same chain & spin location: native $S^x_i,S^y_i,S^z_i$; fermion location: $c_{i\sigma},c^\dagger_{i\sigma},n_{i\sigma}$ plus derived spin/pairing operators \\
 \bottomrule
@@ -135,6 +135,21 @@ supported; see \texttt{mixedchain.py}'s module docstring for why
 \texttt{itensor\_version=2} isn't yet, and
 \texttt{examples/mixed\_spin\_fermion\_chain} for a worked Kondo-lattice
 example.
+
+\texttt{Bosonic\_Chain(n, maxnb=[\ldots])} takes a per-site local
+dimension list (defaulting to \texttt{[4]*n}, i.e.\ up to 3 bosons/site);
+ED always honors it exactly (\texttt{pyboson/boson.py}). On the DMRG
+side, \texttt{itensor\_version=3} and \texttt{itensor\_version="python"}
+both thread a non-default \texttt{maxnb} through to the tensor-network
+site itself (encoded as the site type code $100+\text{maxnb}_i$, see
+\texttt{mpscpp3/get\_sites.h}/\texttt{extra/bosonfour.h} and, on the
+pure-Python side, \texttt{pyitensor/sites/boson.py}'s
+\texttt{get\_boson\_site()} factory) -- \texttt{itensor\_version=2} and
+the Julia backend still only understand the single fixed 4-level boson
+site regardless of what \texttt{maxnb} requests, so a non-default
+\texttt{maxnb} should be run under \texttt{itensor\_version=3} (the
+default) or \texttt{"python"} for DMRG/ED results to actually agree;
+see \texttt{examples/boson\_maxnb\_v3\_VS\_ED}.
 
 \section{Building a Hamiltonian and observables}
 

--- a/examples/boson_maxnb_v3_VS_ED/main.py
+++ b/examples/boson_maxnb_v3_VS_ED/main.py
@@ -1,0 +1,50 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
+
+# Regression test: ITensor v3 and the pure-Python backend must both honor
+# a non-default, per-site Bosonic_Chain(maxnb=...) instead of silently
+# truncating every site to the fixed 4-level BosonFourSite regardless of
+# what was requested (a real, previously-silent DMRG/ED mismatch -- see
+# mpscpp3/get_sites.h's 100+dim boson type-code range and
+# extra/bosonfour.h's MaxOcc-driven site, mirrored on the pyitensor side
+# by pyitensor/sites/boson.py's get_boson_site() factory). Only v3,
+# python, and ED are compared here: v2 still only understands the single
+# fixed-dim-4 boson type code (104), so it's out of scope for this test
+# -- see examples/v2_VS_v3_boson for the default-dim=4 cross-backend
+# comparison that still covers all four backends including v2.
+import numpy as np
+from dmrgpy import bosonchain
+
+n = 3
+maxnb = [3,5,3] # heterogeneous, non-default per-site dimension
+
+def get_energy(itensor_version, mode="DMRG"):
+    bc = bosonchain.Bosonic_Chain(n,maxnb=maxnb)
+    if itensor_version!="python": bc.setup_cpp(itensor_version)
+    else: bc.setup_python()
+    bc.maxm = 120
+    bc.nsweeps = 50
+    np.random.seed(11)
+    h = 0
+    for i in range(n-1):
+        h = h + np.random.random()*(bc.Adag[i]*bc.A[i+1] + bc.Adag[i+1]*bc.A[i])
+    for i in range(n):
+        h = h + 0.7*bc.N[i]*(bc.N[i]-1.0)
+    bc.set_hamiltonian(h)
+    return bc.gs_energy(mode=mode)
+
+e3 = get_energy(3)
+epy = get_energy("python")
+eed = get_energy(3, mode="ED")
+
+print("Ground state energy (ITensor v3,   maxnb=%s) ="%maxnb,e3)
+print("Ground state energy (pure Python,  maxnb=%s) ="%maxnb,epy)
+print("Ground state energy (ED,           maxnb=%s) ="%maxnb,eed)
+
+tol = 1e-3
+for name,e in [("python",epy),("ED",eed)]:
+    diff = abs(e3-e)
+    print("Difference v3 vs %s = %.2e"%(name,diff))
+    assert diff<tol, "v3 vs %s disagree by %g (tol=%g)"%(name,diff,tol)
+
+print("TEST PASSED")

--- a/examples/bosonic_hubbard/main.py
+++ b/examples/bosonic_hubbard/main.py
@@ -2,11 +2,9 @@
 import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
 
 import numpy as np
-import matplotlib.pyplot as plt
 from dmrgpy import bosonchain
-from dmrgpy import multioperator
 n = 3
-bc = bosonchain.Bosonic_Hamiltonian(n) # create the chain
+bc = bosonchain.Bosonic_Chain(n) # create the chain
 
 h = 0 # initialize
 for i in range(n-1): # hopping
@@ -20,7 +18,7 @@ for i in range(n): # hopping
 bc.set_hamiltonian(h) # setup hamiltonian
 print(bc.gs_energy(mode="ED"))
 
-ds = [bc.vev(bc.get_operator("density",i),mode="ED").real for i in range(n)]
+ds = [bc.vev(bc.get_operator("N",i),mode="ED").real for i in range(n)]
 print(ds)
 
 

--- a/src/dmrgpy/bosonchain.py
+++ b/src/dmrgpy/bosonchain.py
@@ -9,16 +9,38 @@ class Bosonic_Chain(Many_Body_Chain):
     """Bosonic Hamiltonian"""
     def __init__(self,n,maxnb=None):
         if maxnb is None: maxnb = [4 for i in range(n)] # maximum # of bosons
-        self.maxnb = maxnb # maximum number of bosons
-        Many_Body_Chain.__init__(self,[104 for i in range(n)])
+        elif len(maxnb)!=n:
+            raise ValueError("maxnb has length %d, but n=%d sites were requested"%(len(maxnb),n))
+        self.maxnb = maxnb # local Hilbert space dimension of each site
+        # Boson type codes are 100+dim (see mpscpp3/get_sites.h), so the
+        # DMRG session actually gets a site of the requested dimension
+        # instead of always the fixed 4-level BosonFourSite -- v3 only,
+        # mpscpp2/pyitensor/julia still only understand the plain 104
+        # code (dim 4) regardless of maxnb, see docs/user_guide.md.
+        Many_Body_Chain.__init__(self,[100+m for m in maxnb])
         self.use_ampo_hamiltonian = True # use ampo
         self.N = [self.get_operator("N",i) for i in range(self.ns)]
-        self.D0 = [self.get_operator("N0",i) for i in range(self.ns)]
-        self.D1 = [self.get_operator("N1",i) for i in range(self.ns)]
-        self.D2 = [self.get_operator("N2",i) for i in range(self.ns)]
-        self.D3 = [self.get_operator("N3",i) for i in range(self.ns)]
         self.A = [self.get_operator("A",i) for i in range(self.ns)]
         self.Adag = [self.get_operator("Adag",i) for i in range(self.ns)]
+        # occupation-number projectors N0..N{maxnb[i]-1}, per site
+        self.D = [[self.get_operator("N"+str(k),i) for k in range(self.maxnb[i])]
+                   for i in range(self.ns)]
+        # D0..D3 convenience aliases, kept for backwards compatibility,
+        # only defined when every site actually has >=4 levels
+        if all(m>=4 for m in self.maxnb):
+            self.D0 = [self.D[i][0] for i in range(self.ns)]
+            self.D1 = [self.D[i][1] for i in range(self.ns)]
+            self.D2 = [self.D[i][2] for i in range(self.ns)]
+            self.D3 = [self.D[i][3] for i in range(self.ns)]
+    def get_density(self,**kwargs):
+        """Return the average boson occupation in each site"""
+        out = [self.vev(self.N[i],**kwargs) for i in range(self.ns)]
+        return np.array(out).real
+    def get_density_fluctuation(self,**kwargs):
+        """Return the occupation-number fluctuations <N^2>-<N>^2 in each site"""
+        d = self.get_density(**kwargs) # get the density
+        d2 = np.array([self.vev(self.N[i]*self.N[i],**kwargs) for i in range(self.ns)])
+        return d2.real-d**2
     def get_ED_obj(self):
         """Return the associated ED object"""
         if not self.has_ED_obj: # not computed

--- a/src/dmrgpy/mpscpp3/extra/bosonfour.h
+++ b/src/dmrgpy/mpscpp3/extra/bosonfour.h
@@ -2,9 +2,24 @@
 #ifndef __ITENSOR_BOSONFOUR_H
 #define __ITENSOR_BOSONFOUR_H
 #include "itensor/mps/siteset.h"
+#include <algorithm>
+#include <cctype>
+#include <string>
 
 // Port of mpscpp2/extra/bosonfour.h to the ITensor v3 API, see
 // spinthreehalf.h in this directory for the general porting notes.
+//
+// Generalized (v3 only, not ported back to mpscpp2) from a fixed 4-level
+// site to an arbitrary occupation cutoff, driven by the "MaxOcc" Args key
+// (dimension = MaxOcc+1, defaulting to 3 i.e. the original 4-level site)
+// -- see get_sites.h's boson type-code range (100+dim, 102..199) for how a
+// dmrgpy-level Bosonic_Chain(maxnb=...) selects MaxOcc. Operator names N,
+// A, Adag, and the occupation-projectors N0..N{MaxOcc} generalize the
+// original hardcoded N0..N3 the same way pyboson/boson.py's ED BosonChain
+// already did (that side was always dimension-generic, see its own
+// per-site "maxnb" loop) -- this brings the DMRG side to the same
+// generality instead of silently truncating to dim 4 regardless of the
+// Python-level maxnb (a real, previously-silent DMRG/ED mismatch bug).
 
 namespace itensor {
 
@@ -34,46 +49,45 @@ class BosonFourSite
 
     BosonFourSite(int n, Args const& args = Args::global())
 		{
-        auto ts = TagSet("Site,Boson=4,n="+str(n));
+        auto maxOcc = args.getInt("MaxOcc",3); // dimension = maxOcc+1, default 4-level site
+        auto dim = maxOcc+1;
+        auto ts = TagSet("Site,Boson="+str(dim)+",n="+str(n));
         if(args.getBool("ConserveQNs",true))
             {
-            s = Index(QN({"Sz",+3}),1,
-                      QN({"Sz",+1}),1,
-                      QN({"Sz",-1}),1,
-                      QN({"Sz",-3}),1,Out,ts);
+            auto qints = Index::qnstorage(dim);
+            for(int occ : range(dim)) qints[occ] = QNInt(QN({"Nb",occ}),1);
+            s = Index(std::move(qints),Out,ts);
             }
         else
             {
-            s = Index(4,ts);
+            s = Index(dim,ts);
             }
 		}
 
     Index
     index() const { return s; }
 
+    // Plain occupation-number strings ("0".."MaxOcc") only. The original
+    // fixed-dim=4 site additionally accepted "Up"/"Upi"/"Dni"/"Dn" and
+    // read its numeric strings ("3","1","-1","-3") as *Sz labels* from
+    // its old fixed QN scheme (matching the +3,+1,-1,-3 Sz values that
+    // scheme's QN block used, i.e. inverted relative to occupation
+    // number: old "3" meant occupation 0, not 3) -- not carried forward
+    // here since MaxOcc is now arbitrary and that convention doesn't
+    // generalize. No caller in this codebase currently invokes
+    // state() for a boson site (dmrg()'s default_mps() always starts
+    // from randomMPS, never InitState), so this is a behavior change
+    // with no live effect today, not a regression -- flagged here for
+    // whoever adds the first real caller.
     IndexVal
     state(std::string const& state)
 		{
-        if (state == "Up" || state == "3")
+        auto maxOcc = dim(s)-1;
+        for(auto occ : range(1+maxOcc))
             {
-            return s(1);
+            if(state == str(occ)) return s(1+occ);
             }
-        else if (state == "Upi" || state == "1")
-            {
-            return s(2);
-            }
-        else if (state == "Dni" || state == "-1")
-            {
-            return s(3);
-            }
-        else if (state == "Dn" || state == "-3")
-            {
-            return s(4);
-            }
-        else
-            {
-            throw ITError("State " + state + " not recognized");
-            }
+        throw ITError("State " + state + " not recognized");
         return IndexVal{};
 		}
 
@@ -81,57 +95,32 @@ class BosonFourSite
     op(std::string const& opname,
        Args const& args) const
 		{
-
-	const Real val1 = std::sqrt(1.0);
-	const Real val2 = std::sqrt(2.0);
-	const Real val3 = std::sqrt(3.0);
         auto sP = prime(s);
-
-        auto A0  = s(1);
-        auto A0P = sP(1);
-        auto A1  = s(2);
-        auto A1P = sP(2);
-        auto A2  = s(3);
-        auto A2P = sP(3);
-        auto A3  = s(4);
-        auto A3P = sP(4);
+        auto maxOcc = dim(s)-1;
 
         auto Op = ITensor(dag(s),sP);
 
         if (opname == "N")
             {
-            Op.set(A0,A0P,+0.0);
-            Op.set(A1,A1P,+1.0);
-            Op.set(A2,A2P,+2.0);
-            Op.set(A3,A3P,+3.0);
-            }
-        else if (opname == "N0")
-            {
-            Op.set(A0,A0P,+1.0);
-            }
-        else if (opname == "N1")
-            {
-            Op.set(A1,A1P,+1.0);
-            }
-        else if (opname == "N2")
-            {
-            Op.set(A2,A2P,+1.0);
-            }
-        else if (opname == "N3")
-            {
-            Op.set(A3,A3P,+1.0);
+            for(auto occ : range1(1+maxOcc)) Op.set(s=occ,sP=occ,occ-1);
             }
         else if (opname == "Adag")
             {
-            Op.set(A0,A1P,val1);
-            Op.set(A1,A2P,val2);
-            Op.set(A2,A3P,val3);
+            for(auto occ : range1(maxOcc)) Op.set(s=occ,sP=occ+1,std::sqrt((Real)occ));
             }
         else if (opname == "A")
             {
-            Op.set(A1,A0P,val1);
-            Op.set(A2,A1P,val2);
-            Op.set(A3,A2P,val3);
+            for(auto occ : range1(maxOcc)) Op.set(s=occ+1,sP=occ,std::sqrt((Real)occ));
+            }
+        else if (opname.size()>1 && opname[0]=='N' &&
+                 std::all_of(opname.begin()+1,opname.end(),::isdigit))
+            {
+            // occupation-number projector N<k>, k=0..maxOcc (generalizes
+            // the original hardcoded N0..N3)
+            auto level = std::stoi(opname.substr(1));
+            if(level<0 || level>maxOcc)
+                throw ITError("Operator " + opname + " out of range for this site's MaxOcc");
+            Op.set(s=level+1,sP=level+1,+1.0);
             }
         else
             {
@@ -152,7 +141,7 @@ BosonFour(int N,
 
     for(int j = start; j < N; ++j)
         {
-        sites.set(j,BosonFourSite(j));
+        sites.set(j,BosonFourSite(j,args));
         }
 
     SiteSet::init(std::move(sites));

--- a/src/dmrgpy/mpscpp3/get_sites.h
+++ b/src/dmrgpy/mpscpp3/get_sites.h
@@ -3,7 +3,15 @@
 // Site-type code convention is unchanged from v2 (see chain_session.h's
 // Chain constructor / manybodychain.py's callers): 2=spin-1/2, 0=spinless
 // fermion, 1=spinful fermion (Hubbard), 3=spin-1, 4=spin-3/2, 5=spin-2,
-// 6=spin-5/2, 104=Boson (4 levels), -2=Z3, -3=Z4.
+// 6=spin-5/2, -2=Z3, -3=Z4. Boson is a *range* of codes, 102..199,
+// v3-only (mpscpp2/pyitensor still only understand the single 104 code):
+// code = 100+dim, dim being the local Hilbert space dimension (dmrgpy's
+// own "maxnb" convention, see bosonchain.py's Bosonic_Chain) so 104 is
+// the original fixed 4-level site and e.g. 108 is an 8-level site. This
+// generalizes BosonFourSite's fixed dim=4 to an arbitrary MaxOcc=dim-1
+// (see extra/bosonfour.h) so DMRG can actually honor a non-default
+// maxnb instead of silently truncating to dim 4 regardless of what the
+// Python layer requested.
 //
 // Class-name changes vs v2: SpinlessSite/HubbardSite are v3's own
 // deprecated-but-supported aliases for FermionSite/ElectronSite (same
@@ -82,7 +90,7 @@ read(std::istream& s)
             else if(nm == 6) store.set(j,SpinFiveHalfSite(I));
             else if(nm == -2) store.set(j,Z3Site(I));
             else if(nm == -3) store.set(j,Z4Site(I));
-            else if(nm == 104) store.set(j,BosonFourSite(I));
+            else if(nm > 100 && nm < 200) store.set(j,BosonFourSite(I)); // dim baked into serialized Index I
             else Error(tinyformat::format("SpinX cannot read index of size %d",nm));
             }
 	sfile.close() ;
@@ -116,7 +124,7 @@ SpinX(Args const& args)
       else if (nm==4) sites.set(i,SpinThreeHalfSite(i,{"ConserveQNs",false})); // use spin=3/2
       else if (nm==5) sites.set(i,SpinTwoSite({"SiteNumber=",i,"ConserveQNs=",false})); // use spin=2
       else if (nm==6) sites.set(i,SpinFiveHalfSite(i,{"ConserveQNs",false})); // use spin=5/2
-      else if (nm==104) sites.set(i,BosonFourSite(i,{"ConserveQNs",false})); // use Boson
+      else if (nm>100 && nm<200) sites.set(i,BosonFourSite(i,{"ConserveQNs",false,"MaxOcc",nm-101})); // Boson, dim=nm-100
       else if (nm==(-2)) sites.set(i,Z3Site({"SiteNumber=",i,"ConserveQNs=",false})); // use Z3
       else if (nm==(-3)) sites.set(i,Z4Site(i,{"ConserveQNs",false})); // use Z4
       else Error(tinyformat::format("SpinX cannot read index of size "));
@@ -141,7 +149,7 @@ SpinX(std::vector<int> const& site_types)
       else if (nm==4) sites.set(i,SpinThreeHalfSite(i,{"ConserveQNs",false})); // use spin=3/2
       else if (nm==5) sites.set(i,SpinTwoSite({"SiteNumber=",i,"ConserveQNs=",false})); // use spin=2
       else if (nm==6) sites.set(i,SpinFiveHalfSite(i,{"ConserveQNs",false})); // use spin=5/2
-      else if (nm==104) sites.set(i,BosonFourSite(i,{"ConserveQNs",false})); // use Boson
+      else if (nm>100 && nm<200) sites.set(i,BosonFourSite(i,{"ConserveQNs",false,"MaxOcc",nm-101})); // Boson, dim=nm-100
       else if (nm==(-2)) sites.set(i,Z3Site({"SiteNumber=",i,"ConserveQNs=",false})); // use Z3
       else if (nm==(-3)) sites.set(i,Z4Site(i,{"ConserveQNs",false})); // use Z4
       else Error(tinyformat::format("SpinX cannot read index of size "));

--- a/src/dmrgpy/pyitensor/sites/__init__.py
+++ b/src/dmrgpy/pyitensor/sites/__init__.py
@@ -1,5 +1,5 @@
 from .base import SiteType, is_fermionic
-from .boson import BosonFourSite
+from .boson import BosonFourSite, get_boson_site
 from .fermion import ElectronSite, FermionSite, HubbardSite, SpinlessSite
 from .parafermion import Z3Site, Z4Site
 from .siteset import SiteX, TYPE_CODE_TO_SITE
@@ -11,5 +11,5 @@ __all__ = [
     "SiteX", "TYPE_CODE_TO_SITE",
     "SpinHalfSite", "SpinOneSite", "SpinThreeHalfSite", "SpinTwoSite", "SpinFiveHalfSite",
     "FermionSite", "SpinlessSite", "ElectronSite", "HubbardSite",
-    "BosonFourSite", "Z3Site", "Z4Site",
+    "BosonFourSite", "get_boson_site", "Z3Site", "Z4Site",
 ]

--- a/src/dmrgpy/pyitensor/sites/boson.py
+++ b/src/dmrgpy/pyitensor/sites/boson.py
@@ -1,21 +1,61 @@
-"""Boson-4 site (4 occupation levels 0..3), transcribed operator-by-operator
-from mpscpp3/extra/bosonfour.h. See sites/base.py for the matrix-entry axis
-convention."""
+"""Boson site(s), transcribed operator-by-operator from
+mpscpp3/extra/bosonfour.h -- see sites/base.py for the matrix-entry axis
+convention.
+
+Generalized (mirroring the same mpscpp3/get_sites.h generalization) from
+a single fixed 4-level site to an arbitrary occupation cutoff: dimension
+= maxOcc+1, matching the dmrgpy-level "maxnb" convention
+(bosonchain.Bosonic_Chain). `get_boson_site(dim)` builds (and caches) the
+SiteType subclass for a given dimension on demand -- see siteset.py's
+TYPE_CODE_TO_SITE dispatch, which routes the same 100+dim type-code
+range used by mpscpp3's get_sites.h to this factory instead of a single
+dict entry. `BosonFourSite` (dim=4, type code 104) is kept as a concrete
+name for backwards compatibility, and is simply `get_boson_site(4)`.
+"""
 
 import numpy as np
 
 from .base import SiteType, build_matrix
 
 
-class BosonFourSite(SiteType):
-    dim = 4
-    _states = {"3": 1, "Up": 1, "1": 2, "Upi": 2, "-1": 3, "Dni": 3, "-3": 4, "Dn": 4}
-    _OPS = {
-        "N": build_matrix(4, [(1, 1, 0.0), (2, 2, 1.0), (3, 3, 2.0), (4, 4, 3.0)]),
-        "N0": build_matrix(4, [(1, 1, 1.0)]),
-        "N1": build_matrix(4, [(2, 2, 1.0)]),
-        "N2": build_matrix(4, [(3, 3, 1.0)]),
-        "N3": build_matrix(4, [(4, 4, 1.0)]),
-        "Adag": build_matrix(4, [(1, 2, 1.0), (2, 3, np.sqrt(2.0)), (3, 4, np.sqrt(3.0))]),
-        "A": build_matrix(4, [(2, 1, 1.0), (3, 2, np.sqrt(2.0)), (4, 3, np.sqrt(3.0))]),
+def _boson_ops(dim):
+    """N, Adag, A, and the occupation-number projectors N0..N{dim-1},
+    generalizing the original hardcoded N/N0-N3/A/Adag entries."""
+    maxOcc = dim - 1
+    ops = {
+        "N": build_matrix(dim, [(k + 1, k + 1, float(k)) for k in range(dim)]),
+        "Adag": build_matrix(dim, [(k + 1, k + 2, np.sqrt(k + 1.0)) for k in range(maxOcc)]),
+        "A": build_matrix(dim, [(k + 2, k + 1, np.sqrt(k + 1.0)) for k in range(maxOcc)]),
     }
+    for k in range(dim):
+        ops["N" + str(k)] = build_matrix(dim, [(k + 1, k + 1, 1.0)])
+    return ops
+
+
+_boson_site_cache = {}
+
+
+def get_boson_site(dim):
+    """Return (building and caching on first use) the SiteType subclass
+    for a boson site of local Hilbert-space dimension `dim`. Plain
+    occupation-number state names only ("0".."{dim-1}") -- unlike the
+    original fixed-dim=4 site, no "Up"/"Upi"/"Dni"/"Dn" aliases and no
+    Sz-label numeric convention (that scheme doesn't generalize to an
+    arbitrary dimension, and nothing in this codebase currently calls
+    SiteX.state_index() for a boson site: DMRG here always starts from
+    randomMPS(), never a named InitState -- see chain.py/mpsalgebra.py).
+    """
+    if dim not in _boson_site_cache:
+        _boson_site_cache[dim] = type(
+            "BosonSite{}".format(dim),
+            (SiteType,),
+            {
+                "dim": dim,
+                "_states": {str(k): k + 1 for k in range(dim)},
+                "_OPS": _boson_ops(dim),
+            },
+        )
+    return _boson_site_cache[dim]
+
+
+BosonFourSite = get_boson_site(4)

--- a/src/dmrgpy/pyitensor/sites/siteset.py
+++ b/src/dmrgpy/pyitensor/sites/siteset.py
@@ -3,12 +3,16 @@ constructor -- a SiteSet built directly from in-memory per-site type codes,
 with no file I/O, using the exact same type-code convention as
 manybodychain.py's callers (see get_sites.h's comment and CLAUDE.md):
 2=spin-1/2, 0=spinless fermion, 1=spinful fermion (Hubbard), 3=spin-1,
-4=spin-3/2, 5=spin-2, 6=spin-5/2, 104=Boson (4 levels), -2=Z3, -3=Z4.
+4=spin-3/2, 5=spin-2, 6=spin-5/2, -2=Z3, -3=Z4. Boson is a *range* of
+codes, 102..199 (code = 100+dim, dim being the requested local Hilbert
+space dimension -- see bosonchain.Bosonic_Chain's "maxnb"), routed to
+boson.get_boson_site(dim) below instead of a single dict entry -- the
+same generalization mpscpp3/get_sites.h applies to BosonFourSite.
 """
 
 from ..index import Index
 from ..tensor import ITensor
-from .boson import BosonFourSite
+from .boson import BosonFourSite, get_boson_site
 from .fermion import ElectronSite, FermionSite
 from .parafermion import Z3Site, Z4Site
 from .spin import SpinFiveHalfSite, SpinHalfSite, SpinOneSite, SpinThreeHalfSite, SpinTwoSite
@@ -27,12 +31,18 @@ TYPE_CODE_TO_SITE = {
 }
 
 
+def _site_class(type_code):
+    if 100 < type_code < 200:
+        return get_boson_site(type_code - 100)
+    try:
+        return TYPE_CODE_TO_SITE[type_code]
+    except KeyError as e:
+        raise ValueError("SiteX cannot build a site of type code {}".format(e.args[0]))
+
+
 class SiteX:
     def __init__(self, site_types):
-        try:
-            self._types = [TYPE_CODE_TO_SITE[t] for t in site_types]
-        except KeyError as e:
-            raise ValueError("SiteX cannot build a site of type code {}".format(e.args[0]))
+        self._types = [_site_class(t) for t in site_types]
         self._indices = [Index(t.dim, tags="Site,n={}".format(i + 1))
                           for i, t in enumerate(self._types)]
 

--- a/tests/test_boson_chain.py
+++ b/tests/test_boson_chain.py
@@ -1,0 +1,140 @@
+"""Functional coverage for bosonchain.Bosonic_Chain, distilled from
+examples/bosonic_chain and examples/boson_maxnb_v3_VS_ED down to small,
+fast systems, comparing ED against DMRG on ITensor v2, v3, and the
+pure-Python backend (see _helpers.py). Only Bosonic_Chain is covered
+here, not SpinBoson_Chain (its ED backend is an unfinished stub, see
+pyboson/boson.py).
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import bosonchain
+
+from _helpers import energy_ed_v2_v3, vev_ed_v2_v3, setup_backend
+
+# Looser than the 1e-6 spin/fermion tests get away with: mpscpp3's DMRG
+# seeds from an actual random MPS (default_mps() = randomMPS(...), see
+# CLAUDE.md/get_sites.h), not a fixed/seeded starting point. Spin/fermion
+# tests dodge this because their dim-2 sites fit losslessly under the
+# default maxm regardless of starting point; boson's dim-4+ sites don't,
+# so occasional runs converge to a slightly different local optimum.
+DMRG_TOL = 1e-4
+
+
+def test_boson_dimer_hopping_energy():
+    """Two-site boson hopping Hamiltonian H = t(Adag_0 A_1 + h.c.) at the
+    default per-site dimension (maxnb=4, max 3 bosons/site). Unlike the
+    spinless-fermion dimer (test_fermion_chain.py), bosons have no
+    exclusion principle, so the ground state isn't the single-particle
+    bonding orbital at E=-t: it piles multiple bosons into the bonding
+    mode, up to what each site's occupation cutoff allows, giving the
+    golden value -2*sqrt(3) checked here. Also exercises the
+    itensor_version==3, ns<3 ED fallback (same mpscpp3 two-site-dmrg()
+    limitation as spin/fermion dimers)."""
+    n = 2
+    bc = bosonchain.Bosonic_Chain(n)
+    h = bc.Adag[0] * bc.A[1]
+    h = h + h.get_dagger()
+
+    golden = -2 * np.sqrt(3)
+    e_ed, e_v2, e_v3 = energy_ed_v2_v3(bc, h)
+    assert e_ed == pytest.approx(golden, abs=1e-8)
+    assert e_v2 == pytest.approx(golden, abs=DMRG_TOL)
+    assert e_v3 == pytest.approx(golden, abs=DMRG_TOL)
+
+
+def test_boson_chain_energy_and_density_default_maxnb():
+    """4-site Bose-Hubbard-like chain (hopping + onsite repulsion) at the
+    default per-site dimension (maxnb=4, i.e. site type code 104 on
+    every backend): ground-state energy and total occupation must agree
+    between ED and DMRG on both ITensor v2 and v3."""
+    n = 4
+    bc = bosonchain.Bosonic_Chain(n)
+    bc.maxm = 120 # dim-4 sites need more bond dimension than the dim-2
+    bc.nsweeps = 50 # sites spin/fermion tests get away with at the default
+    h = 0
+    for i in range(n - 1):
+        h = h + bc.Adag[i] * bc.A[i + 1]
+    h = h + h.get_dagger()
+    for i in range(n):
+        h = h + 1.0 * bc.N[i] * (bc.N[i] - 1.0)
+
+    Nop = 0
+    for i in range(n):
+        Nop = Nop + bc.N[i]
+
+    e_ed, e_v2, e_v3 = energy_ed_v2_v3(bc, h)
+    assert e_v2 == pytest.approx(e_ed, abs=DMRG_TOL)
+    assert e_v3 == pytest.approx(e_ed, abs=DMRG_TOL)
+
+    n_ed, n_v2, n_v3 = vev_ed_v2_v3(bc, h, Nop)
+    assert n_v2.real == pytest.approx(n_ed.real, abs=DMRG_TOL)
+    assert n_v3.real == pytest.approx(n_ed.real, abs=DMRG_TOL)
+
+
+def test_boson_chain_get_density_and_fluctuation():
+    """get_density/get_density_fluctuation (bosonchain.py) must agree
+    between ED and DMRG (v3), and the total density must match the
+    total-N vev computed the direct way."""
+    n = 3
+    bc = bosonchain.Bosonic_Chain(n)
+    bc.maxm = 120
+    bc.nsweeps = 50
+    h = 0
+    for i in range(n - 1):
+        h = h + bc.Adag[i] * bc.A[i + 1]
+    h = h + h.get_dagger()
+    for i in range(n):
+        h = h + 0.5 * bc.N[i] * (bc.N[i] - 1.0)
+    bc.set_hamiltonian(h)
+
+    d_ed = bc.get_density(mode="ED")
+    fluc_ed = bc.get_density_fluctuation(mode="ED")
+
+    bc.set_hamiltonian(h)
+    bc.setup_cpp(3)
+    d_v3 = bc.get_density(mode="DMRG")
+    fluc_v3 = bc.get_density_fluctuation(mode="DMRG")
+
+    assert d_v3 == pytest.approx(d_ed, abs=DMRG_TOL)
+    assert fluc_v3 == pytest.approx(fluc_ed, abs=DMRG_TOL)
+    assert np.all(fluc_ed >= -1e-8) # fluctuations are non-negative
+
+
+def test_boson_chain_nondefault_maxnb_matches_ed_on_v3_and_python():
+    """Regression test for the maxnb-wiring fix (bosonchain.py's
+    Bosonic_Chain now encodes each site's requested dimension into its
+    DMRG type code, 100+dim, instead of always building the fixed
+    4-level BosonFourSite regardless of maxnb -- see
+    mpscpp3/get_sites.h and, on the pure-Python side,
+    pyitensor/sites/boson.py's get_boson_site() factory). Uses a
+    heterogeneous, non-default maxnb so that a hardcoded dim=4 site
+    would silently disagree with ED. v2 is not checked: it still only
+    understands the single fixed-dim-4 boson type code (104), see
+    examples/boson_maxnb_v3_VS_ED."""
+    n = 3
+    maxnb = [3, 5, 3]
+    bc = bosonchain.Bosonic_Chain(n, maxnb=maxnb)
+    assert bc.sites == [103, 105, 103]
+
+    h = 0
+    for i in range(n - 1):
+        h = h + bc.Adag[i] * bc.A[i + 1]
+    h = h + h.get_dagger()
+    for i in range(n):
+        h = h + 0.7 * bc.N[i] * (bc.N[i] - 1.0)
+
+    bc.set_hamiltonian(h)
+    e_ed = bc.gs_energy(mode="ED")
+
+    bc.set_hamiltonian(h)
+    bc.maxm = 120
+    bc.nsweeps = 50
+    bc.setup_cpp(3)
+    e_v3 = bc.gs_energy(mode="DMRG")
+    assert e_v3 == pytest.approx(e_ed, abs=1e-4)
+
+    bc.set_hamiltonian(h)
+    setup_backend(bc, "python")
+    e_py = bc.gs_energy(mode="DMRG")
+    assert e_py == pytest.approx(e_ed, abs=1e-6)


### PR DESCRIPTION
## Summary
- `Bosonic_Chain(n, maxnb=...)` previously always built DMRG sessions with the fixed 4-level `BosonFourSite` regardless of `maxnb`, while ED honored `maxnb` exactly — a silent DMRG/ED mismatch for any non-default value. Boson type codes are now a range, `100+dim` per site: `mpscpp3`'s `BosonFourSite` (`extra/bosonfour.h`) generalizes to an `Args("MaxOcc",...)`-driven arbitrary occupation cutoff, and `get_sites.h` routes `102..199` to it.
- pyitensor mirrors this with a `get_boson_site(dim)` factory (`pyitensor/sites/boson.py`/`siteset.py`), since its `SiteType` machinery is class-level only and can't take a dimension as a constructor argument the way the C++ side does. `itensor_version=2` and the Julia backend still only understand the fixed dim-4 site.
- Added `Bosonic_Chain.get_density()`/`get_density_fluctuation()`, `maxnb`/`n` length validation, and generalized the occupation-projector operators into a per-site `bc.D[i][k]` list (keeping `D0..D3` as a back-compat alias when every site has ≥4 levels).
- Fixed `examples/bosonic_hubbard/main.py`, which referenced a nonexistent `Bosonic_Hamiltonian` class.
- Added `tests/test_boson_chain.py` and `examples/boson_maxnb_v3_VS_ED`, comparing ED against DMRG on v2, v3, and the pure-Python backend.
- Updated `docs/user_guide.{md,tex}` and `docs/documentation.{md,tex}` (both `.tex` files verified to compile cleanly).

## Test plan
- [x] `python3 -m pytest tests -q` — 82 passed
- [x] `docs/documentation.tex` and `docs/user_guide.tex` compile cleanly with `pdflatex`
- [x] `examples/bosonic_chain`, `examples/bosonic_hubbard`, `examples/boson_maxnb_v3_VS_ED`, `examples/v2_VS_v3_boson`, `examples/spinboson_chain`, `examples/pyitensor/selftest_sites.py` all run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnzVELywmCLqu2sjY1c3Qg