### PR TITLE
Add third-order STM/Kondo perturbation-theory spectrum (ED + T=0 DMRG)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1024,15 +1024,45 @@ requires:
   against and as a fast, exact ground truth for `dmrgtwotime.py`'s own
   test.
 
-`dmrgtwotime.py` specifically -- unlike every other piece of this
-feature, each cross-checked against an independent reference to
-sub-percent accuracy -- was written against this codebase's existing,
-verified DMRG API but has not been executed or numerically validated
-against a compiled ITensor v3 backend (none was available in the
-environment it was developed in). `tests/test_kondo_spectrum_dmrgtwotime.py`
-would validate it against the ED two-time reference in an environment
-where `itensor_version=3` is compiled; it is skipped automatically
-otherwise.
+`dmrgtwotime.py` was written against this codebase's existing, verified
+DMRG API and validated once a compiled ITensor v3 backend became
+available: `G(t2,tau)` matches the ED reference to ~1e-9-1e-10
+pointwise, and the swept third-order Kondo term matches a
+grid-consistent ED reference to ~1e-10
+(`tests/test_kondo_spectrum_dmrgtwotime.py`, skipped automatically when
+no compiled `itensor_version=3` backend is available). Getting there
+surfaced three real bugs, none of which showed up in the ED-only testing
+this module was originally written against:
+
+- `tdvp_step` silently renormalizes its output to unit norm on *every*
+  call. `Sj|GS>` (the state each two-time trajectory starts from) is
+  generally not unit-norm (`Sj` isn't norm-preserving), so letting that
+  renormalization stand discarded the true amplitude at every step --
+  confirmed directly, it produced overlaps exactly a factor of 2 too
+  large end to end for a state of norm 0.5. Fixed by evolving a
+  normalized copy and rescaling every returned checkpoint by the true
+  original norm.
+- The forward/backward time-stepping loop shared one running `times`
+  list, so the "backward" branch kept counting down from the forward
+  branch's endpoint instead of from `t=0` -- it never actually reached
+  negative times at all. Fixed by walking forward and backward from
+  `t=0` independently and merging afterward.
+- `twotime.py`'s `t2`-integral used `np.trapz` per chunk, which is
+  exactly 0 for a single-point chunk (no width to integrate over) -- and
+  DMRG chunks are always single-point (each `t2` checkpoint is its own
+  real trajectory), so this silently zeroed the entire third-order Kondo
+  term end to end. Fixed with a uniform Riemann-sum accumulation
+  (trapezoidal endpoint correction only at the true global first/last
+  `t2` points) that is well defined for any chunk size.
+
+A 1-site test chain also hit an unrelated internal ITensor v3 error
+(building the Hamiltonian MPO, distinct from the two-site-`dmrg()`
+short-chain crash `mode.py`'s ED fallback already guards against) --
+chains need at least 3 sites for this feature. The second-order
+term (`submode="KPM"`) was spot-checked too, agreeing to within a few
+tens of percent at thresholds, consistent with the expected
+delta-broadening/moment-truncation error on top of what the ED path
+already has.
 
 ### 4.9 TDZ / complex-time-evolution dynamical correlator
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -962,6 +962,34 @@ coupled recursion also reproduces an independently-derived scalar
 recursion exactly for a 1x1 test case, and the reconstructed density
 correctly sharpens with more moments.)
 
+### 4.8c STM/Kondo tunneling spectra (`kondospectrumtk/`)
+
+`Spin_Chain.get_kondo_spectrum` (physics documented in the user guide,
+§17) is a different kind of ED calculation from the dynamical-correlator
+machinery above: it needs the *full* spectrum (every eigenstate, as a
+possible virtual intermediate state in the third-order perturbation
+theory), not just the ground state or a resolvent at a target frequency.
+It reuses the ED backend's existing `EDchain.get_diagonalized_hamiltonian`
+(dense `eigh`, already used elsewhere for small systems) rather than
+adding a new diagonalization path, and is deliberately independent of a
+chain's own `itensor_version`/mode setting -- DMRG cannot supply the
+full spectrum this method needs regardless of which backend a chain
+would otherwise use, so `KondoSpectrum` (`kondospectrumtk/edkondo.py`)
+always goes through `Spin_Chain.get_ED_obj()` directly.
+
+Two of the source paper's own closed-form equations for supporting
+numerical functions (the temperature-broadened step and a
+temperature-broadened logarithmic Kondo function) do not reproduce the
+behavior the paper itself describes and plots for them; `kondospectrumtk/
+stepfunctions.py` re-derives both from the paper's own unambiguous
+defining integrals instead, each independently verified against
+digitized values from the paper's own figures. See that module's
+docstring and `docs/user_guide.md`'s §17 for the full derivation notes
+and the feature's other scope limitations (single tip-coupled site,
+third-order terms are single-direction only, the potential-scattering
+interference term's general-spin form is an extrapolation from the
+paper's own worked example).
+
 ### 4.9 TDZ / complex-time-evolution dynamical correlator
 
 `tdz.py` implements `submode="TDZ"` (Cao, Lu, Stoudenmire & Parcollet,

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -990,6 +990,50 @@ third-order terms are single-direction only, the potential-scattering
 interference term's general-spin form is an extrapolation from the
 paper's own worked example).
 
+**`mode="DMRG"`** (`T=0` only) is a second, independent route through
+this same feature that *does* stay within `itensor_version=3`, never
+diagonalizing beyond the ground state -- viable because at `T=0` both
+terms simplify enough to avoid needing the full spectrum `mode="ED"`
+requires:
+
+- The second-order term (`secondorder_dc.py`) becomes a `Theta0`-weighted
+  cumulative integral of the ordinary `T=0` dynamical structure factor,
+  so it reuses `get_dynamical_correlator` (`submode="KPM"`/`"CVM"`)
+  as-is.
+- The third-order Kondo term (`twotime.py`, `dmrgtwotime.py`) is a
+  genuinely new construction: a Heisenberg three-point function
+  `G(t2,tau)=<GS|Sl(t2+tau)Sk(t2)Sj(0)|GS>` built via real TDVP time
+  evolution (a "checkpoint-and-branch" pattern: evolve `Sj|GS>` forward
+  and backward through `t2`, apply `Sk` at each checkpoint, evolve each
+  branch further through `tau`, overlap with a fixed `Sl|GS>` reference
+  at every step -- reusing the single-step `tdvp_step` primitive
+  `tdz.py` already drives manually the same way), then converted to a
+  frequency-domain quantity via two closed-form time-domain kernels
+  (`Theta0`'s Cauchy-principal-value kernel, computed via an FFT-based
+  Hilbert transform; `F0`'s kernel, smooth and closed-form) rather than
+  by evaluating those functions pointwise on a discrete frequency grid --
+  an initial FFT-grid attempt at the same physics did not converge
+  robustly (a discontinuous step function and a log singularity both
+  have slowly-decaying spectral content that a finite discrete grid
+  resolves poorly), which is why this construction exists in the first
+  place rather than a simpler direct approach. `twotime.py`'s functions
+  are backend-agnostic (they only ever consume a discretely-sampled
+  `G(t2,tau)` array or batches thereof) -- `edtwotimeref.py` supplies
+  the same interface via exact ED eigenbasis time evolution, used both
+  as the development-time reference this construction was validated
+  against and as a fast, exact ground truth for `dmrgtwotime.py`'s own
+  test.
+
+`dmrgtwotime.py` specifically -- unlike every other piece of this
+feature, each cross-checked against an independent reference to
+sub-percent accuracy -- was written against this codebase's existing,
+verified DMRG API but has not been executed or numerically validated
+against a compiled ITensor v3 backend (none was available in the
+environment it was developed in). `tests/test_kondo_spectrum_dmrgtwotime.py`
+would validate it against the ED two-time reference in an environment
+where `itensor_version=3` is compiled; it is skipped automatically
+otherwise.
+
 ### 4.9 TDZ / complex-time-evolution dynamical correlator
 
 `tdz.py` implements `submode="TDZ"` (Cao, Lu, Stoudenmire & Parcollet,

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1064,6 +1064,27 @@ tens of percent at thresholds, consistent with the expected
 delta-broadening/moment-truncation error on top of what the ED path
 already has.
 
+The potential-interference term (`U!=0`, part of `order=3`) is also
+supported for `mode="DMRG"`, via `potentialdc.py`: its own `T=0` limit
+collapses the excited-state sum to a convolution of the *same* `T=0`
+dynamical structure factor against the `F0` kernel instead of `Theta0`'s
+cumulative-sum weighting (`Theta0(eV-x)` is a step, integrated
+cumulatively; `F0` is not, so this piece genuinely convolves rather than
+cumulatively sums) -- so it reuses `get_dynamical_correlator` exactly
+like the second-order term above, needing no excited-state enumeration
+either, and no new DMRG-side primitive. Verified (`mode="ED"`,
+`submode="ED"`) against the excited-state-sum
+`conductance.third_order_potential_dIdV` to ~0.07% relative error
+(`tests/test_kondo_spectrum_potentialdc.py`); a real `mode="DMRG"`,
+`submode="KPM"` run through the full public API was tried directly but
+found impractically expensive for a routine test -- a single KPM
+dynamical-correlator call took ~40s on the development machine even with
+a trivially small number of moments, confirmed directly -- so the
+`Spin_Chain._get_kondo_spectrum_dmrg` wiring that combines this term
+with the other two is instead checked with the three underlying
+(expensive) calls monkeypatched out
+(`tests/test_kondo_spectrum.py::test_get_kondo_spectrum_dmrg_combines_terms_correctly`).
+
 ### 4.9 TDZ / complex-time-evolution dynamical correlator
 
 `tdz.py` implements `submode="TDZ"` (Cao, Lu, Stoudenmire & Parcollet,

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -1242,16 +1242,48 @@ needing the full spectrum \texttt{mode="ED"} requires:
   ground truth for \texttt{dmrgtwotime.py}'s own test.
 \end{itemize}
 
-\texttt{dmrgtwotime.py} specifically -- unlike every other piece of this
-feature, each cross-checked against an independent reference to
-sub-percent accuracy -- was written against this codebase's existing,
-verified DMRG API but has not been executed or numerically validated
-against a compiled ITensor v3 backend (none was available in the
-environment it was developed in).
-\texttt{tests/test\_kondo\_spectrum\_dmrgtwotime.py} would validate it
-against the ED two-time reference in an environment where
-\texttt{itensor\_version=3} is compiled; it is skipped automatically
-otherwise.
+\texttt{dmrgtwotime.py} was written against this codebase's existing,
+verified DMRG API and validated once a compiled ITensor v3 backend
+became available: \texttt{G(t2,tau)} matches the ED reference to
+$\sim10^{-9}$--$10^{-10}$ pointwise, and the swept third-order Kondo term
+matches a grid-consistent ED reference to $\sim10^{-10}$
+(\texttt{tests/test\_kondo\_spectrum\_dmrgtwotime.py}, skipped
+automatically when no compiled \texttt{itensor\_version=3} backend is
+available). Getting there surfaced three real bugs, none of which showed
+up in the ED-only testing this module was originally written against:
+
+\begin{itemize}
+\item \texttt{tdvp\_step} silently renormalizes its output to unit norm
+  on \emph{every} call. \texttt{Sj|GS>} (the state each two-time
+  trajectory starts from) is generally not unit-norm (\texttt{Sj} isn't
+  norm-preserving), so letting that renormalization stand discarded the
+  true amplitude at every step -- confirmed directly, it produced
+  overlaps exactly a factor of 2 too large end to end for a state of
+  norm 0.5. Fixed by evolving a normalized copy and rescaling every
+  returned checkpoint by the true original norm.
+\item The forward/backward time-stepping loop shared one running
+  \texttt{times} list, so the "backward" branch kept counting down from
+  the forward branch's endpoint instead of from \texttt{t=0} -- it never
+  actually reached negative times at all. Fixed by walking forward and
+  backward from \texttt{t=0} independently and merging afterward.
+\item \texttt{twotime.py}'s \texttt{t2}-integral used \texttt{np.trapz}
+  per chunk, which is exactly 0 for a single-point chunk (no width to
+  integrate over) -- and DMRG chunks are always single-point (each
+  \texttt{t2} checkpoint is its own real trajectory), so this silently
+  zeroed the entire third-order Kondo term end to end. Fixed with a
+  uniform Riemann-sum accumulation (trapezoidal endpoint correction only
+  at the true global first/last \texttt{t2} points) that is well defined
+  for any chunk size.
+\end{itemize}
+
+A 1-site test chain also hit an unrelated internal ITensor v3 error
+(building the Hamiltonian MPO, distinct from the two-site-\texttt{dmrg()}
+short-chain crash \texttt{mode.py}'s ED fallback already guards against)
+-- chains need at least 3 sites for this feature. The second-order term
+(\texttt{submode="KPM"}) was spot-checked too, agreeing to within a few
+tens of percent at thresholds, consistent with the expected
+delta-broadening/moment-truncation error on top of what the ED path
+already has.
 
 \subsection{TDZ / complex-time-evolution dynamical correlator}
 

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -1285,6 +1285,29 @@ tens of percent at thresholds, consistent with the expected
 delta-broadening/moment-truncation error on top of what the ED path
 already has.
 
+The potential-interference term (\texttt{U!=0}, part of
+\texttt{order=3}) is also supported for \texttt{mode="DMRG"}, via
+\texttt{potentialdc.py}: its own $T=0$ limit collapses the excited-state
+sum to a convolution of the \emph{same} $T=0$ dynamical structure factor
+against the $F_0$ kernel instead of $\Theta_0$'s cumulative-sum
+weighting ($\Theta_0(\mathrm{eV}-x)$ is a step, integrated cumulatively;
+$F_0$ is not, so this piece genuinely convolves rather than cumulatively
+sums) -- so it reuses \texttt{get\_dynamical\_correlator} exactly like
+the second-order term above, needing no excited-state enumeration
+either, and no new DMRG-side primitive. Verified (\texttt{mode="ED"},
+\texttt{submode="ED"}) against the excited-state-sum
+\texttt{conductance.third\_order\_potential\_dIdV} to $\sim0.07\%$
+relative error (\texttt{tests/test\_kondo\_spectrum\_potentialdc.py}); a
+real \texttt{mode="DMRG"}, \texttt{submode="KPM"} run through the full
+public API was tried directly but found impractically expensive for a
+routine test -- a single KPM dynamical-correlator call took $\sim40$s on
+the development machine even with a trivially small number of moments,
+confirmed directly -- so the
+\texttt{Spin\_Chain.\_get\_kondo\_spectrum\_dmrg} wiring that combines
+this term with the other two is instead checked with the three
+underlying (expensive) calls monkeypatched out
+(\texttt{tests/test\_kondo\_spectrum.py::test\_get\_kondo\_spectrum\_dmrg\_combines\_terms\_correctly}).
+
 \subsection{TDZ / complex-time-evolution dynamical correlator}
 
 \texttt{tdz.py} implements \texttt{submode="TDZ"} (Cao, Lu, Stoudenmire

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -1203,6 +1203,56 @@ terms are single-direction only, the potential-scattering interference
 term's general-spin form is an extrapolation from the paper's own worked
 example).
 
+\textbf{\texttt{mode="DMRG"}} (\texttt{T=0} only) is a second,
+independent route through this same feature that \emph{does} stay within
+\texttt{itensor\_version=3}, never diagonalizing beyond the ground state
+-- viable because at \texttt{T=0} both terms simplify enough to avoid
+needing the full spectrum \texttt{mode="ED"} requires:
+
+\begin{itemize}
+\item The second-order term (\texttt{secondorder\_dc.py}) becomes a
+  \texttt{Theta0}-weighted cumulative integral of the ordinary
+  \texttt{T=0} dynamical structure factor, so it reuses
+  \texttt{get\_dynamical\_correlator} (\texttt{submode="KPM"}/\texttt{"CVM"})
+  as-is.
+\item The third-order Kondo term (\texttt{twotime.py},
+  \texttt{dmrgtwotime.py}) is a genuinely new construction: a Heisenberg
+  three-point function
+  \texttt{G(t2,tau)=<GS|Sl(t2+tau)Sk(t2)Sj(0)|GS>} built via real TDVP
+  time evolution (a "checkpoint-and-branch" pattern: evolve
+  \texttt{Sj|GS>} forward and backward through \texttt{t2}, apply
+  \texttt{Sk} at each checkpoint, evolve each branch further through
+  \texttt{tau}, overlap with a fixed \texttt{Sl|GS>} reference at every
+  step -- reusing the single-step \texttt{tdvp\_step} primitive
+  \texttt{tdz.py} already drives manually the same way), then converted
+  to a frequency-domain quantity via two closed-form time-domain kernels
+  (\texttt{Theta0}'s Cauchy-principal-value kernel, computed via an
+  FFT-based Hilbert transform; \texttt{F0}'s kernel, smooth and
+  closed-form) rather than by evaluating those functions pointwise on a
+  discrete frequency grid -- an initial FFT-grid attempt at the same
+  physics did not converge robustly (a discontinuous step function and a
+  log singularity both have slowly-decaying spectral content that a
+  finite discrete grid resolves poorly), which is why this construction
+  exists in the first place rather than a simpler direct approach.
+  \texttt{twotime.py}'s functions are backend-agnostic (they only ever
+  consume a discretely-sampled \texttt{G(t2,tau)} array or batches
+  thereof) -- \texttt{edtwotimeref.py} supplies the same interface via
+  exact ED eigenbasis time evolution, used both as the development-time
+  reference this construction was validated against and as a fast, exact
+  ground truth for \texttt{dmrgtwotime.py}'s own test.
+\end{itemize}
+
+\texttt{dmrgtwotime.py} specifically -- unlike every other piece of this
+feature, each cross-checked against an independent reference to
+sub-percent accuracy -- was written against this codebase's existing,
+verified DMRG API but has not been executed or numerically validated
+against a compiled ITensor v3 backend (none was available in the
+environment it was developed in).
+\texttt{tests/test\_kondo\_spectrum\_dmrgtwotime.py} would validate it
+against the ED two-time reference in an environment where
+\texttt{itensor\_version=3} is compiled; it is skipped automatically
+otherwise.
+
 \subsection{TDZ / complex-time-evolution dynamical correlator}
 
 \texttt{tdz.py} implements \texttt{submode="TDZ"} (Cao, Lu, Stoudenmire

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -1172,6 +1172,37 @@ coupled recursion also reproduces an independently-derived scalar
 recursion exactly for a $1\times1$ test case, and the reconstructed
 density correctly sharpens with more moments.)
 
+\subsection{STM/Kondo tunneling spectra (\texttt{kondospectrumtk/})}
+
+\texttt{Spin\_Chain.get\_kondo\_spectrum} (physics documented in the user
+guide's ``STM/Kondo tunneling spectra'' section) is a different kind of
+ED calculation from the dynamical-correlator machinery above: it needs the
+\emph{full} spectrum (every eigenstate, as a possible virtual
+intermediate state in the third-order perturbation theory), not just the
+ground state or a resolvent at a target frequency. It reuses the ED
+backend's existing \texttt{EDchain.get\_diagonalized\_hamiltonian} (dense
+\texttt{eigh}, already used elsewhere for small systems) rather than
+adding a new diagonalization path, and is deliberately independent of a
+chain's own \texttt{itensor\_version}/mode setting -- DMRG cannot supply
+the full spectrum this method needs regardless of which backend a chain
+would otherwise use, so \texttt{KondoSpectrum}
+(\texttt{kondospectrumtk/edkondo.py}) always goes through
+\texttt{Spin\_Chain.get\_ED\_obj()} directly.
+
+Two of the source paper's own closed-form equations for supporting
+numerical functions (the temperature-broadened step and a
+temperature-broadened logarithmic Kondo function) do not reproduce the
+behavior the paper itself describes and plots for them;
+\texttt{kondospectrumtk/stepfunctions.py} re-derives both from the
+paper's own unambiguous defining integrals instead, each independently
+verified against digitized values from the paper's own figures. See
+that module's docstring and the user guide's ``STM/Kondo tunneling
+spectra'' section for the full derivation notes and the
+feature's other scope limitations (single tip-coupled site, third-order
+terms are single-direction only, the potential-scattering interference
+term's general-spin form is an extrapolation from the paper's own worked
+example).
+
 \subsection{TDZ / complex-time-evolution dynamical correlator}
 
 \texttt{tdz.py} implements \texttt{submode="TDZ"} (Cao, Lu, Stoudenmire

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1013,9 +1013,16 @@ DMRG (raises `NotImplementedError`); the second-order term's `es`
 frequency-grid parameter has no safe default and must be supplied
 explicitly (it needs to cover every relevant transition energy, which is
 a property of the chain's spectrum, not of the `eV` sweep range — see
-`second_order_dIdV_dc`'s docstring); chains need at least 3 sites (a
-1-site chain hits an internal ITensor v3 error unrelated to this
-feature, building the Hamiltonian MPO).
+`second_order_dIdV_dc`'s docstring); the third-order term's `dt2`,
+`n_t2_half`, `dtau`, `n_tau_half` time-grid parameters likewise have no
+safe default and must be supplied explicitly (a grid fine/wide enough for
+the default $\omega_0$/$\Gamma_0$ needs $\sim10^5$–$10^6$ $t_2$
+checkpoints, each its own real TDVP trajectory — infeasible as a silent
+default — while a small, fast default is wildly under-resolved and
+returns a finite but silently wrong result instead of erroring, confirmed
+directly; see `two_time_kondo_term_dmrg`'s docstring); chains need at
+least 3 sites (a 1-site chain hits an internal ITensor v3 error unrelated
+to this feature, building the Hamiltonian MPO).
 
 `kondospectrumtk/dmrgtwotime.py` was written against this codebase's
 existing, verified DMRG API and validated once a compiled ITensor v3

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -28,6 +28,7 @@ reference on small systems.
 14. [Reduced density matrices and operator distributions](#14-reduced-density-matrices-and-operator-distributions)
 15. [Post-processing tools](#15-post-processing-tools)
 16. [Worked-example cookbook](#16-worked-example-cookbook)
+17. [STM/Kondo tunneling spectra (third-order perturbation theory)](#17-stmkondo-tunneling-spectra-third-order-perturbation-theory)
 
 ## 1. Physical models and Hilbert spaces
 
@@ -891,3 +892,78 @@ for i in range(n):
         x, y = sc.get_dynamical_correlator(submode="KPM", name=(sc.Sz[i], sc.Sz[j]))
         Sqw[(i, j)] = (x, y)          # combine with sum_ij e^{iq(i-j)} S_ij(w) offline
 ```
+
+## 17. STM/Kondo tunneling spectra (third-order perturbation theory)
+
+`Spin_Chain.get_kondo_spectrum` computes the differential tunneling
+conductance $dI/dV(eV)$ of an STM tip coupled to one site of a spin
+chain, following the weak-coupling (Kondo-scattering) perturbation
+theory of Ternes, *New J. Phys.* **17**, 063016 (2015),
+[arXiv:1505.04430](https://arxiv.org/abs/1505.04430). This is a
+different observable from the dynamical correlators of §6: instead of a
+retarded Green's function of the spin system alone, it is the full
+Fermi's-golden-rule tunneling current through tip+spin+sample, expanded
+to third order in the tip-sample tunneling amplitude, evaluated by full
+exact diagonalization of the chain's Hamiltonian (every eigenstate is
+needed as a possible virtual intermediate state, not just the low-energy
+ones — DMRG is not used here regardless of the chain's own
+`itensor_version`/mode setting).
+
+```python
+sc = spinchain.Spin_Chain(["1/2"])
+sc.set_hamiltonian(g*muB*B*sc.Sz[0])   # Zeeman-split S=1/2 impurity
+eV, dIdV = sc.get_kondo_spectrum(eV_grid, site=0, Jrho_s=-0.05, U=0.25,
+                                  T=1.0, order=3)
+```
+
+**Second order** (`order=2`) is the plain spin-flip/potential-scattering
+Fermi golden rule result,
+
+$$\frac{\partial I}{\partial V}(eV)\propto\sum_{i,f}p_i\Big[\tfrac12|\langle f|S_-|i\rangle|^2+\tfrac12|\langle f|S_+|i\rangle|^2+|\langle f|S_z|i\rangle|^2\Big]\,\Theta(eV-\epsilon_{if})+U^2$$
+
+summed over both tunneling directions, with $p_i$ the Boltzmann
+occupation of eigenstate $i$ at temperature $T$ and $\Theta$ a
+temperature-broadened step function. This reproduces the textbook
+inelastic-tunneling spin-flip steps at $eV=\pm(\epsilon_f-\epsilon_i)$
+(e.g. the Zeeman step of a single $S=1/2$ impurity).
+
+**Third order** (`order=3`, the default) adds two corrections that
+require summing over *all* eigenstates as virtual intermediate states
+$m$ (energy conservation is not required for $m$): a Kondo term (a
+Levi-Civita triple product of spin matrix elements $\langle i|S|f\rangle$,
+$\langle f|S|m\rangle$, $\langle m|S|i\rangle$, weighted by a
+temperature-broadened logarithmic function $F(eV-\epsilon_m,T)$ that
+produces the characteristic zero-bias Kondo-like resonance, splitting
+into two peaks under a Zeeman field), and — when `U!=0` — a
+potential-scattering interference term responsible for a bias-asymmetric
+lineshape.
+
+**Scope and known limitations**, worth reading before trusting specific
+numbers:
+
+- Only a single chain site couples to the tip (`site=`); the paper's own
+  model allows several sites with independent tip couplings, not
+  implemented here.
+- The third-order terms (`order=3`) are $\partial I^{t\to s}/\partial V$
+  only, not the full bidirectional net-current derivative that
+  `order=2` provides. The paper never gives a general $t\leftrightarrow
+  s$ formula for them — its own worked $S=1/2$ example shows the two
+  directions are related by more than a plain $eV\to-eV$ mirror, so no
+  such generalization is attempted here. This mainly affects the
+  *symmetry* of the returned third-order spectrum, not its second-order
+  part.
+- The paper's own closed-form equations for two numerical building
+  blocks — the temperature-broadened step $\Theta(x)$ and the
+  temperature-broadened Kondo log function $F(\epsilon,T)$ — do not
+  reproduce the physics the paper itself describes for them (checked
+  directly: the printed $\Theta(x)$ diverges rather than saturating, and
+  the printed $F$ closed form drops its own temperature broadening).
+  `kondospectrumtk/stepfunctions.py` uses corrected forms instead,
+  re-derived from the paper's own unambiguous defining integrals and
+  verified against digitized values from the paper's own figures (see
+  that module's docstring, and `examples/kondo_spectrum_VS_paper/`).
+- The potential-interference term's general-spin closed form (`U!=0` in
+  `order=3`) is an extrapolation from the paper's own worked $S=1/2$
+  example (only that special case is spelled out in closed form in the
+  paper) and carries lower confidence than the other terms; treat it as
+  provisional.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1013,14 +1013,27 @@ DMRG (raises `NotImplementedError`); the second-order term's `es`
 frequency-grid parameter has no safe default and must be supplied
 explicitly (it needs to cover every relevant transition energy, which is
 a property of the chain's spectrum, not of the `eV` sweep range — see
-`second_order_dIdV_dc`'s docstring). Most importantly,
+`second_order_dIdV_dc`'s docstring); chains need at least 3 sites (a
+1-site chain hits an internal ITensor v3 error unrelated to this
+feature, building the Hamiltonian MPO).
+
 `kondospectrumtk/dmrgtwotime.py` was written against this codebase's
-existing, already-verified DMRG API (`toMPO`, the `tdvp_step` primitive,
-MPS operator application/overlap) but has not been executed or
-numerically validated against a compiled ITensor v3 backend — unlike
-every other piece of this feature (each cross-checked against an
-independent reference to sub-percent accuracy), it should be treated as
-provisional until confirmed in an environment where `itensor_version=3`
-is actually compiled (`tests/test_kondo_spectrum_dmrgtwotime.py`, which
-compares it against the ED two-time reference, is skipped automatically
-otherwise).
+existing, verified DMRG API and validated once a compiled ITensor v3
+backend became available: $G(t_2,\tau)$ matches the ED reference to
+$\sim10^{-9}$–$10^{-10}$ pointwise, and the swept third-order Kondo term
+matches a grid-consistent ED reference to $\sim10^{-10}$
+(`tests/test_kondo_spectrum_dmrgtwotime.py`, skipped automatically when
+no compiled `itensor_version=3` backend is available). Getting there
+surfaced three real bugs, none of which showed up in the ED-only testing
+this module was originally written against — see that module's own
+docstring for the details (in short: `tdvp_step` silently renormalizes
+every step to unit norm, discarding $S_j|\mathrm{GS}\rangle$'s true
+amplitude unless corrected for explicitly; a forward/backward
+time-stepping bug meant "backward" checkpoints never actually reached
+negative times; and a naive per-chunk trapezoidal integral is exactly 0
+for the single-$t_2$-point chunks real-time evolution necessarily
+produces, silently zeroing the entire term). The second-order term
+(`submode="KPM"`) was spot-checked too, agreeing to within a few tens of
+percent at thresholds, consistent with the expected
+$\delta$-broadening/moment-truncation error on top of what the ED path
+already has.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -903,11 +903,17 @@ theory of Ternes, *New J. Phys.* **17**, 063016 (2015),
 different observable from the dynamical correlators of §6: instead of a
 retarded Green's function of the spin system alone, it is the full
 Fermi's-golden-rule tunneling current through tip+spin+sample, expanded
-to third order in the tip-sample tunneling amplitude, evaluated by full
-exact diagonalization of the chain's Hamiltonian (every eigenstate is
-needed as a possible virtual intermediate state, not just the low-energy
-ones — DMRG is not used here regardless of the chain's own
-`itensor_version`/mode setting).
+to third order in the tip-sample tunneling amplitude.
+
+Two backends are available via `mode=`:
+
+- `mode="ED"` (default): full exact diagonalization of the chain's
+  Hamiltonian (every eigenstate is needed as a possible virtual
+  intermediate state, not just the low-energy ones), independent of the
+  chain's own `itensor_version`/mode setting. Works at any `T>=0`.
+- `mode="DMRG"`: `itensor_version=3` throughout, never diagonalizing
+  beyond the ground state — only `T=0` is supported. See "T=0 and the
+  DMRG backend" below.
 
 ```python
 sc = spinchain.Spin_Chain(["1/2"])
@@ -967,3 +973,54 @@ numbers:
   example (only that special case is spelled out in closed form in the
   paper) and carries lower confidence than the other terms; treat it as
   provisional.
+
+**T=0 and the DMRG backend** (`mode="DMRG"`). At $T=0$ only the ground
+state is thermally populated, which simplifies both terms enough to
+avoid diagonalizing beyond the ground state entirely — the actual
+motivation for supporting `mode="DMRG"` in the first place, since DMRG
+cannot enumerate excited states the way `mode="ED"` does:
+
+- **Second order** reduces to a $\Theta_0$-weighted (the exact,
+  closed-form Heaviside limit of $\Theta$) cumulative integral of the
+  ordinary $T=0$ dynamical structure factor
+  $S_{\alpha\alpha}(\omega)=\sum_f|\langle f|S_\alpha|\mathrm{GS}\rangle|^2\delta(\omega-\epsilon_{f0})$,
+  which `get_dynamical_correlator` already computes (`submode="KPM"` or
+  `"CVM"`) without any excited-state enumeration
+  (`kondospectrumtk/secondorder_dc.py`).
+- **Third order** cannot be reduced to a two-operator correlator (it is
+  a three-vertex object, with two *different* intermediate states each
+  weighted by a different function, $\Theta_0$ and $F_0$) — instead it
+  is built from a Heisenberg three-point function
+  $G(t_2,\tau)=\langle\mathrm{GS}|S_l(t_2+\tau)S_k(t_2)S_j(0)|\mathrm{GS}\rangle$,
+  obtained via real-time TDVP evolution with a "checkpoint-and-branch"
+  construction (evolve $S_j|\mathrm{GS}\rangle$ forward/backward in
+  $t_2$, apply $S_k$ at each checkpoint, evolve each branch further in
+  $\tau$, overlap with a fixed $S_l|\mathrm{GS}\rangle$ reference at
+  every step), then extracted via two closed-form time-domain kernels
+  (derived by inverse-Fourier-transforming $\Theta_0$ and $F_0$) rather
+  than by evaluating those functions pointwise on a discrete frequency
+  grid, which does not converge robustly for this construction — see
+  `kondospectrumtk/twotime.py`'s module docstring for the full
+  derivation and the numerical pitfalls it was built to avoid ($\Theta_0$'s
+  kernel is a Cauchy principal value, computed via an FFT-based Hilbert
+  transform for machine-precision accuracy). This is the expensive part:
+  cost scales with the number of $t_2$ checkpoints, each its own short
+  TDVP trajectory (`kondospectrumtk/dmrgtwotime.py`).
+
+Further `mode="DMRG"` limitations beyond the general ones above: the
+potential-interference term (`U!=0`, `order=3`) is not implemented for
+DMRG (raises `NotImplementedError`); the second-order term's `es`
+frequency-grid parameter has no safe default and must be supplied
+explicitly (it needs to cover every relevant transition energy, which is
+a property of the chain's spectrum, not of the `eV` sweep range — see
+`second_order_dIdV_dc`'s docstring). Most importantly,
+`kondospectrumtk/dmrgtwotime.py` was written against this codebase's
+existing, already-verified DMRG API (`toMPO`, the `tdvp_step` primitive,
+MPS operator application/overlap) but has not been executed or
+numerically validated against a compiled ITensor v3 backend — unlike
+every other piece of this feature (each cross-checked against an
+independent reference to sub-percent accuracy), it should be treated as
+provisional until confirmed in an environment where `itensor_version=3`
+is actually compiled (`tests/test_kondo_spectrum_dmrgtwotime.py`, which
+compares it against the ED two-time reference, is skipped automatically
+otherwise).

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1006,10 +1006,18 @@ cannot enumerate excited states the way `mode="ED"` does:
   transform for machine-precision accuracy). This is the expensive part:
   cost scales with the number of $t_2$ checkpoints, each its own short
   TDVP trajectory (`kondospectrumtk/dmrgtwotime.py`).
+- **Potential-interference term** (`U!=0`, part of `order=3`) is also
+  supported: its own $T=0$ limit collapses the excited-state sum to a
+  convolution of the *same* $T=0$ dynamical structure factor against the
+  $F_0$ kernel instead of $\Theta_0$'s cumulative-sum weighting, so it
+  reuses `get_dynamical_correlator` exactly like the second-order term
+  above, needing no excited-state enumeration either
+  (`kondospectrumtk/potentialdc.py`). Carries the same general-spin
+  extrapolation caveat as `conductance.third_order_potential_dIdV` (see
+  that function's docstring).
 
 Further `mode="DMRG"` limitations beyond the general ones above: the
-potential-interference term (`U!=0`, `order=3`) is not implemented for
-DMRG (raises `NotImplementedError`); the second-order term's `es`
+second-order term's `es`
 frequency-grid parameter has no safe default and must be supplied
 explicitly (it needs to cover every relevant transition energy, which is
 a property of the chain's spectrum, not of the `eV` sweep range — see

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1064,11 +1064,20 @@ different observable from the dynamical correlators of
 Section~\ref{sec:dynamical}: instead of a retarded Green's function of
 the spin system alone, it is the full Fermi's-golden-rule tunneling
 current through tip+spin+sample, expanded to third order in the
-tip-sample tunneling amplitude, evaluated by full exact diagonalization
-of the chain's Hamiltonian (every eigenstate is needed as a possible
-virtual intermediate state, not just the low-energy ones -- DMRG is not
-used here regardless of the chain's own \texttt{itensor\_version}/mode
-setting).
+tip-sample tunneling amplitude.
+
+Two backends are available via \texttt{mode=}:
+
+\begin{itemize}
+\item \texttt{mode="ED"} (default): full exact diagonalization of the
+  chain's Hamiltonian (every eigenstate is needed as a possible virtual
+  intermediate state, not just the low-energy ones), independent of the
+  chain's own \texttt{itensor\_version}/mode setting. Works at any
+  $T\geq0$.
+\item \texttt{mode="DMRG"}: \texttt{itensor\_version=3} throughout, never
+  diagonalizing beyond the ground state -- only $T=0$ is supported. See
+  "T=0 and the DMRG backend" below.
+\end{itemize}
 
 \begin{lstlisting}
 sc = spinchain.Spin_Chain(["1/2"])
@@ -1133,5 +1142,61 @@ specific numbers:
   out in closed form in the paper) and carries lower confidence than the
   other terms; treat it as provisional.
 \end{itemize}
+
+\textbf{T=0 and the DMRG backend} (\texttt{mode="DMRG"}). At $T=0$ only
+the ground state is thermally populated, which simplifies both terms
+enough to avoid diagonalizing beyond the ground state entirely -- the
+actual motivation for supporting \texttt{mode="DMRG"} in the first
+place, since DMRG cannot enumerate excited states the way
+\texttt{mode="ED"} does:
+
+\begin{itemize}
+\item \textbf{Second order} reduces to a $\Theta_0$-weighted (the exact,
+  closed-form Heaviside limit of $\Theta$) cumulative integral of the
+  ordinary $T=0$ dynamical structure factor
+  $S_{\alpha\alpha}(\omega)=\sum_f|\langle f|S_\alpha|\mathrm{GS}\rangle|^2\delta(\omega-\epsilon_{f0})$,
+  which \texttt{get\_dynamical\_correlator} already computes
+  (\texttt{submode="KPM"} or \texttt{"CVM"}) without any excited-state
+  enumeration (\texttt{kondospectrumtk/secondorder\_dc.py}).
+\item \textbf{Third order} cannot be reduced to a two-operator correlator
+  (it is a three-vertex object, with two \emph{different} intermediate
+  states each weighted by a different function, $\Theta_0$ and $F_0$) --
+  instead it is built from a Heisenberg three-point function
+  $G(t_2,\tau)=\langle\mathrm{GS}|S_l(t_2+\tau)S_k(t_2)S_j(0)|\mathrm{GS}\rangle$,
+  obtained via real-time TDVP evolution with a "checkpoint-and-branch"
+  construction (evolve $S_j|\mathrm{GS}\rangle$ forward/backward in
+  $t_2$, apply $S_k$ at each checkpoint, evolve each branch further in
+  $\tau$, overlap with a fixed $S_l|\mathrm{GS}\rangle$ reference at
+  every step), then extracted via two closed-form time-domain kernels
+  (derived by inverse-Fourier-transforming $\Theta_0$ and $F_0$) rather
+  than by evaluating those functions pointwise on a discrete frequency
+  grid, which does not converge robustly for this construction -- see
+  \texttt{kondospectrumtk/twotime.py}'s module docstring for the full
+  derivation and the numerical pitfalls it was built to avoid
+  ($\Theta_0$'s kernel is a Cauchy principal value, computed via an
+  FFT-based Hilbert transform for machine-precision accuracy). This is
+  the expensive part: cost scales with the number of $t_2$ checkpoints,
+  each its own short TDVP trajectory
+  (\texttt{kondospectrumtk/dmrgtwotime.py}).
+\end{itemize}
+
+Further \texttt{mode="DMRG"} limitations beyond the general ones above:
+the potential-interference term (\texttt{U!=0}, \texttt{order=3}) is not
+implemented for DMRG (raises \texttt{NotImplementedError}); the
+second-order term's \texttt{es} frequency-grid parameter has no safe
+default and must be supplied explicitly (it needs to cover every
+relevant transition energy, which is a property of the chain's spectrum,
+not of the \texttt{eV} sweep range -- see \texttt{second\_order\_dIdV\_dc}'s
+docstring). Most importantly, \texttt{kondospectrumtk/dmrgtwotime.py} was
+written against this codebase's existing, already-verified DMRG API
+(\texttt{toMPO}, the \texttt{tdvp\_step} primitive, MPS operator
+application/overlap) but has not been executed or numerically validated
+against a compiled ITensor v3 backend -- unlike every other piece of this
+feature (each cross-checked against an independent reference to
+sub-percent accuracy), it should be treated as provisional until
+confirmed in an environment where \texttt{itensor\_version=3} is actually
+compiled (\texttt{tests/test\_kondo\_spectrum\_dmrgtwotime.py}, which
+compares it against the ED two-time reference, is skipped automatically
+otherwise).
 
 \end{document}

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1187,9 +1187,16 @@ second-order term's \texttt{es} frequency-grid parameter has no safe
 default and must be supplied explicitly (it needs to cover every
 relevant transition energy, which is a property of the chain's spectrum,
 not of the \texttt{eV} sweep range -- see \texttt{second\_order\_dIdV\_dc}'s
-docstring); chains need at least 3 sites (a 1-site chain hits an internal
-ITensor v3 error unrelated to this feature, building the Hamiltonian
-MPO).
+docstring); the third-order term's \texttt{dt2}, \texttt{n\_t2\_half},
+\texttt{dtau}, \texttt{n\_tau\_half} time-grid parameters likewise have
+no safe default and must be supplied explicitly (a grid fine/wide enough
+for the default $\omega_0$/$\Gamma_0$ needs $\sim10^5$--$10^6$ $t_2$
+checkpoints, each its own real TDVP trajectory -- infeasible as a silent
+default -- while a small, fast default is wildly under-resolved and
+returns a finite but silently wrong result instead of erroring, confirmed
+directly; see \texttt{two\_time\_kondo\_term\_dmrg}'s docstring); chains
+need at least 3 sites (a 1-site chain hits an internal ITensor v3 error
+unrelated to this feature, building the Hamiltonian MPO).
 
 \texttt{kondospectrumtk/dmrgtwotime.py} was written against this
 codebase's existing, verified DMRG API and validated once a compiled

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1178,12 +1178,20 @@ place, since DMRG cannot enumerate excited states the way
   the expensive part: cost scales with the number of $t_2$ checkpoints,
   each its own short TDVP trajectory
   (\texttt{kondospectrumtk/dmrgtwotime.py}).
+\item \textbf{Potential-interference term} (\texttt{U!=0}, part of
+  \texttt{order=3}) is also supported: its own $T=0$ limit collapses the
+  excited-state sum to a convolution of the \emph{same} $T=0$ dynamical
+  structure factor against the $F_0$ kernel instead of $\Theta_0$'s
+  cumulative-sum weighting, so it reuses \texttt{get\_dynamical\_correlator}
+  exactly like the second-order term above, needing no excited-state
+  enumeration either (\texttt{kondospectrumtk/potentialdc.py}). Carries
+  the same general-spin extrapolation caveat as
+  \texttt{conductance.third\_order\_potential\_dIdV} (see that function's
+  docstring).
 \end{itemize}
 
 Further \texttt{mode="DMRG"} limitations beyond the general ones above:
-the potential-interference term (\texttt{U!=0}, \texttt{order=3}) is not
-implemented for DMRG (raises \texttt{NotImplementedError}); the
-second-order term's \texttt{es} frequency-grid parameter has no safe
+the second-order term's \texttt{es} frequency-grid parameter has no safe
 default and must be supplied explicitly (it needs to cover every
 relevant transition energy, which is a property of the chain's spectrum,
 not of the \texttt{eV} sweep range -- see \texttt{second\_order\_dIdV\_dc}'s

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1187,16 +1187,29 @@ second-order term's \texttt{es} frequency-grid parameter has no safe
 default and must be supplied explicitly (it needs to cover every
 relevant transition energy, which is a property of the chain's spectrum,
 not of the \texttt{eV} sweep range -- see \texttt{second\_order\_dIdV\_dc}'s
-docstring). Most importantly, \texttt{kondospectrumtk/dmrgtwotime.py} was
-written against this codebase's existing, already-verified DMRG API
-(\texttt{toMPO}, the \texttt{tdvp\_step} primitive, MPS operator
-application/overlap) but has not been executed or numerically validated
-against a compiled ITensor v3 backend -- unlike every other piece of this
-feature (each cross-checked against an independent reference to
-sub-percent accuracy), it should be treated as provisional until
-confirmed in an environment where \texttt{itensor\_version=3} is actually
-compiled (\texttt{tests/test\_kondo\_spectrum\_dmrgtwotime.py}, which
-compares it against the ED two-time reference, is skipped automatically
-otherwise).
+docstring); chains need at least 3 sites (a 1-site chain hits an internal
+ITensor v3 error unrelated to this feature, building the Hamiltonian
+MPO).
+
+\texttt{kondospectrumtk/dmrgtwotime.py} was written against this
+codebase's existing, verified DMRG API and validated once a compiled
+ITensor v3 backend became available: $G(t_2,\tau)$ matches the ED
+reference to $\sim10^{-9}$--$10^{-10}$ pointwise, and the swept
+third-order Kondo term matches a grid-consistent ED reference to
+$\sim10^{-10}$ (\texttt{tests/test\_kondo\_spectrum\_dmrgtwotime.py},
+skipped automatically when no compiled \texttt{itensor\_version=3}
+backend is available). Getting there surfaced three real bugs, none of
+which showed up in the ED-only testing this module was originally
+written against -- see that module's own docstring for the details (in
+short: \texttt{tdvp\_step} silently renormalizes every step to unit norm,
+discarding $S_j|\mathrm{GS}\rangle$'s true amplitude unless corrected for
+explicitly; a forward/backward time-stepping bug meant "backward"
+checkpoints never actually reached negative times; and a naive per-chunk
+trapezoidal integral is exactly 0 for the single-$t_2$-point chunks
+real-time evolution necessarily produces, silently zeroing the entire
+term). The second-order term (\texttt{submode="KPM"}) was spot-checked
+too, agreeing to within a few tens of percent at thresholds, consistent
+with the expected $\delta$-broadening/moment-truncation error on top of
+what the ED path already has.
 
 \end{document}

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1052,4 +1052,86 @@ for i in range(n):
         Sqw[(i, j)] = (x, y)          # combine with sum_ij e^{iq(i-j)} S_ij(w) offline
 \end{lstlisting}
 
+\section{STM/Kondo tunneling spectra (third-order perturbation theory)}
+\label{sec:kondospectrum}
+
+\texttt{Spin\_Chain.get\_kondo\_spectrum} computes the differential
+tunneling conductance $dI/dV(eV)$ of an STM tip coupled to one site of a
+spin chain, following the weak-coupling (Kondo-scattering) perturbation
+theory of Ternes, \emph{New J. Phys.} \textbf{17}, 063016 (2015),
+\href{https://arxiv.org/abs/1505.04430}{arXiv:1505.04430}. This is a
+different observable from the dynamical correlators of
+Section~\ref{sec:dynamical}: instead of a retarded Green's function of
+the spin system alone, it is the full Fermi's-golden-rule tunneling
+current through tip+spin+sample, expanded to third order in the
+tip-sample tunneling amplitude, evaluated by full exact diagonalization
+of the chain's Hamiltonian (every eigenstate is needed as a possible
+virtual intermediate state, not just the low-energy ones -- DMRG is not
+used here regardless of the chain's own \texttt{itensor\_version}/mode
+setting).
+
+\begin{lstlisting}
+sc = spinchain.Spin_Chain(["1/2"])
+sc.set_hamiltonian(g*muB*B*sc.Sz[0])   # Zeeman-split S=1/2 impurity
+eV, dIdV = sc.get_kondo_spectrum(eV_grid, site=0, Jrho_s=-0.05, U=0.25,
+                                  T=1.0, order=3)
+\end{lstlisting}
+
+\textbf{Second order} (\texttt{order=2}) is the plain
+spin-flip/potential-scattering Fermi golden rule result,
+
+\begin{equation}
+\frac{\partial I}{\partial V}(eV)\propto\sum_{i,f}p_i\Big[\tfrac12|\langle f|S_-|i\rangle|^2+\tfrac12|\langle f|S_+|i\rangle|^2+|\langle f|S_z|i\rangle|^2\Big]\,\Theta(eV-\epsilon_{if})+U^2
+\end{equation}
+
+summed over both tunneling directions, with $p_i$ the Boltzmann
+occupation of eigenstate $i$ at temperature $T$ and $\Theta$ a
+temperature-broadened step function. This reproduces the textbook
+inelastic-tunneling spin-flip steps at $eV=\pm(\epsilon_f-\epsilon_i)$
+(e.g.\ the Zeeman step of a single $S=1/2$ impurity).
+
+\textbf{Third order} (\texttt{order=3}, the default) adds two
+corrections that require summing over \emph{all} eigenstates as virtual
+intermediate states $m$ (energy conservation is not required for $m$): a
+Kondo term (a Levi-Civita triple product of spin matrix elements
+$\langle i|S|f\rangle$, $\langle f|S|m\rangle$, $\langle m|S|i\rangle$,
+weighted by a temperature-broadened logarithmic function
+$F(eV-\epsilon_m,T)$ that produces the characteristic zero-bias
+Kondo-like resonance, splitting into two peaks under a Zeeman field),
+and -- when \texttt{U!=0} -- a potential-scattering interference term
+responsible for a bias-asymmetric lineshape.
+
+\textbf{Scope and known limitations}, worth reading before trusting
+specific numbers:
+
+\begin{itemize}
+\item Only a single chain site couples to the tip (\texttt{site=}); the
+  paper's own model allows several sites with independent tip couplings,
+  not implemented here.
+\item The third-order terms (\texttt{order=3}) are
+  $\partial I^{t\to s}/\partial V$ only, not the full bidirectional
+  net-current derivative that \texttt{order=2} provides. The paper never
+  gives a general $t\leftrightarrow s$ formula for them -- its own worked
+  $S=1/2$ example shows the two directions are related by more than a
+  plain $eV\to-eV$ mirror, so no such generalization is attempted here.
+  This mainly affects the \emph{symmetry} of the returned third-order
+  spectrum, not its second-order part.
+\item The paper's own closed-form equations for two numerical building
+  blocks -- the temperature-broadened step $\Theta(x)$ and the
+  temperature-broadened Kondo log function $F(\epsilon,T)$ -- do not
+  reproduce the physics the paper itself describes for them (checked
+  directly: the printed $\Theta(x)$ diverges rather than saturating, and
+  the printed $F$ closed form drops its own temperature broadening).
+  \texttt{kondospectrumtk/stepfunctions.py} uses corrected forms
+  instead, re-derived from the paper's own unambiguous defining
+  integrals and verified against digitized values from the paper's own
+  figures (see that module's docstring, and
+  \texttt{examples/kondo\_spectrum\_VS\_paper/}).
+\item The potential-interference term's general-spin closed form
+  (\texttt{U!=0} in \texttt{order=3}) is an extrapolation from the
+  paper's own worked $S=1/2$ example (only that special case is spelled
+  out in closed form in the paper) and carries lower confidence than the
+  other terms; treat it as provisional.
+\end{itemize}
+
 \end{document}

--- a/examples/kondo_spectrum_VS_paper/main.py
+++ b/examples/kondo_spectrum_VS_paper/main.py
@@ -1,0 +1,83 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../src')
+
+# Regression example for Spin_Chain.get_kondo_spectrum (kondospectrumtk/),
+# the third-order STM/Kondo perturbation-theory dI/dV spectrum of Ternes,
+# New J. Phys. 17 063016 (2015), arXiv:1505.04430, for a single S=1/2
+# impurity spin in a Zeeman field -- the paper's own simplest worked
+# example (Figs. 2 and 3).
+#
+# Two of the paper's own closed-form equations for the numerical building
+# blocks (eq. "step-fkt" for the temperature-broadened step Theta(x), and
+# equ. "F_2" for the temperature-broadened Kondo log function F(eps,T))
+# turned out not to reproduce the physics/figures the paper itself
+# describes (Theta(x) as printed diverges as x->-inf instead of
+# saturating at 0; F(eps,T) as printed drops the temperature-dependent
+# broadening the surrounding text and Fig. F describe). kondospectrumtk/
+# uses corrected forms instead, re-derived directly from the paper's own
+# unambiguous defining equations (eq. "current" for Theta; equ. "F_1" for
+# F) -- see kondospectrumtk/stepfunctions.py's module docstring for the
+# full derivation notes. This example checks those corrected pieces
+# quantitatively against the paper's own plotted values (digitized by eye
+# from Fig. F(b)), and the assembled spectrum against the qualitative
+# shapes described in the text and shown in Figs. 2 and 3.
+import numpy as np
+from dmrgpy import spinchain
+from dmrgpy.kondospectrumtk.stepfunctions import F
+
+G = 2.0
+MUB = 5.7883818066e-5 # eV/T
+
+# --- F(eps,T) vs Fig. F(b): T=1K, omega0=200meV, Gamma0=5ueV --------------
+vals = F(np.array([0., 10e-3]), T=1.0, omega0=0.2, Gamma0=5e-6)
+assert abs(vals[0] - 7.5) < 0.1, vals[0] # peak height read off the figure
+assert abs(vals[1] - 3.1) < 0.2, vals[1] # value at eV-eps_m=10meV
+
+# --- second order: S=1/2 Zeeman step, T=1K, g=2 (Fig. 2) ------------------
+def make_chain(B):
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*B*sc.Sz[0])
+    return sc
+
+B = 10.0 # Tesla
+zeeman = G*MUB*B
+sc = make_chain(B)
+eVs = np.linspace(-3*zeeman, 3*zeeman, 121)
+eV, dIdV2 = sc.get_kondo_spectrum(eVs, site=0, T=1.0, order=2)
+
+# symmetric temperature-broadened step centered at +-the Zeeman energy:
+# low plateau (only the elastic channel open) well inside +-zeeman, high
+# plateau (elastic + inelastic both open) well outside it
+inside = np.abs(eV) < 0.3*zeeman
+outside = np.abs(eV) > 2*zeeman
+assert np.allclose(dIdV2, dIdV2[::-1], atol=1e-6) # symmetric in eV
+assert np.mean(dIdV2[outside]) > 2*np.mean(dIdV2[inside])
+
+# --- third order Kondo term: zero-field zero-bias resonance (Fig. 3a/b) ---
+sc0 = make_chain(0.0)
+span = 3e-3
+eVs3 = np.linspace(-span, span, 61)
+_, d2_only = sc0.get_kondo_spectrum(eVs3, site=0, T=1.0, order=2)
+_, d3_total = sc0.get_kondo_spectrum(eVs3, site=0, Jrho_s=-0.05, T=1.0, order=3)
+# with U=0 second order is exactly flat at B=0 (fully degenerate levels);
+# the third-order Kondo term must add real structure (a zero-bias feature)
+assert np.allclose(d2_only, d2_only[0])
+assert np.max(np.abs(d3_total - d2_only)) > 0.05*d2_only[0]
+
+# --- third order potential-interference term: bias asymmetry (Fig. 3c/d) --
+# Isolate eq. "U-M"'s own contribution (d_U - d_noU): the third-order
+# Kondo term alone (d_noU) is t->s current only (see
+# third_order_kondo_dIdV's docstring) and so is not itself perfectly
+# symmetric in eV either, which would confound a direct d_noU-vs-d_U
+# comparison -- the potential-interference term specifically is what eq.
+# "U-M" says should be bias-asymmetric.
+from dmrgpy.kondospectrumtk.conductance import third_order_potential_dIdV
+from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum
+scB = make_chain(10.0)
+eVs4 = np.linspace(-3e-3, 3e-3, 41)
+ksB = KondoSpectrum(scB, site=0, T=1.0)
+dU_only = third_order_potential_dIdV(ksB, eVs4, Jrho_s=-0.05, U=0.25, T0=1.0)
+assert np.allclose(third_order_potential_dIdV(ksB, eVs4, Jrho_s=-0.05, U=0.0, T0=1.0), 0.)
+assert not np.allclose(dU_only, dU_only[::-1], atol=1e-8) # bias-asymmetric
+
+print("All Kondo-spectrum checks against the paper's Figs. F/2/3 passed.")

--- a/examples/kondo_spectrum_VS_paper/main.py
+++ b/examples/kondo_spectrum_VS_paper/main.py
@@ -81,3 +81,35 @@ assert np.allclose(third_order_potential_dIdV(ksB, eVs4, Jrho_s=-0.05, U=0.0, T0
 assert not np.allclose(dU_only, dU_only[::-1], atol=1e-8) # bias-asymmetric
 
 print("All Kondo-spectrum checks against the paper's Figs. F/2/3 passed.")
+
+# --- T=0: exact closed-form limit, consistent with small-but-finite T ------
+from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum as KS0
+scB2 = make_chain(10.0)
+eVs5 = np.linspace(-2e-3, 2e-3, 21)
+_, dIdV_T0 = scB2.get_kondo_spectrum(eVs5, site=0, Jrho_s=-0.05, T=0.0, order=3)
+_, dIdV_smallT = scB2.get_kondo_spectrum(eVs5, site=0, Jrho_s=-0.05, T=1e-3, order=3)
+assert np.max(np.abs(dIdV_T0 - dIdV_smallT)) < 1e-2
+
+# --- T=0 third-order Kondo term via the excited-state-free two-time
+# construction (kondospectrumtk/twotime.py + edtwotimeref.py), the
+# building block a DMRG (itensor_version=3) implementation reuses on top
+# of real TDVP time evolution instead of ED's eigenbasis-exact evolution
+# -- checked here against the ordinary excited-state-sum reference, using
+# deliberately modest/fast grid parameters (see that module's own tests
+# for the resolution/accuracy tradeoffs).
+from dmrgpy.kondospectrumtk.conductance import third_order_kondo_dIdV as tokd
+from dmrgpy.kondospectrumtk.edtwotimeref import two_time_kondo_term_ed
+
+scC = make_chain(10.0)
+ksC = KS0(scC, site=0, T=0.0)
+eVs6 = np.linspace(-2e-3, 2e-3, 9)
+omega0_tt, Gamma0_tt = 2e-3, 5e-6
+twotime_term = 4*np.pi*1.0**2*(-0.05)*two_time_kondo_term_ed(
+        ksC, eVs6, omega0=omega0_tt, Gamma0=Gamma0_tt,
+        t2_width=25/Gamma0_tt, t2_npts=40_000, t2_batch=10_000,
+        tau_width=2*np.pi/2e-5, tau_npts=1_000)
+excited_state_sum_term = tokd(ksC, eVs6, -0.05, T0=1.0, omega0=omega0_tt,
+                               Gamma0=Gamma0_tt)
+assert np.max(np.abs(twotime_term - excited_state_sum_term)) < 0.02
+
+print("All T=0 / two-time-correlator checks passed.")

--- a/src/dmrgpy/kondospectrumtk/conductance.py
+++ b/src/dmrgpy/kondospectrumtk/conductance.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .stepfunctions import Theta, FBuilder
+from .stepfunctions import Theta, Theta0, FBuilder, F0
 
 # Second- and third-order dI/dV for the STM/Kondo perturbation theory of
 # Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430, assembled from
@@ -25,6 +25,23 @@ from .stepfunctions import Theta, FBuilder
 # two directions.
 
 
+def _theta_raw(ks, x):
+    """Theta evaluated at a raw energy argument x (not yet divided by kT);
+    ks.T==0 dispatches to the closed-form Heaviside limit Theta0(x)."""
+    if ks.T == 0.: return Theta0(x)
+    return Theta(x/(ks.kB*ks.T))
+
+
+def _get_F(ks, omega0, Gamma0, Fb):
+    """Return a callable F(x_array)->array: the closed-form F0 at ks.T==0,
+    otherwise a (possibly caller-supplied, shared) FBuilder."""
+    if ks.T == 0.:
+        return lambda x: F0(x, omega0=omega0, Gamma0=Gamma0)
+    if Fb is None:
+        return FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    return Fb
+
+
 def _spin_matrix_elements_squared(ks):
     """|M_if|^2 = 1/2|<f|S-|i>|^2 + 1/2|<f|S+|i>|^2 + |<f|Sz|i>|^2,
     eq. "SA-transitionmatrix" (unpolarized tip and sample)."""
@@ -42,15 +59,15 @@ def second_order_dIdV(ks, eVs, T0=1.0, U=0.0):
     and is not included here (a polarized-lead generalization would need
     the appendix's eq. "Matrix-appendix")."""
     eVs = np.asarray(eVs, dtype=float)
-    kT = ks.kB*ks.T
     M2 = _spin_matrix_elements_squared(ks) # [f,i]
     eps = ks.e[:, None] - ks.e[None, :] # eps[f,i] = e_f - e_i
     weight = ks.p[None, :]*M2 # weight[f,i] = p_i*|M_if|^2
-    x_ts = (eVs[:, None, None] - eps[None, :, :])/kT
-    x_st = (-eVs[:, None, None] - eps[None, :, :])/kT
-    spin_term = (np.einsum('fi,efi->e', weight, Theta(x_ts))
-                 + np.einsum('fi,efi->e', weight, Theta(x_st)))
-    # elastic potential scattering: eps_ii=0, Theta(eV/kT)+Theta(-eV/kT)=1
+    x_ts = eVs[:, None, None] - eps[None, :, :]
+    x_st = -eVs[:, None, None] - eps[None, :, :]
+    spin_term = (np.einsum('fi,efi->e', weight, _theta_raw(ks, x_ts))
+                 + np.einsum('fi,efi->e', weight, _theta_raw(ks, x_st)))
+    # elastic potential scattering: eps_ii=0, Theta(eV)+Theta(-eV)=1
+    # (Theta0(0)+Theta0(-0)=1 too, by the same convention)
     U_term = (U**2)*np.ones_like(eVs)
     return 2*np.pi*T0**2*(spin_term + U_term)
 
@@ -101,17 +118,17 @@ def third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0, omega0=20e-3, Gamma0=5e-6,
     _band_integral over hundreds of adaptive-quadrature points, so
     callers that also need third_order_potential_dIdV with the same
     T/omega0/Gamma0 (e.g. Spin_Chain.get_kondo_spectrum) should build it
-    once and pass it to both."""
+    once and pass it to both. Ignored at ks.T==0 (uses the closed-form F0
+    instead)."""
     eVs = np.asarray(eVs, dtype=float)
-    kT = ks.kB*ks.T
     coeff = np.imag(_triple_product_coefficients(ks))/4. # Re[X/(4i)] = Im[X]/4
     eps_if = ks.e[None, :] - ks.e[:, None] # eps_if[i,f] = e_f - e_i
     eps_im = ks.e[None, :] - ks.e[:, None] # eps_im[i,m] = e_m - e_i
-    if Fb is None: Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    Fcall = _get_F(ks, omega0, Gamma0, Fb)
     dim = ks.dim
-    Fim = Fb((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
-    Fmi = Fb((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
-    Th = Theta((eVs[:, None, None] - eps_if[None, :, :])/kT)
+    Fim = Fcall((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Fmi = Fcall((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Th = _theta_raw(ks, eVs[:, None, None] - eps_if[None, :, :])
     Fsum = Fim + Fmi # direct (eps_im) + exchange (eps_mi=-eps_im) diagrams
     total = np.einsum('i,ifm,eif,eim->e', ks.p, coeff, Th, Fsum, optimize=True)
     return 4*np.pi*T0**2*Jrho_s*total
@@ -147,16 +164,17 @@ def third_order_potential_dIdV(ks, eVs, Jrho_s, U, T0=1.0, omega0=20e-3,
     produce in the first place).
 
     Fb: see third_order_kondo_dIdV's docstring -- pass the same FBuilder
-    to both to avoid rebuilding its expensive tabulation twice."""
+    to both to avoid rebuilding its expensive tabulation twice. Ignored at
+    ks.T==0 (uses the closed-form F0 instead)."""
     eVs = np.asarray(eVs, dtype=float)
     Xi = np.stack([ks.Sx, ks.Sy, ks.Sz], axis=-1) # Xi[a,b,alpha]=<a|S_alpha|b>
     loop = np.real(np.einsum('imk,mik->im', Xi, Xi)) # sum_k |<i|Sk|m>|^2
     eps_im = ks.e[None, :] - ks.e[:, None] # eps_im[i,m] = e_m - e_i
-    if Fb is None: Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    Fcall = _get_F(ks, omega0, Gamma0, Fb)
     dim = ks.dim
-    Fim = Fb((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
-    Fmi = Fb((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Fim = Fcall((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Fmi = Fcall((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
     Fsum = Fim + Fmi
     weighted = np.einsum('i,im,eim->e', ks.p, loop, Fsum, optimize=True)
-    total = weighted*Theta(eVs/(ks.kB*ks.T))
+    total = weighted*_theta_raw(ks, eVs)
     return 4*np.pi*T0**2*Jrho_s*U*total

--- a/src/dmrgpy/kondospectrumtk/conductance.py
+++ b/src/dmrgpy/kondospectrumtk/conductance.py
@@ -1,0 +1,151 @@
+import numpy as np
+from .stepfunctions import Theta, FBuilder
+
+# Second- and third-order dI/dV for the STM/Kondo perturbation theory of
+# Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430, assembled from
+# a KondoSpectrum (full ED spectrum + eigenbasis spin matrix elements,
+# see edkondo.py).
+#
+# Throughout, matrices Sx/Sy/Sz stored on a KondoSpectrum are indexed
+# [f,i] = <f|S|i>, i.e. directly in the paper's M_if convention (row is
+# the *second*, bra, subscript). eps[f,i] = e_f - e_i matches eps_if.
+#
+# Results are returned in units of 2*pi*e^2*T0^2/hbar (i.e. the physical
+# prefactor is folded into T0, which is otherwise a free, experiment-
+# dependent tunneling-strength scale -- see eq. "current"/"conductance").
+#
+# Both tunneling directions (t->s and s->t) are summed, since a measured
+# dI/dV is for the net current I = I^{t->s} - I^{s->t} (eq. "current").
+# For unpolarized tip and sample the spin-exchange matrix elements are
+# identical in both directions (the polarization-dependent prefactors
+# (1+-eta)/2 both reduce to 1/2 at eta=0), and the s->t contribution to
+# d(-I^{s->t})/d(eV) works out to the same Theta(x) evaluated at
+# x=-eV-eps_if (see the derivation note in kondospectrum.py's module
+# docstring) -- so only the sign of eV (not of eps_if) flips between the
+# two directions.
+
+
+def _spin_matrix_elements_squared(ks):
+    """|M_if|^2 = 1/2|<f|S-|i>|^2 + 1/2|<f|S+|i>|^2 + |<f|Sz|i>|^2,
+    eq. "SA-transitionmatrix" (unpolarized tip and sample)."""
+    Splus = ks.Sx + 1j*ks.Sy
+    Sminus = ks.Sx - 1j*ks.Sy
+    return 0.5*np.abs(Sminus)**2 + 0.5*np.abs(Splus)**2 + np.abs(ks.Sz)**2
+
+
+def second_order_dIdV(ks, eVs, T0=1.0, U=0.0):
+    """Second-order (Fermi golden rule) dI/dV, eq. "conductance", summed
+    over both tunneling directions. U is the dimensionless potential-
+    scattering ratio (eq. "Matrix1"); its interference with the spin-
+    exchange term (eq. "Matrix1sq"'s third term, the origin of magneto-
+    resistive tunneling) vanishes identically for unpolarized tip/sample
+    and is not included here (a polarized-lead generalization would need
+    the appendix's eq. "Matrix-appendix")."""
+    eVs = np.asarray(eVs, dtype=float)
+    kT = ks.kB*ks.T
+    M2 = _spin_matrix_elements_squared(ks) # [f,i]
+    eps = ks.e[:, None] - ks.e[None, :] # eps[f,i] = e_f - e_i
+    weight = ks.p[None, :]*M2 # weight[f,i] = p_i*|M_if|^2
+    x_ts = (eVs[:, None, None] - eps[None, :, :])/kT
+    x_st = (-eVs[:, None, None] - eps[None, :, :])/kT
+    spin_term = (np.einsum('fi,efi->e', weight, Theta(x_ts))
+                 + np.einsum('fi,efi->e', weight, Theta(x_st)))
+    # elastic potential scattering: eps_ii=0, Theta(eV/kT)+Theta(-eV/kT)=1
+    U_term = (U**2)*np.ones_like(eVs)
+    return 2*np.pi*T0**2*(spin_term + U_term)
+
+
+_EPS3 = np.zeros((3, 3, 3))
+for _i, _j, _k in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]:
+    _EPS3[_i, _j, _k] = 1.
+for _i, _j, _k in [(0, 2, 1), (2, 1, 0), (1, 0, 2)]:
+    _EPS3[_i, _j, _k] = -1.
+
+
+def _triple_product_coefficients(ks):
+    """coeff[i,f,m] = sum_jkl eps_jkl <i|S_l|f><f|S_k|m><m|S_j|i>, the
+    Levi-Civita triple product appearing in eq. "3rd-normal"/"3rd-reversed"
+    (both give the identical coefficient; only the F(...) argument
+    differs between the direct and exchange diagrams)."""
+    Xi = np.stack([ks.Sx, ks.Sy, ks.Sz], axis=-1) # Xi[a,b,alpha]=<a|S_alpha|b>
+    return np.einsum('jkl,ifl,fmk,mij->ifm', _EPS3, Xi, Xi, Xi, optimize=True)
+
+
+def third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0, omega0=20e-3, Gamma0=5e-6):
+    """Third-order Kondo term, eqs. "3rd-normal" (direct diagram) +
+    "3rd-reversed" (exchange diagram -- despite the name this is NOT the
+    s->t tunneling direction: the paper's own "t -R-> s" notation on eq.
+    "3rd-reversed" marks it as the reversed *interaction order* diagram,
+    still for t->s tunneling; both equations are introduced as replacing
+    M_1 with M_1+M_2 inside eq. "conductance", which is explicitly the
+    t->s formula), summed over all i,f,m (m unrestricted -- a virtual
+    intermediate state).
+
+    Unlike second_order_dIdV, this returns d(I^{t->s})/dV only: the paper
+    never gives a general s->t formula for the third-order terms (its own
+    worked S=1/2 example, eqs. "sym_z"/"asym_U", shows the two directions
+    are related by more than a plain eV -> -eV mirror -- an overall sign
+    flip "due to the rearrangement of the interaction order together with
+    the switching from hole-like to electron-like scattering"), so no
+    such generalization is attempted here. For the field-split zero-bias
+    Kondo peak this reproduces (Fig. 3a/b), t->s alone already carries the
+    symmetric-in-eV lineshape shown there.
+
+    This is an O(dim^3 * len(eVs)) calculation, inherent to the triple sum
+    over eigenstates -- expected to be the bottleneck for larger Hilbert
+    spaces."""
+    eVs = np.asarray(eVs, dtype=float)
+    kT = ks.kB*ks.T
+    coeff = np.imag(_triple_product_coefficients(ks))/4. # Re[X/(4i)] = Im[X]/4
+    eps_if = ks.e[:, None] - ks.e[None, :] # eps_if[i,f] = e_f - e_i
+    eps_im = ks.e[None, :] - ks.e[:, None] # eps_im[i,m] = e_m - e_i
+    Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    dim = ks.dim
+    Fim = Fb((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Fmi = Fb((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Th = Theta((eVs[:, None, None] - eps_if[None, :, :])/kT)
+    Fsum = Fim + Fmi # direct (eps_im) + exchange (eps_mi=-eps_im) diagrams
+    total = np.einsum('i,ifm,eif,eim->e', ks.p, coeff, Th, Fsum, optimize=True)
+    return 4*np.pi*T0**2*Jrho_s*total
+
+
+def third_order_potential_dIdV(ks, eVs, Jrho_s, U, T0=1.0, omega0=20e-3,
+                                Gamma0=5e-6):
+    """Third-order potential-scattering interference term, eq. "U-M"
+    (the origin of the bias asymmetry in Fig. 3c/d).
+
+    LOWER CONFIDENCE than second_order_dIdV/third_order_kondo_dIdV: the
+    paper gives eq. "U-M" itself unambiguously, but only spells out its
+    electron-spin-averaged (unpolarized-lead) closed form -- the one
+    actually needed here -- via a worked S=1/2 example (eqs. "sym_z"/
+    "asym_U"), not a general-S formula. This implementation extrapolates
+    to general S by replacing eq. "3rd-normal"'s antisymmetric
+    Levi-Civita triple product (which comes from an electron-spin trace
+    of three Pauli matrices, Tr[sigma_l sigma_k sigma_j] ~ i*eps_jkl) with
+    the symmetric dot product Tr[sigma_l * I] ~ delta_lk gives when the
+    outer, U-carrying vertex is the electron identity instead of a third
+    Pauli matrix -- i.e. sum_k <i|Sk|m><m|Sk|i> = sum_k |<i|Sk|m>|^2,
+    manifestly real. eq. "U-M"'s I_fi=delta_fi forces the impurity to
+    return to its initial state (elastic), collapsing the i,f,m sum to a
+    two-state i,m loop. The overall numeric prefactor is not pinned down
+    by the paper and is set here to match third_order_kondo_dIdV's
+    normalization by analogy; treat this term as provisional until
+    checked against Fig. 3c/d directly.
+
+    Like third_order_kondo_dIdV, this returns d(I^{t->s})/dV only -- see
+    that function's docstring for why the s->t direction is not attempted
+    here (the paper's own worked example shows it is not a plain eV ->
+    -eV mirror, which is exactly the bias asymmetry this term is meant to
+    produce in the first place)."""
+    eVs = np.asarray(eVs, dtype=float)
+    Xi = np.stack([ks.Sx, ks.Sy, ks.Sz], axis=-1) # Xi[a,b,alpha]=<a|S_alpha|b>
+    loop = np.real(np.einsum('imk,mik->im', Xi, Xi)) # sum_k |<i|Sk|m>|^2
+    eps_im = ks.e[None, :] - ks.e[:, None] # eps_im[i,m] = e_m - e_i
+    Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    dim = ks.dim
+    Fim = Fb((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Fmi = Fb((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
+    Fsum = Fim + Fmi
+    weighted = np.einsum('i,im,eim->e', ks.p, loop, Fsum, optimize=True)
+    total = weighted*Theta(eVs/(ks.kB*ks.T))
+    return 4*np.pi*T0**2*Jrho_s*U*total

--- a/src/dmrgpy/kondospectrumtk/conductance.py
+++ b/src/dmrgpy/kondospectrumtk/conductance.py
@@ -122,8 +122,10 @@ def third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0, omega0=20e-3, Gamma0=5e-6,
     instead)."""
     eVs = np.asarray(eVs, dtype=float)
     coeff = np.imag(_triple_product_coefficients(ks))/4. # Re[X/(4i)] = Im[X]/4
-    eps_if = ks.e[None, :] - ks.e[:, None] # eps_if[i,f] = e_f - e_i
-    eps_im = ks.e[None, :] - ks.e[:, None] # eps_im[i,m] = e_m - e_i
+    # eps_if[i,f] = e_f - e_i and eps_im[i,m] = e_m - e_i are the same
+    # array (e[None,:]-e[:,None]) under two names for readability at the
+    # call sites below
+    eps_if = eps_im = ks.e[None, :] - ks.e[:, None]
     Fcall = _get_F(ks, omega0, Gamma0, Fb)
     dim = ks.dim
     Fim = Fcall((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)

--- a/src/dmrgpy/kondospectrumtk/conductance.py
+++ b/src/dmrgpy/kondospectrumtk/conductance.py
@@ -71,7 +71,8 @@ def _triple_product_coefficients(ks):
     return np.einsum('jkl,ifl,fmk,mij->ifm', _EPS3, Xi, Xi, Xi, optimize=True)
 
 
-def third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0, omega0=20e-3, Gamma0=5e-6):
+def third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0, omega0=20e-3, Gamma0=5e-6,
+                            Fb=None):
     """Third-order Kondo term, eqs. "3rd-normal" (direct diagram) +
     "3rd-reversed" (exchange diagram -- despite the name this is NOT the
     s->t tunneling direction: the paper's own "t -R-> s" notation on eq.
@@ -93,13 +94,20 @@ def third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0, omega0=20e-3, Gamma0=5e-6):
 
     This is an O(dim^3 * len(eVs)) calculation, inherent to the triple sum
     over eigenstates -- expected to be the bottleneck for larger Hilbert
-    spaces."""
+    spaces.
+
+    Fb: an existing FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    to reuse instead of building a new one -- building it tabulates
+    _band_integral over hundreds of adaptive-quadrature points, so
+    callers that also need third_order_potential_dIdV with the same
+    T/omega0/Gamma0 (e.g. Spin_Chain.get_kondo_spectrum) should build it
+    once and pass it to both."""
     eVs = np.asarray(eVs, dtype=float)
     kT = ks.kB*ks.T
     coeff = np.imag(_triple_product_coefficients(ks))/4. # Re[X/(4i)] = Im[X]/4
-    eps_if = ks.e[:, None] - ks.e[None, :] # eps_if[i,f] = e_f - e_i
+    eps_if = ks.e[None, :] - ks.e[:, None] # eps_if[i,f] = e_f - e_i
     eps_im = ks.e[None, :] - ks.e[:, None] # eps_im[i,m] = e_m - e_i
-    Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    if Fb is None: Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
     dim = ks.dim
     Fim = Fb((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
     Fmi = Fb((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
@@ -110,7 +118,7 @@ def third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0, omega0=20e-3, Gamma0=5e-6):
 
 
 def third_order_potential_dIdV(ks, eVs, Jrho_s, U, T0=1.0, omega0=20e-3,
-                                Gamma0=5e-6):
+                                Gamma0=5e-6, Fb=None):
     """Third-order potential-scattering interference term, eq. "U-M"
     (the origin of the bias asymmetry in Fig. 3c/d).
 
@@ -136,12 +144,15 @@ def third_order_potential_dIdV(ks, eVs, Jrho_s, U, T0=1.0, omega0=20e-3,
     that function's docstring for why the s->t direction is not attempted
     here (the paper's own worked example shows it is not a plain eV ->
     -eV mirror, which is exactly the bias asymmetry this term is meant to
-    produce in the first place)."""
+    produce in the first place).
+
+    Fb: see third_order_kondo_dIdV's docstring -- pass the same FBuilder
+    to both to avoid rebuilding its expensive tabulation twice."""
     eVs = np.asarray(eVs, dtype=float)
     Xi = np.stack([ks.Sx, ks.Sy, ks.Sz], axis=-1) # Xi[a,b,alpha]=<a|S_alpha|b>
     loop = np.real(np.einsum('imk,mik->im', Xi, Xi)) # sum_k |<i|Sk|m>|^2
     eps_im = ks.e[None, :] - ks.e[:, None] # eps_im[i,m] = e_m - e_i
-    Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
+    if Fb is None: Fb = FBuilder(ks.T, omega0=omega0, Gamma0=Gamma0, kB=ks.kB)
     dim = ks.dim
     Fim = Fb((eVs[:, None, None] - eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)
     Fmi = Fb((eVs[:, None, None] + eps_im[None, :, :]).ravel()).reshape(len(eVs), dim, dim)

--- a/src/dmrgpy/kondospectrumtk/dmrgtwotime.py
+++ b/src/dmrgpy/kondospectrumtk/dmrgtwotime.py
@@ -1,0 +1,158 @@
+import numpy as np
+from .twotime import kondo_term_from_two_time
+
+# DMRG (itensor_version=3) construction of the two-time third-order Kondo
+# term (twotime.py), replacing edtwotimeref.py's exact eigenbasis time
+# evolution with real TDVP time evolution -- avoiding excited-state
+# enumeration/diagonalization entirely, as requested. Reuses the exact
+# same kernel machinery (theta0_filter, K_W) already validated against
+# the excited-state-sum third_order_kondo_dIdV via edtwotimeref.py, since
+# that machinery only ever consumes a discretely-sampled G(t2,tau) array
+# -- it does not care how G was computed.
+#
+# IMPORTANT CAVEAT: this module was written against the verified,
+# already-used-elsewhere DMRG API (Many_Body_Chain.toMPO, the C++
+# tdvp_step single-step primitive already driven manually by tdz.py's
+# _advance_complex_time_step, MPS operator application/overlap) but could
+# NOT be executed or numerically validated in the environment this was
+# developed in (no compiled C++ backend available: cppext.available(3) is
+# False there). Treat it as a best-effort implementation that follows the
+# same patterns already proven correct elsewhere in this codebase, not as
+# independently verified the way edtwotimeref.py/twotime.py's ED path is
+# (which matches the excited-state-sum reference to ~0.01-1%, depending
+# on grid resolution). Run test_kondo_spectrum_dmrgtwotime.py (skipped
+# automatically when no C++ backend is compiled) in an environment with
+# itensor_version=3 compiled to actually check this.
+#
+# Algorithm (the "checkpoint-and-branch" construction from the design
+# discussion): for each j in {Sx,Sy,Sz} (the eq. "3rd-normal" vertex
+# applied at t=0):
+#   1. build |psi_j(0)> = Sj|GS>
+#   2. step |psi_j(0)> forward AND backward in time (tdvp_step with
+#      +dt2/-dt2) to get a trajectory of checkpoints |psi_j(t2)> across
+#      the full t2_grid (both signs, since G(t2,tau) is needed for
+#      negative t2 too -- see twotime.py's K_W kernel, defined for all
+#      real t2)
+#   3. at each checkpoint, apply each k in {Sx,Sy,Sz}: |phi_jk(t2)> =
+#      Sk|psi_j(t2)>
+#   4. step |phi_jk(t2)> forward AND backward across the full tau_grid,
+#      taking the overlap with each of the three fixed reference states
+#      <GS|Sl (l in {Sx,Sy,Sz}) at every tau checkpoint -- this directly
+#      gives G_jkl(t2,tau) for that (j,k,l) triple
+#   5. combine via the Levi-Civita contraction (as edtwotimeref.py does)
+#      into the single coeffG(t2,tau) twotime.py's kernels consume.
+#
+# This costs, per t2 checkpoint (of which there are len(t2_grid)), one
+# tau-direction trajectory per (j,k) pair (9 combinations, several
+# vanishing by antisymmetry but computed generically here) -- i.e.
+# O(len(t2_grid)) separate short TDVP trajectories, each
+# O(len(tau_grid)) steps. This is the "N_t2 separate DMRG runs" cost
+# flagged from the start of this feature's design discussion.
+
+_AXES = ("Sx", "Sy", "Sz")
+
+_EPS3 = np.zeros((3, 3, 3))
+for _i, _j, _k in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]:
+    _EPS3[_i, _j, _k] = 1.
+for _i, _j, _k in [(0, 2, 1), (2, 1, 0), (1, 0, 2)]:
+    _EPS3[_i, _j, _k] = -1.
+
+
+def _tdvp_trajectory(chain, Hop, wf0, dt, n_half):
+    """(times, wfs): 2*n_half+1 checkpoints of wf0 evolved under Hop,
+    spanning t in [-n_half*dt, +n_half*dt] in steps of dt, via repeated
+    single-step tdvp_step calls (the same primitive tdz.py's
+    _advance_complex_time_step drives manually; here with a plain real
+    dt, forward for positive steps and backward -- i.e. dt<0, which
+    tdvp_step already supports as a "possibly complex/signed" time step,
+    per its own docstring -- for negative ones)."""
+    from .. import mps as mpsmod
+    times = [0.0]
+    wfs = [wf0]
+    wf = wf0
+    for _ in range(n_half):
+        handle = chain._session.tdvp_step(Hop.cpp_handle, wf.cpp_handle, dt)
+        wf = mpsmod.MPS(chain, cpp_handle=handle).copy()
+        times.append(times[-1] + dt)
+        wfs.append(wf)
+    wf = wf0
+    for _ in range(n_half):
+        handle = chain._session.tdvp_step(Hop.cpp_handle, wf.cpp_handle, -dt)
+        wf = mpsmod.MPS(chain, cpp_handle=handle).copy()
+        times.append(times[-1] - dt)
+        wfs.append(wf)
+    order = np.argsort(times)
+    times = np.array(times)[order]
+    wfs = [wfs[i] for i in order]
+    return times, wfs
+
+
+def _levi_civita_coeff_G_batches_dmrg(chain, site, dt2, n_t2_half, dtau,
+                                       n_tau_half, t2_batch=1):
+    """Generator of (t2_chunk, G_chunk) pairs -- see twotime.py's
+    kondo_term_from_two_time for the contract -- built via real TDVP
+    time evolution instead of edtwotimeref.py's eigenbasis shortcut.
+    t2_batch=1 here (each checkpoint's tau-trajectory is its own
+    "chunk"): unlike the ED case, there is no cheap way to batch many t2
+    checkpoints into one vectorized array, since each one requires its
+    own independent tau-direction TDVP trajectory."""
+    ops = {name: getattr(chain, name) for name in _AXES}
+    E0 = chain.gs_energy()
+    Hop = chain.toMPO(chain.hamiltonian - E0) # e0-shifted, matching the
+                                               # e[0]=0 convention used
+                                               # throughout kondospectrumtk
+    gs = chain.get_gs()
+
+    ref_wf = {l: ops[l][site]*gs for l in _AXES} # <GS|Sl, i.e. Sl|GS> (l fixed)
+
+    t2_times, t2_wfs_by_j = {}, {}
+    for j in _AXES:
+        psi_j0 = ops[j][site]*gs
+        times, wfs = _tdvp_trajectory(chain, Hop, psi_j0, dt2, n_t2_half)
+        t2_times[j] = times
+        t2_wfs_by_j[j] = wfs
+
+    n_t2 = len(t2_times[_AXES[0]])
+    for it2 in range(n_t2):
+        t2 = t2_times[_AXES[0]][it2]
+        G_row = np.zeros((1, 2*n_tau_half + 1), dtype=complex)
+        tau_grid_row = None
+        for jj, j in enumerate(_AXES):
+            psi_j_t2 = t2_wfs_by_j[j][it2]
+            for kk, k in enumerate(_AXES):
+                branch = ops[k][site]*psi_j_t2
+                tau_times, tau_wfs = _tdvp_trajectory(chain, Hop, branch,
+                                                       dtau, n_tau_half)
+                if tau_grid_row is None: tau_grid_row = tau_times
+                for ll, l in enumerate(_AXES):
+                    c = _EPS3[jj, kk, ll]
+                    if c == 0.: continue
+                    overlap = np.array([ref_wf[l].dot(wf) for wf in tau_wfs])
+                    G_row[0, :] += c*overlap
+        yield np.array([t2]), tau_grid_row, G_row
+
+
+def two_time_kondo_term_dmrg(chain, site, eVs, omega0=20e-3, Gamma0=5e-6,
+                              dt2=1.0, n_t2_half=200, dtau=1.0,
+                              n_tau_half=200):
+    """DMRG counterpart of edtwotimeref.two_time_kondo_term_ed -- see
+    this module's docstring for the algorithm and its important
+    untested-in-development caveat. dt2/n_t2_half and dtau/n_tau_half
+    set the (uniform) time grids in each leg; see twotime.py's module
+    docstring for the resolution/range requirements (K_W needs t2
+    spacing finer than 1/omega0 and a range wider than several/Gamma0;
+    the Hilbert-transform-based Theta0 filter is comparatively
+    forgiving)."""
+    def batches():
+        for t2_chunk, _tau_row, G_chunk in _levi_civita_coeff_G_batches_dmrg(
+                chain, site, dt2, n_t2_half, dtau, n_tau_half):
+            yield t2_chunk, G_chunk
+
+    # kondo_term_from_two_time only needs t2_grid/tau_grid for their
+    # spacing (dt2/dtau) and midpoint check, both fully determined by the
+    # step sizes and half-widths -- no need to wait for the actual
+    # trajectory output to build them
+    t2_grid = dt2*np.arange(-n_t2_half, n_t2_half + 1)
+    tau_grid = dtau*np.arange(-n_tau_half, n_tau_half + 1)
+    return kondo_term_from_two_time(t2_grid, tau_grid, batches(), eVs,
+                                     omega0, Gamma0)

--- a/src/dmrgpy/kondospectrumtk/dmrgtwotime.py
+++ b/src/dmrgpy/kondospectrumtk/dmrgtwotime.py
@@ -146,6 +146,9 @@ def _levi_civita_coeff_G_batches_dmrg(chain, site, dt2, n_t2_half, dtau,
         for jj, j in enumerate(_AXES):
             psi_j_t2 = t2_wfs_by_j[j][it2]
             for kk, k in enumerate(_AXES):
+                if jj == kk: continue # eps_jkl==0 for every l here -- skip
+                                       # the expensive tau trajectory itself,
+                                       # not just the (already-guarded) sum
                 branch = ops[k][site]*psi_j_t2
                 tau_times, tau_wfs = _tdvp_trajectory(chain, Hop, branch,
                                                        dtau, n_tau_half)
@@ -159,16 +162,37 @@ def _levi_civita_coeff_G_batches_dmrg(chain, site, dt2, n_t2_half, dtau,
 
 
 def two_time_kondo_term_dmrg(chain, site, eVs, omega0=20e-3, Gamma0=5e-6,
-                              dt2=1.0, n_t2_half=200, dtau=1.0,
-                              n_tau_half=200):
+                              dt2=None, n_t2_half=None, dtau=None,
+                              n_tau_half=None):
     """DMRG counterpart of edtwotimeref.two_time_kondo_term_ed -- see
-    this module's docstring for the algorithm and its important
-    untested-in-development caveat. dt2/n_t2_half and dtau/n_tau_half
-    set the (uniform) time grids in each leg; see twotime.py's module
-    docstring for the resolution/range requirements (K_W needs t2
+    this module's docstring for the algorithm and its validation status.
+
+    dt2/n_t2_half and dtau/n_tau_half set the (uniform) time grids in
+    each leg and have no default (all four required): see twotime.py's
+    module docstring for the resolution/range requirements (K_W needs t2
     spacing finer than 1/omega0 and a range wider than several/Gamma0;
-    the Hilbert-transform-based Theta0 filter is comparatively
-    forgiving)."""
+    the Hilbert-transform-based Theta0 filter is comparatively forgiving
+    about dtau/n_tau_half). There is no numeric default that is both
+    correct and practical to pick automatically: a grid fine/wide enough
+    to actually resolve the default omega0/Gamma0 (e.g. dt2 ~ 1/omega0,
+    t2 range ~ 25/Gamma0) needs order 10^5-10^6 t2 checkpoints, each its
+    own real TDVP trajectory -- computationally infeasible as a silent
+    default -- while a small, fast default (e.g. the flat dt2=1.0,
+    n_t2_half=200 tried initially) is wildly under-resolved for those
+    same omega0/Gamma0 and returns a finite but silently, badly wrong
+    result instead of erroring (confirmed directly). Pick values
+    deliberately for your own omega0/Gamma0 and desired accuracy/cost
+    tradeoff instead (the tests in
+    test_kondo_spectrum_dmrgtwotime.py use dt2=25./Gamma0/n_t2_half with
+    n_t2_half=10 and dtau=(2*pi/2e-5)/n_tau_half with n_tau_half=15 as a
+    small, fast, deliberately-coarse example -- not a recommended
+    production resolution)."""
+    if dt2 is None or n_t2_half is None or dtau is None or n_tau_half is None:
+        raise ValueError(
+            "dt2, n_t2_half, dtau, n_tau_half must all be given "
+            "explicitly: no default grid is both correct and practical "
+            "for arbitrary omega0/Gamma0 -- see this function's own "
+            "docstring")
     def batches():
         for t2_chunk, _tau_row, G_chunk in _levi_civita_coeff_G_batches_dmrg(
                 chain, site, dt2, n_t2_half, dtau, n_tau_half):

--- a/src/dmrgpy/kondospectrumtk/dmrgtwotime.py
+++ b/src/dmrgpy/kondospectrumtk/dmrgtwotime.py
@@ -10,19 +10,22 @@ from .twotime import kondo_term_from_two_time
 # that machinery only ever consumes a discretely-sampled G(t2,tau) array
 # -- it does not care how G was computed.
 #
-# IMPORTANT CAVEAT: this module was written against the verified,
-# already-used-elsewhere DMRG API (Many_Body_Chain.toMPO, the C++
-# tdvp_step single-step primitive already driven manually by tdz.py's
-# _advance_complex_time_step, MPS operator application/overlap) but could
-# NOT be executed or numerically validated in the environment this was
-# developed in (no compiled C++ backend available: cppext.available(3) is
-# False there). Treat it as a best-effort implementation that follows the
-# same patterns already proven correct elsewhere in this codebase, not as
-# independently verified the way edtwotimeref.py/twotime.py's ED path is
-# (which matches the excited-state-sum reference to ~0.01-1%, depending
-# on grid resolution). Run test_kondo_spectrum_dmrgtwotime.py (skipped
-# automatically when no C++ backend is compiled) in an environment with
-# itensor_version=3 compiled to actually check this.
+# VALIDATED (see test_kondo_spectrum_dmrgtwotime.py): after a compiled
+# itensor_version=3 backend became available, this module's G(t2,tau)
+# matched the ED reference (edtwotimeref.py) to ~1e-9-1e-10 pointwise,
+# and the full eV-swept third-order Kondo term matched a grid-consistent
+# ED reference to ~1e-10. Getting there surfaced three real bugs, none of
+# which had shown up in the ED-only testing this module was originally
+# written against -- see _tdvp_trajectory's and
+# twotime.kondo_term_from_two_time's docstrings for the details (in
+# short: tdvp_step silently renormalizes every step to unit norm, which
+# discards Sj|GS>'s true amplitude unless corrected for explicitly; a
+# forward/backward time-stepping bug meant "backward" checkpoints never
+# actually reached negative times; and a per-chunk np.trapz integral is
+# exactly 0 for the single-t2-point chunks this module's real-time
+# evolution necessarily produces). A 1-site test chain also hit an
+# internal ITensor v3 error unrelated to any of the above -- see
+# _build_chain in the test file for why chains need >=3 sites.
 #
 # Algorithm (the "checkpoint-and-branch" construction from the design
 # discussion): for each j in {Sx,Sy,Sz} (the eq. "3rd-normal" vertex
@@ -65,25 +68,48 @@ def _tdvp_trajectory(chain, Hop, wf0, dt, n_half):
     _advance_complex_time_step drives manually; here with a plain real
     dt, forward for positive steps and backward -- i.e. dt<0, which
     tdvp_step already supports as a "possibly complex/signed" time step,
-    per its own docstring -- for negative ones)."""
+    per its own docstring -- for negative ones).
+
+    tdvp_step renormalizes its output to unit norm at every single call
+    (confirmed directly: even a near-zero dt=0.01 step takes an
+    input norm^2=0.25 state straight to norm^2=1) -- correct/harmless for
+    evolving an already-normalized physical state, but wf0 here is
+    Sj|GS> or Sk|psi(t2)>, which is generally NOT unit-norm (Sj isn't
+    norm-preserving). Silently letting that renormalization stand would
+    throw away wf0's true amplitude at every step -- confirmed directly,
+    it produced overlaps exactly a factor of 2 too large end to end for a
+    wf0 of norm 0.5. Fixed by normalizing wf0 before the loop and
+    rescaling every returned checkpoint by the true original norm
+    afterward, so the trajectory is evolved on a unit-norm state
+    throughout (where tdvp_step's renormalization is a no-op) but
+    reported at wf0's actual scale."""
     from .. import mps as mpsmod
-    times = [0.0]
-    wfs = [wf0]
-    wf = wf0
-    for _ in range(n_half):
-        handle = chain._session.tdvp_step(Hop.cpp_handle, wf.cpp_handle, dt)
-        wf = mpsmod.MPS(chain, cpp_handle=handle).copy()
-        times.append(times[-1] + dt)
-        wfs.append(wf)
-    wf = wf0
-    for _ in range(n_half):
-        handle = chain._session.tdvp_step(Hop.cpp_handle, wf.cpp_handle, -dt)
-        wf = mpsmod.MPS(chain, cpp_handle=handle).copy()
-        times.append(times[-1] - dt)
-        wfs.append(wf)
-    order = np.argsort(times)
-    times = np.array(times)[order]
-    wfs = [wfs[i] for i in order]
+    norm0 = np.sqrt(wf0.dot(wf0).real)
+    wf0_unit = wf0*(1./norm0) if norm0 > 1e-12 else wf0
+
+    def _walk(step):
+        # forward (step=dt) or backward (step=-dt) checkpoints from t=0,
+        # NOT including t=0 itself -- each direction must restart its own
+        # time counter at 0 rather than continuing the other direction's
+        # (confirmed directly: sharing one running `times` list across
+        # both loops made the "backward" branch keep counting down from
+        # the forward branch's endpoint instead of from 0, so it never
+        # actually reached negative times at all -- e.g. n_half=3,
+        # dt=1000 produced times=[0,0,1000,1000,2000,2000,3000], not the
+        # intended [-3000,...,0,...,3000])
+        t, wf, out_t, out_wf = 0.0, wf0_unit, [], []
+        for _ in range(n_half):
+            handle = chain._session.tdvp_step(Hop.cpp_handle, wf.cpp_handle, step)
+            wf = mpsmod.MPS(chain, cpp_handle=handle).copy()
+            t = t + step
+            out_t.append(t); out_wf.append(wf)
+        return out_t, out_wf
+
+    fwd_t, fwd_wf = _walk(dt)
+    bwd_t, bwd_wf = _walk(-dt)
+    times = np.array(bwd_t[::-1] + [0.0] + fwd_t)
+    wfs = bwd_wf[::-1] + [wf0_unit] + fwd_wf
+    wfs = [norm0*wf for wf in wfs]
     return times, wfs
 
 

--- a/src/dmrgpy/kondospectrumtk/edkondo.py
+++ b/src/dmrgpy/kondospectrumtk/edkondo.py
@@ -19,8 +19,12 @@ class KondoSpectrum():
     def __init__(self, chain, site, T, kB=8.617333262e-5):
         # kB in eV/K by default (so T is given in Kelvin, energies in eV,
         # matching how the rest of dmrgpy's examples quote energies); pass
-        # kB=1 if you'd rather work in units where T is already an energy
-        if T <= 0.: raise ValueError("KondoSpectrum requires T>0")
+        # kB=1 if you'd rather work in units where T is already an energy.
+        # T=0 is a valid, exact limit (not an error): both the spin
+        # system's Boltzmann occupation and the tunneling-electron thermal
+        # smearing (Theta/F -> Theta0/F0) collapse to their T=0 closed
+        # forms, see stepfunctions.py.
+        if T < 0.: raise ValueError("KondoSpectrum requires T>=0")
         self.chain = chain
         self.site = site
         self.T = T
@@ -34,9 +38,12 @@ class KondoSpectrum():
         self.e = emu - emu[0] # ground state energy set to 0
         self.vs = vs
         self.dim = len(self.e)
-        kT = kB*T
-        p = np.exp(-self.e/kT)
-        self.p = p/np.sum(p) # Boltzmann occupations, eq. "boltzmann"
+        if T == 0.:
+            self.p = np.zeros(self.dim); self.p[0] = 1. # only the GS is occupied
+        else:
+            kT = kB*T
+            p = np.exp(-self.e/kT)
+            self.p = p/np.sum(p) # Boltzmann occupations, eq. "boltzmann"
         self.Sx = self._eigenbasis_spin_operator("Sx")
         self.Sy = self._eigenbasis_spin_operator("Sy")
         self.Sz = self._eigenbasis_spin_operator("Sz")

--- a/src/dmrgpy/kondospectrumtk/edkondo.py
+++ b/src/dmrgpy/kondospectrumtk/edkondo.py
@@ -1,0 +1,48 @@
+import numpy as np
+from .. import multioperator
+from ..algebra import algebra
+
+# Full-spectrum ED building blocks for the third-order Kondo/STM
+# perturbation theory (Ternes, arXiv:1505.04430). Unlike the ground-state
+# ED already used elsewhere in dmrgpy (EDchain.get_gs_array()), the third
+# order Kondo term sums over *every* eigenstate as a virtual intermediate
+# state, so this always needs the full spectrum, not just the low-energy
+# states DMRG or a Lanczos-type ED would normally target.
+
+
+class KondoSpectrum():
+    """Holds everything derived once from a chain's full ED spectrum that
+    the second- and third-order conductance terms need: eigenenergies
+    (shifted so the ground state is at 0), Boltzmann occupations at
+    temperature T, and the impurity spin operators Sx/Sy/Sz transformed
+    into the Hamiltonian eigenbasis."""
+    def __init__(self, chain, site, T, kB=8.617333262e-5):
+        # kB in eV/K by default (so T is given in Kelvin, energies in eV,
+        # matching how the rest of dmrgpy's examples quote energies); pass
+        # kB=1 if you'd rather work in units where T is already an energy
+        if T <= 0.: raise ValueError("KondoSpectrum requires T>0")
+        self.chain = chain
+        self.site = site
+        self.T = T
+        self.kB = kB
+        edobj = chain.get_ED_obj() # full-spectrum ED backend (pychain)
+        emu, vs = edobj.get_diagonalized_hamiltonian() # all eigenpairs
+        emu = np.array(emu, dtype=float)
+        order = np.argsort(emu) # eigh output should already be sorted
+        emu = emu[order]
+        vs = np.array(vs)[:, order]
+        self.e = emu - emu[0] # ground state energy set to 0
+        self.vs = vs
+        self.dim = len(self.e)
+        kT = kB*T
+        p = np.exp(-self.e/kT)
+        self.p = p/np.sum(p) # Boltzmann occupations, eq. "boltzmann"
+        self.Sx = self._eigenbasis_spin_operator("Sx")
+        self.Sy = self._eigenbasis_spin_operator("Sy")
+        self.Sz = self._eigenbasis_spin_operator("Sz")
+    def _eigenbasis_spin_operator(self, name):
+        edobj = self.chain.get_ED_obj()
+        op = getattr(self.chain, name)[self.site] # MultiOperator, this site
+        mat = algebra.todense(multioperator.MO2matrix(op, edobj))
+        mat = np.array(mat, dtype=complex)
+        return np.conjugate(self.vs.T)@mat@self.vs # Xi^alpha_{ab} = <a|S|b>

--- a/src/dmrgpy/kondospectrumtk/edtwotimeref.py
+++ b/src/dmrgpy/kondospectrumtk/edtwotimeref.py
@@ -1,0 +1,76 @@
+import numpy as np
+from .twotime import kondo_term_from_two_time
+
+# Pure-ED reference implementation of the two-time third-order Kondo term
+# (twotime.py), used to validate that construction independently of the
+# excited-state-sum third_order_kondo_dIdV (conductance.py) -- and,
+# eventually, as the small-system ground truth for the DMRG two-leg
+# time-evolution construction (kondospectrumtk/dmrgtwotime.py). Computes
+# G(t2,tau)=<GS|Sl(t2+tau)Sk(t2)Sj(0)|GS> via exact time evolution in the
+# Hamiltonian eigenbasis already available on a KondoSpectrum (ks.e,
+# ks.Sx/Sy/Sz), rather than by any actual real-time-evolution algorithm --
+# appropriate here since the point is to test the two-time/kernel
+# machinery itself, not ED's own (already independently validated)
+# ability to get transition matrix elements.
+
+_EPS3 = np.zeros((3, 3, 3))
+for _i, _j, _k in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]:
+    _EPS3[_i, _j, _k] = 1.
+for _i, _j, _k in [(0, 2, 1), (2, 1, 0), (1, 0, 2)]:
+    _EPS3[_i, _j, _k] = -1.
+
+_AXES = ("Sx", "Sy", "Sz")
+
+
+def _levi_civita_coeff_G_chunk(ks, t2_chunk, tau_grid):
+    """coeffG(t2,tau) = sum_jkl eps_jkl <GS|Sl(t2+tau)Sk(t2)Sj(0)|GS>,
+    the full Levi-Civita-contracted two-time correlator (eq. "3rd-normal"'s
+    triple product, now as a function of two real times instead of three
+    discrete states), on one t2-chunk x the full tau_grid."""
+    e = ks.e
+    ops = {"Sx": ks.Sx, "Sy": ks.Sy, "Sz": ks.Sz} # ops[name][a,b] = <a|S|b>
+    phase_t2 = np.exp(-1j*np.outer(t2_chunk, e)) # (nb, dim)
+    phase_tau = np.exp(-1j*np.outer(tau_grid, e)) # (ntau, dim)
+    out = np.zeros((len(t2_chunk), len(tau_grid)), dtype=complex)
+    for jj, j in enumerate(_AXES):
+        v0 = ops[j][:, 0] # Sj|GS> in the eigenbasis
+        v_t2 = phase_t2*v0[None, :] # Sj|GS> evolved to each t2
+        for kk, k in enumerate(_AXES):
+            phi_t2 = v_t2 @ ops[k].T # Sk applied at each t2
+            for ll, l in enumerate(_AXES):
+                c = _EPS3[jj, kk, ll]
+                if c == 0.: continue
+                ref_l = ops[l][:, 0] # <GS|Sl, for the final overlap
+                weighted = phi_t2*np.conjugate(ref_l)[None, :]
+                out += c*(weighted @ phase_tau.T)
+    return out
+
+
+def two_time_kondo_term_ed(ks, eVs, omega0=20e-3, Gamma0=5e-6,
+                            t2_width=None, t2_npts=200_000,
+                            tau_width=None, tau_npts=4_000,
+                            t2_batch=2_000):
+    """Term(eV) for every eV in `eVs` (see
+    twotime.kondo_term_from_two_time's return-value convention) computed
+    via exact-diagonalization two-time evolution. Requires ks.T==0 (only
+    the ground state is a meaningful initial state for this single-
+    three-point-function construction; see kondospectrumtk/dmrgkondo.py
+    docs for why T=0 is the natural regime for this method in general).
+
+    t2_width/tau_width default to scales tied to Gamma0/omega0 (see
+    module docstring in twotime.py for why K_W needs t2 resolution finer
+    than 1/omega0 and range wider than ~1/Gamma0). G(t2,tau) is built
+    once per t2-chunk and reused for the whole eVs sweep."""
+    if ks.T != 0.: raise ValueError("two_time_kondo_term_ed requires T=0")
+    if t2_width is None: t2_width = 40./Gamma0
+    if tau_width is None: tau_width = 2*np.pi/1e-5
+    t2_grid = np.linspace(-t2_width, t2_width, t2_npts)
+    tau_grid = np.linspace(-tau_width, tau_width, tau_npts, endpoint=False)
+
+    def batches():
+        for start in range(0, t2_npts, t2_batch):
+            t2_chunk = t2_grid[start:start+t2_batch]
+            yield t2_chunk, _levi_civita_coeff_G_chunk(ks, t2_chunk, tau_grid)
+
+    return kondo_term_from_two_time(t2_grid, tau_grid, batches(), eVs,
+                                     omega0, Gamma0)

--- a/src/dmrgpy/kondospectrumtk/potentialdc.py
+++ b/src/dmrgpy/kondospectrumtk/potentialdc.py
@@ -1,0 +1,69 @@
+import numpy as np
+from .stepfunctions import F0, Theta0
+
+# T=0 third-order potential-interference dI/dV (conductance.py's
+# third_order_potential_dIdV) via the dynamical correlator, the DMRG-side
+# counterpart of secondorder_dc.py's second_order_dIdV_dc -- same idea,
+# different kernel. conductance.third_order_potential_dIdV's T=0 limit
+# (ks.p one-hot on the ground state) collapses its i,m sum to
+#   Theta0(eV) * sum_m sum_k |<m|Sk|GS>|^2 [F0(eV-eps_m0)+F0(eV+eps_m0)]
+# (k running over Sx,Sy,Sz, matching that function's Xi[a,b,alpha] stack)
+# and sum_m |<m|Sk|GS>|^2 delta(w-eps_m0) is exactly the T=0 dynamical
+# structure factor S_kk(w) that get_dynamical_correlator already computes
+# -- so the m-sum becomes an F0-weighted convolution of S_kk against the
+# es frequency grid, in the same spirit as second_order_dIdV_dc's
+# Theta0-weighted cumulative integral (a cumulative sum there vs. a
+# genuine convolution here, since F0 -- unlike Theta0 -- is not a step).
+
+
+def _convolved_F0_weight(chain, op, eVs, omega0, Gamma0, mode, submode,
+                          delta, es, **kwargs):
+    """dw * sum_i S(w_i) * [F0(eV-w_i) + F0(eV+w_i)] for every eV in eVs,
+    where S(w) = sum_m |<m|op|GS>|^2 delta(w-eps_m0) is the T=0 dynamical
+    structure factor for A=op.get_dagger(), B=op (see secondorder_dc.py's
+    module docstring for why the explicit get_dagger() is required)."""
+    x, S = chain.get_dynamical_correlator(
+            mode=mode, submode=submode, name=(op.get_dagger(), op),
+            delta=delta, es=es, **kwargs)
+    x = np.asarray(x, dtype=float)
+    S = np.asarray(S).real
+    dw = x[1] - x[0]
+    diff = eVs[:, None] - x[None, :]
+    ssum = eVs[:, None] + x[None, :]
+    kernel = (F0(diff.ravel(), omega0=omega0, Gamma0=Gamma0).reshape(diff.shape)
+              + F0(ssum.ravel(), omega0=omega0, Gamma0=Gamma0).reshape(ssum.shape))
+    return dw*np.einsum('w,ew->e', S, kernel)
+
+
+def third_order_potential_dIdV_dc(chain, site, eVs, Jrho_s, U, T0=1.0,
+                                   omega0=20e-3, Gamma0=5e-6, mode="DMRG",
+                                   submode="KPM", delta=2e-6, es=None,
+                                   **kwargs):
+    """T=0 third-order potential-interference dI/dV (eq. "U-M"), computed
+    via the dynamical correlator instead of the explicit excited-state
+    sum conductance.third_order_potential_dIdV uses -- see module
+    docstring. Matches that function's return convention and carries the
+    same LOWER CONFIDENCE caveat (general-S extrapolation from the
+    paper's worked S=1/2 example -- see third_order_potential_dIdV's own
+    docstring) on top of the usual delta/es-resolution error already
+    present in second_order_dIdV_dc.
+
+    delta/es: see second_order_dIdV_dc's docstring -- es is required for
+    the same reason (it must cover every eigenstate transition energy
+    from the ground state, a property of the chain's own spectrum, not
+    of the eVs sweep range).
+
+    mode/submode: forwarded to chain.get_dynamical_correlator, as in
+    second_order_dIdV_dc."""
+    eVs = np.asarray(eVs, dtype=float)
+    if es is None:
+        raise ValueError(
+            "es must be given explicitly: it needs to cover every "
+            "eigenstate transition energy relevant to this system, which "
+            "the eVs sweep range alone does not determine")
+    ops = (chain.Sx[site], chain.Sy[site], chain.Sz[site])
+    weighted = sum(_convolved_F0_weight(chain, op, eVs, omega0, Gamma0,
+                                         mode, submode, delta, es, **kwargs)
+                   for op in ops)
+    total = weighted*Theta0(eVs)
+    return 4*np.pi*T0**2*Jrho_s*U*total

--- a/src/dmrgpy/kondospectrumtk/secondorder_dc.py
+++ b/src/dmrgpy/kondospectrumtk/secondorder_dc.py
@@ -1,0 +1,88 @@
+import numpy as np
+
+# T=0 second-order dI/dV via the dynamical correlator, avoiding explicit
+# excited-state enumeration -- the natural DMRG-side counterpart of
+# second_order_dIdV (conductance.py, which sums explicitly over ED
+# eigenstates). At T=0 only the ground state is populated, so
+#   sum_f |<f|S_alpha|GS>|^2 Theta0(eV-eps_f0)
+# is exactly a Theta0-weighted cumulative integral of the T=0 dynamical
+# structure factor S_aa(w) = sum_f |<f|S_alpha|GS>|^2 delta(w-eps_f0),
+# which chain.get_dynamical_correlator already computes (as a function of
+# w, broadened by its own `delta`/`eta` parameter) without ever
+# diagonalizing beyond the ground state -- e.g. via submode="KPM" (a
+# Chebyshev moment expansion) or "CVM" (correction-vector method), both
+# already implemented for itensor_version=3.
+#
+# Convention note: get_dynamical_correlator(name=(A,B)) computes
+# G_AB(w) = <GS|A (w-H+E0+i*delta)^-1 B|GS>. To get the POSITIVE spectral
+# weight sum_f |<f|B|GS>|^2 (not some other, possibly complex, bilinear
+# combination), A must be B's own dagger: name=(B.get_dagger(), B) -- NOT
+# name=(B,B) (confirmed directly: the "ED" submode does not
+# auto-conjugate its first operator the way submode="EX" does).
+#
+# Verified (mode="ED", submode="ED", a small S=1/2 Zeeman-split system)
+# against the already-validated excited-state-sum second_order_dIdV: sum
+# rule (total spectral weight) matches to ~0.06%, and the swept dI/dV
+# matches to within ~0.7% (the residual is the expected effect of the
+# finite `delta` broadening the otherwise-sharp Theta0 threshold -- it
+# shrinks as delta/es resolution are tightened).
+
+
+def _cumulative_theta0_weight(chain, op, eVs, mode, submode, delta, es,
+                               **kwargs):
+    """sum_f |<f|op|GS>|^2 [Theta0(eV-eps_f0) + Theta0(-eV-eps_f0)] for
+    every eV in eVs (both tunneling directions, matching
+    second_order_dIdV's convention), via a Theta0-weighted cumulative
+    integral of the T=0 dynamical structure factor S(w) for
+    A=op.get_dagger(), B=op."""
+    x, S = chain.get_dynamical_correlator(
+            mode=mode, submode=submode, name=(op.get_dagger(), op),
+            delta=delta, es=es, **kwargs)
+    S = np.asarray(S).real
+    dw = x[1] - x[0]
+    cum = np.cumsum(S)*dw # cumulative integral from -inf up to each x point
+    return np.interp(eVs, x, cum) + np.interp(-eVs, x, cum)
+
+
+def second_order_dIdV_dc(chain, site, eVs, T0=1.0, U=0.0, mode="DMRG",
+                          submode="KPM", delta=2e-6, es=None, **kwargs):
+    """T=0 second-order dI/dV (eq. "conductance"), computed via the
+    dynamical correlator instead of the explicit excited-state sum
+    conductance.second_order_dIdV uses -- see module docstring. Matches
+    that function's return convention (units of 2*pi*e^2*T0^2/hbar,
+    U^2 elastic term added directly since it needs no dynamical
+    information).
+
+    delta: broadening of the dynamical correlator; controls how sharply
+    the Theta0 threshold is resolved (smaller delta -> sharper, but needs
+    a correspondingly fine `es` grid to stay well resolved).
+    es: frequency grid passed to get_dynamical_correlator. Required (no
+    default): it must cover every eigenstate transition energy from the
+    ground state that matters for the eVs sweep, at several times finer
+    spacing than delta -- these are properties of the chain's own
+    spectrum, not of the eVs sweep range, so guessing a default from eVs
+    alone is unsafe (confirmed directly: doing so silently misses real
+    transitions whenever the eVs sweep happens to be narrower than, or
+    offset from, the system's actual energy scale).
+
+    mode/submode: forwarded to chain.get_dynamical_correlator (e.g.
+    mode="ED", submode="ED" for an exact small-system check; mode="DMRG",
+    submode="KPM"|"CVM" for itensor_version=3)."""
+    eVs = np.asarray(eVs, dtype=float)
+    if es is None:
+        raise ValueError(
+            "es must be given explicitly: it needs to cover every "
+            "eigenstate transition energy relevant to this system, which "
+            "the eVs sweep range alone does not determine")
+
+    Sminus = chain.Sx[site] + (-1j)*chain.Sy[site]
+    Splus = chain.Sx[site] + 1j*chain.Sy[site]
+    Sz = chain.Sz[site]
+
+    def weight(op):
+        return _cumulative_theta0_weight(chain, op, eVs, mode, submode,
+                                          delta, es, **kwargs)
+
+    spin_term = 0.5*weight(Sminus) + 0.5*weight(Splus) + weight(Sz)
+    U_term = (U**2)*np.ones_like(eVs)
+    return 2*np.pi*T0**2*(spin_term + U_term)

--- a/src/dmrgpy/kondospectrumtk/secondorder_dc.py
+++ b/src/dmrgpy/kondospectrumtk/secondorder_dc.py
@@ -25,7 +25,12 @@ import numpy as np
 # rule (total spectral weight) matches to ~0.06%, and the swept dI/dV
 # matches to within ~0.7% (the residual is the expected effect of the
 # finite `delta` broadening the otherwise-sharp Theta0 threshold -- it
-# shrinks as delta/es resolution are tightened).
+# shrinks as delta/es resolution are tightened). Also spot-checked with
+# mode="DMRG", submode="KPM" against a compiled itensor_version=3
+# backend once one became available: same qualitative agreement (a few
+# tens of percent at the thresholds, matching elsewhere), with the
+# expected additional KPM moment-truncation error on top of the delta
+# broadening.
 
 
 def _cumulative_theta0_weight(chain, op, eVs, mode, submode, delta, es,

--- a/src/dmrgpy/kondospectrumtk/stepfunctions.py
+++ b/src/dmrgpy/kondospectrumtk/stepfunctions.py
@@ -137,7 +137,6 @@ class FBuilder():
                           for e in grid])
         self._spline = CubicSpline(grid, vals, extrapolate=False)
         self._grid_min, self._grid_max = grid[0], grid[-1]
-        self._val_min, self._val_max = vals[0], vals[-1]
         width = nwidth*self.kT
         self._fp_grid = np.linspace(-width, width, npts)
         self._fp = _fermi_prime(self._fp_grid, self.kT)

--- a/src/dmrgpy/kondospectrumtk/stepfunctions.py
+++ b/src/dmrgpy/kondospectrumtk/stepfunctions.py
@@ -157,3 +157,31 @@ def F(x, T, omega0=20e-3, Gamma0=5e-6, kB=8.617333262e-5):
     for the efficient, precomputed-kernel version used when sweeping many
     eV points against a fixed set of intermediate-state energies)."""
     return FBuilder(T, omega0=omega0, Gamma0=Gamma0, kB=kB)(x)
+
+
+def Theta0(x):
+    """T=0 limit of Theta(x): a Heaviside step, Theta0(0)=1/2. Both the
+    spin system's Boltzmann occupation and the tunneling-electron thermal
+    smearing collapse at T=0, so this is not merely "Theta at very small
+    T" evaluated numerically -- it is the exact, closed-form limit."""
+    x = np.asarray(x, dtype=float)
+    return np.where(x > 0, 1., np.where(x < 0, 0., 0.5))
+
+
+def F0(x, omega0=20e-3, Gamma0=5e-6):
+    """T=0 limit of F(eps,T) (see FBuilder/F). At T=0, f'(ep,T) -> -delta(ep)
+    in equ. "F_1", collapsing its outer eps''-integral entirely and leaving
+    just the (still Gamma0-regularized) inner eps'-integral evaluated
+    exactly at eps -- i.e. this is _band_integral's own T->0 limit, not an
+    independent approximation:
+
+        F0(eps) = 1/2 ln[(omega0-eps)^2+Gamma0^2] - 1/2 ln[eps^2+Gamma0^2]
+
+    Verified numerically against FBuilder(T) for T shrinking to ~0 (an
+    earlier candidate closed form, ln(omega0+|eps|)-1/2 ln(eps^2+Gamma0^2),
+    was checked the same way and found to only agree for eps<0 -- it is
+    NOT F0, despite superficially resembling it; this form is the one
+    confirmed to match _band_integral pointwise over the full range,
+    including inside the band where the two candidates diverge)."""
+    x = np.asarray(x, dtype=float)
+    return 0.5*np.log((omega0-x)**2+Gamma0**2) - 0.5*np.log(x**2+Gamma0**2)

--- a/src/dmrgpy/kondospectrumtk/stepfunctions.py
+++ b/src/dmrgpy/kondospectrumtk/stepfunctions.py
@@ -1,0 +1,160 @@
+import numpy as np
+from scipy.integrate import simpson, quad
+from scipy.interpolate import CubicSpline
+
+# Numerical building blocks for the third-order STM/Kondo perturbation
+# theory of Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430.
+#
+# Theta(x) and F(eps,T) below are NOT literal transcriptions of the
+# closed-form equations printed in the arXiv source for them (eq.
+# "step-fkt" and equ. "F_2") because those printed closed forms fail
+# basic physical requirements the paper itself states:
+#   - eq. "step-fkt", Theta(x) = (1+(x-1)e^x)/e^(2x), diverges as x->-inf
+#     instead of saturating at 0, so it cannot be the bounded, symmetric,
+#     temperature-broadened step shown in the paper's own Fig. 2. Theta(x)
+#     here was instead re-derived directly from eq. "current" (the paper's
+#     own prescription: differentiate it w.r.t. eV) and verified against
+#     direct numerical integration to machine precision.
+#   - equ. "F_2" as printed has its ln(...) prefactor independent of the
+#     integration variable, making the integral trivial and removing
+#     exactly the temperature-dependent broadening of the log singularity
+#     the surrounding text describes -- and an initial attempt at a
+#     corrected/convolution reading of it, while qualitatively peaked in
+#     the right place, was verified (see below) to have the wrong sign and
+#     the wrong magnitude against the paper's own Fig. F. F(eps,T) here is
+#     instead a direct, vectorized evaluation of the paper's unambiguous
+#     defining double integral, equ. "F_1" (electron-like processes),
+#     verified to reproduce the actual plotted values of Fig. F(b) (e.g.
+#     T=1K, omega0=200meV: F(0)=7.459 here vs. ~7.5 read off the figure;
+#     F(10meV)=2.945 here vs. ~3.1 read off the figure).
+
+
+def Theta(x):
+    """Temperature-broadened step function.
+
+    Derived by differentiating eq. "current" w.r.t. eV (the paper's own
+    prescription) and evaluating the resulting Fermi-function convolution
+    in closed form:
+
+        Theta(x) = 1/2 + [sinh(x) - x] / [2(cosh(x) - 1)]
+
+    with x = eps/(kB T). Theta(x) -> 0 as x -> -inf, -> 1 as x -> +inf,
+    Theta(0) = 1/2, and Theta(x) + Theta(-x) = 1 identically.
+    """
+    x = np.asarray(x, dtype=float)
+    out = np.empty_like(x)
+    small = np.abs(x) < 1e-4
+    large = np.abs(x) > 40
+    mid = ~small & ~large
+    out[small] = 0.5 + x[small]/6.0 - x[small]**3/360.0
+    xm = x[mid]
+    out[mid] = 0.5 + (np.sinh(xm) - xm)/(2*(np.cosh(xm) - 1))
+    xl = x[large]
+    pos = xl > 0
+    out[large] = np.where(pos,
+                           1.0 - (np.abs(xl)+1)*np.exp(-np.abs(xl)),
+                           (np.abs(xl)+1)*np.exp(-np.abs(xl)))
+    return out
+
+
+def Theta_prime(x):
+    """d Theta / dx, the even, unit-normalized (integral over x is 1)
+    thermal broadening kernel used inside F(eps,T)."""
+    x = np.asarray(x, dtype=float)
+    out = np.empty_like(x)
+    small = np.abs(x) < 1e-4
+    large = np.abs(x) > 40
+    mid = ~small & ~large
+    out[small] = 1.0/6 - x[small]**2/60.0
+    xm = x[mid]
+    out[mid] = (xm*np.sinh(xm)/2 - np.cosh(xm) + 1)/(np.cosh(xm) - 1)**2
+    xl = x[large]
+    out[large] = np.abs(xl)*np.exp(-np.abs(xl))
+    return out
+
+
+def _fermi(e, kT):
+    x = np.clip(e/kT, -700, 700)
+    return 1.0/(1.0 + np.exp(x))
+
+
+def _fermi_prime(e, kT):
+    x = np.clip(e/kT, -350, 350)
+    ex = np.exp(x)
+    return -ex/(kT*(1 + ex)**2)
+
+
+def _band_integral(epp, kT, omega0, Gamma0):
+    """Re[ integral_{-omega0}^{+omega0} (1-f(ep,T))/(ep-epp+i*Gamma0) dep ],
+    the exact eps'-integral of equ. "F_1" (a real-valued Lorentzian
+    regularization of the ep=epp pole; Gamma0 is the lifetime broadening).
+    Smooth in epp except for its own kT-scale Fermi cutoff near epp=0 (the
+    Gamma0 pole is already integrated out here, not a remaining feature of
+    this function)."""
+    def integrand(ep):
+        d = ep - epp
+        return (1 - _fermi(ep, kT))*d/(d**2 + Gamma0**2)
+    # hint both the (Gamma0-regularized) pole at ep=epp and the Fermi
+    # cutoff of (1-f(ep,T)) at ep=0 to the adaptive quadrature, when they
+    # fall inside the band -- otherwise quad can flag a well-converged
+    # result as "probably divergent" if the two nearby features aren't
+    # both resolved by its initial subdivision
+    pts = sorted({0.} | ({epp} if abs(epp) < omega0 else set()))
+    val, _ = quad(integrand, -omega0, omega0, points=pts, limit=200)
+    return val
+
+
+class FBuilder():
+    """Vectorized evaluator of F(eps,T), the paper's own defining double
+    integral equ. "F_1" (electron-like processes) -- see the module
+    docstring for why this replaces the printed closed-form equ. "F_2".
+
+    equ. "F_1" separates into an ep'-integral over the fixed +-omega0 band
+    (done once, tabulated over eps'' on a grid and spline-interpolated --
+    _band_integral above) and an eps''-integral against the temperature
+    derivative of the Fermi function (a narrow, kT-wide kernel), which is
+    then a cheap convolution evaluated on the fly for any array of
+    eps = eV - eps_m values.
+    """
+    def __init__(self, T, omega0=20e-3, Gamma0=5e-6, kB=8.617333262e-5,
+                 ngrid=400, nwidth=60, npts=2001, grid_span=10.):
+        if T <= 0.: raise ValueError("F(eps,T) requires T>0")
+        self.kT = kB*T
+        self.omega0 = omega0
+        self.Gamma0 = Gamma0
+        # tabulate the band integral: dense near 0 (kT-scale Fermi cutoff)
+        # and near +-omega0 (band edge), spanning well beyond the band
+        # (grid_span*omega0) since eV sweeps can range further out than
+        # omega0 itself -- _band_integral is smooth there (no remaining
+        # sharp feature once the ep' integral is done), just evaluated on
+        # a grid coarse enough that cubic-spline extrapolation past it
+        # would otherwise blow up (confirmed: it does)
+        lin = np.linspace(-1., 1., ngrid)
+        grid = np.sign(lin)*grid_span*omega0*np.abs(lin)**3
+        grid = np.unique(np.concatenate(
+            [grid, np.linspace(-20*self.kT, 20*self.kT, 101)]))
+        vals = np.array([_band_integral(e, self.kT, omega0, Gamma0)
+                          for e in grid])
+        self._spline = CubicSpline(grid, vals, extrapolate=False)
+        self._grid_min, self._grid_max = grid[0], grid[-1]
+        self._val_min, self._val_max = vals[0], vals[-1]
+        width = nwidth*self.kT
+        self._fp_grid = np.linspace(-width, width, npts)
+        self._fp = _fermi_prime(self._fp_grid, self.kT)
+    def _band_value(self, epp):
+        # constant extrapolation beyond the tabulated grid instead of
+        # letting CubicSpline extrapolate (see __init__ note)
+        out = self._spline(np.clip(epp, self._grid_min, self._grid_max))
+        return out
+    def __call__(self, x):
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        epp = x[:, None] + self._fp_grid[None, :]
+        integrand = self._band_value(epp)*self._fp[None, :]
+        return -simpson(integrand, x=self._fp_grid, axis=1)
+
+
+def F(x, T, omega0=20e-3, Gamma0=5e-6, kB=8.617333262e-5):
+    """Convenience one-shot evaluation of F(eps,T) at eps=x (see FBuilder
+    for the efficient, precomputed-kernel version used when sweeping many
+    eV points against a fixed set of intermediate-state energies)."""
+    return FBuilder(T, omega0=omega0, Gamma0=Gamma0, kB=kB)(x)

--- a/src/dmrgpy/kondospectrumtk/twotime.py
+++ b/src/dmrgpy/kondospectrumtk/twotime.py
@@ -1,0 +1,115 @@
+import numpy as np
+
+# T=0 third-order Kondo term via a two-time correlator, avoiding explicit
+# excited-state enumeration -- see docs/user_guide.md sec. 17 for the
+# physics and derivation summary, and this module's own functions for the
+# numerical details. Backend-agnostic: everything here operates on a
+# supplied G(t2,tau) array (or a callable producing chunks of it), so the
+# same pipeline serves both the ED reference (edtwotimeref.py) and the
+# DMRG two-leg time-evolution construction.
+#
+# Physics: define the Heisenberg three-point function
+#   G(t2,tau) = <GS|Sl(t2+tau) Sk(t2) Sj(0)|GS>
+#             = sum_{f,m} <GS|Sl|f><f|Sk|m><m|Sj|GS> * exp(-i*eps_f0*tau) * exp(-i*eps_m0*t2)
+# so that
+#   Term(eV) = sum_{f,m} [...] * Theta0(eV-eps_f0) * (F0(eV-eps_m0)+F0(eV+eps_m0))
+#            = integral dtau dt2  K_theta(tau;eV) * K_W(t2;eV) * G(t2,tau)
+# for two closed-form time-domain kernels K_theta, K_W derived below by
+# inverse-Fourier-transforming Theta0(eV-.) and F0(eV-.)+F0(eV+.) --
+# avoiding ever having to evaluate a discontinuous step or the F0 log
+# singularity pointwise on a discrete frequency grid (which was tried
+# first and does not converge robustly -- see the module docstring notes
+# in stepfunctions.py and the PR history for why).
+#
+# K_theta(tau;eV) = (1/2)*delta(tau) - (i/(2*pi)) * exp(i*eV*tau) * PV(1/tau)
+#   (the exact inverse FT of a Heaviside step; PV = Cauchy principal value)
+# so that integral K_theta(tau;eV) h(tau) dtau
+#   = 0.5*h(0) + (i/2) * HilbertTransform[exp(i*eV*tau)*h(tau)](tau=0)
+# via the standard identity PV integral h(tau)/tau dtau = -pi*Hilbert[h](0).
+# The Hilbert transform is computed via the standard FFT method (multiply
+# the FFT by -i*sign(frequency)) -- this converges to machine precision
+# even on coarse grids, unlike a naive principal-value trapezoidal
+# quadrature (which needs impractically fine grids for the same accuracy:
+# confirmed directly, see PR history).
+#
+# K_W(t2;eV) = (1/|t2|) * exp(-Gamma0*|t2|) * [cos(t2*eV) - cos(t2*(eV-omega0))]
+#   (the exact inverse FT of F0(eV-.)+F0(eV+.), derived from F0's own
+#   closed form via the standard FT pair ln(x^2+b^2) <-> -2*pi*exp(-b|w|)/|w|)
+# applied via ordinary numerical integration over t2 (K_W is smooth, no
+# singularity at t2=0 -- the two cosines cancel there).
+#
+# Both kernels were verified independently (direct numerical/closed-form
+# checks) and the full pipeline verified end-to-end against the exact,
+# already-validated Lehmann-representation third_order_kondo_dIdV (ED, all
+# eigenstates) on small test systems -- max relative error ~0.01% at the
+# module's default parameters.
+
+
+def hilbert_transform_at_zero(signal, dt):
+    """Hilbert transform of `signal` (array, last axis = the time
+    coordinate, uniformly spaced with step dt, symmetric about 0),
+    evaluated at the t=0 grid point (assumed to be the array's midpoint
+    for an odd-length, endpoint-excluded symmetric grid -- see callers).
+    FFT-based (multiply the spectrum by -i*sign(frequency)); exact to
+    machine precision for a periodic-boundary approximation of a
+    sufficiently long/damped window."""
+    n = signal.shape[-1]
+    freqs = np.fft.fftfreq(n, d=dt)
+    kernel = -1j*np.sign(freqs)
+    return np.fft.ifft(np.fft.fft(signal, axis=-1)*kernel, axis=-1)
+
+
+def theta0_filter(tau_grid, G_of_tau, eV):
+    """integral K_theta(tau;eV) G_of_tau(tau) dtau, i.e. the exact T=0
+    Theta0(eV-H) filter applied along the last (tau) axis of G_of_tau
+    (any leading shape, e.g. a batch of t2 rows). tau_grid must be
+    uniform and symmetric about (and include) tau=0."""
+    dtau = tau_grid[1] - tau_grid[0]
+    idx0 = len(tau_grid)//2
+    if abs(tau_grid[idx0]) > 1e-6*dtau:
+        raise ValueError("tau_grid must include tau=0 at its midpoint")
+    h = np.exp(1j*eV*tau_grid)*G_of_tau
+    Hh0 = hilbert_transform_at_zero(h, dtau)[..., idx0]
+    return 0.5*G_of_tau[..., idx0] + (1j/2.)*Hh0
+
+
+def K_W(t2, eV, omega0, Gamma0):
+    """Closed-form time-domain kernel for F0(eV-.)+F0(eV+.) (see module
+    docstring). Smooth everywhere, including t2=0 (the naive 1/|t2|
+    factor there is cancelled by the vanishing bracket)."""
+    t2 = np.asarray(t2, dtype=float)
+    out = np.zeros_like(t2)
+    nz = np.abs(t2) > 1e-300
+    tnz = np.abs(t2[nz])
+    out[nz] = (np.exp(-Gamma0*tnz)/tnz)*(np.cos(t2[nz]*eV) - np.cos(t2[nz]*(eV-omega0)))
+    return out
+
+
+def kondo_term_from_two_time(t2_grid, tau_grid, G_batches, eVs, omega0, Gamma0):
+    """Assemble Term(eV) = integral dt2 K_W(t2;eV) * theta0_filter(G(t2,.);eV)
+    for every eV in `eVs`, from G(t2,tau) supplied in chunks over t2 (to
+    bound memory: the full (len(t2_grid), len(tau_grid)) array is not
+    required to exist at once).
+
+    G_batches: an iterable of (t2_slice, G_chunk) pairs, where t2_slice is
+    a 1D array (a contiguous chunk of t2_grid) and G_chunk has shape
+    (len(t2_slice), len(tau_grid)) = G(t2,tau) on that chunk. Each chunk
+    is visited exactly once, regardless of len(eVs) -- computing G is the
+    expensive part (a real time evolution on the DMRG side), so this
+    shares that one pass across the whole eV sweep instead of rebuilding
+    G per eV.
+
+    Returns an array of real-valued Term(eV), one per eVs entry (already
+    includes the Im[...]/4 from Re[X/(4i)]=Im[X]/4, matching eq.
+    "3rd-normal"'s prefactor convention in conductance.py -- multiply by
+    4*pi*T0^2*Jrho_s for the full third-order Kondo dI/dV contribution,
+    exactly as conductance.third_order_kondo_dIdV does for its own
+    (excited-state-sum-based) construction)."""
+    eVs = np.atleast_1d(np.asarray(eVs, dtype=float))
+    totals = np.zeros(len(eVs), dtype=complex)
+    for t2_chunk, G_chunk in G_batches:
+        for i, eV in enumerate(eVs):
+            h_t2 = theta0_filter(tau_grid, G_chunk, eV)
+            kw = K_W(t2_chunk, eV, omega0, Gamma0)
+            totals[i] += np.trapz(kw*h_t2, t2_chunk)
+    return np.imag(totals)/4.

--- a/src/dmrgpy/kondospectrumtk/twotime.py
+++ b/src/dmrgpy/kondospectrumtk/twotime.py
@@ -97,7 +97,15 @@ def kondo_term_from_two_time(t2_grid, tau_grid, G_batches, eVs, omega0, Gamma0):
     is visited exactly once, regardless of len(eVs) -- computing G is the
     expensive part (a real time evolution on the DMRG side), so this
     shares that one pass across the whole eV sweep instead of rebuilding
-    G per eV.
+    G per eV. Chunks may be as small as a single t2 point (as they are on
+    the DMRG side, where every t2 checkpoint is its own real trajectory) --
+    the t2 integral is done as a uniform Riemann sum weighted by t2_grid's
+    own spacing (with the standard trapezoidal half-weight only at the two
+    true endpoints of the *full* t2_grid, not per chunk), which is well
+    defined for any chunk size; a per-chunk np.trapz (tried first) silently
+    returns exactly 0 for every single-point chunk -- confirmed directly,
+    it produced an all-zero result end to end -- since a trapezoidal rule
+    needs at least two points to have any width to integrate over.
 
     Returns an array of real-valued Term(eV), one per eVs entry (already
     includes the Im[...]/4 from Re[X/(4i)]=Im[X]/4, matching eq.
@@ -107,9 +115,14 @@ def kondo_term_from_two_time(t2_grid, tau_grid, G_batches, eVs, omega0, Gamma0):
     (excited-state-sum-based) construction)."""
     eVs = np.atleast_1d(np.asarray(eVs, dtype=float))
     totals = np.zeros(len(eVs), dtype=complex)
+    dt2 = t2_grid[1] - t2_grid[0]
+    t2_first, t2_last = t2_grid[0], t2_grid[-1]
     for t2_chunk, G_chunk in G_batches:
+        weights = np.full(len(t2_chunk), dt2)
+        weights[np.isclose(t2_chunk, t2_first)] *= 0.5
+        weights[np.isclose(t2_chunk, t2_last)] *= 0.5
         for i, eV in enumerate(eVs):
             h_t2 = theta0_filter(tau_grid, G_chunk, eV)
             kw = K_W(t2_chunk, eV, omega0, Gamma0)
-            totals[i] += np.trapz(kw*h_t2, t2_chunk)
+            totals[i] += np.sum(kw*h_t2*weights)
     return np.imag(totals)/4.

--- a/src/dmrgpy/spinchain.py
+++ b/src/dmrgpy/spinchain.py
@@ -149,5 +149,53 @@ class Spin_Chain(Many_Body_Chain):
             out = out + fieldterms
         # still have to add the fields!!
         return out # return multioperator
+    def get_kondo_spectrum(self, eV, site=0, Jrho_s=0.0, U=0.0, T=1.0,
+                            T0=1.0, omega0=20e-3, Gamma0=5e-6, order=3,
+                            kB=8.617333262e-5):
+        """Third-order STM/Kondo perturbation-theory tunneling spectrum
+        dI/dV(eV) for a single impurity site under the tip, following
+        Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430. Always
+        uses full ED diagonalization of this chain's Hamiltonian (every
+        eigenstate is needed as a possible virtual intermediate state, not
+        just the low-energy ones DMRG/Lanczos-type ED would target), via
+        kondospectrumtk.edkondo.KondoSpectrum -- independent of this
+        chain's own itensor_version/DMRG-vs-ED mode setting.
+
+        Parameters (see kondospectrumtk.conductance for the underlying
+        equations):
+          eV: array of bias energies (same units as the Hamiltonian, e.g.
+              eV if built with eV-scale couplings)
+          site: chain site index coupled to the tip
+          Jrho_s: dimensionless Kondo exchange coupling (J*rho_sample)
+          U: dimensionless potential-scattering ratio (eq. "Matrix1")
+          T: temperature in Kelvin (kB below is eV/K by default; pass a
+             matching kB if your Hamiltonian is in different energy units)
+          T0: overall tunneling-strength scale (only sets the absolute
+              scale of the returned dI/dV, in units of 2*pi*e^2*T0^2/hbar)
+          omega0, Gamma0: band cutoff and lifetime broadening for the
+              third-order Kondo function F(eps,T)
+          order: 2 for the second-order (Fermi golden rule) term alone, 3
+              to add the third-order Kondo and (if U!=0) potential-
+              interference terms. The third-order terms are d(I^{t->s})/dV
+              only -- see third_order_kondo_dIdV's docstring for why (the
+              paper never gives a general t<->s formula for them); the
+              second-order term is the full, bidirectional net-current
+              derivative.
+
+        Returns (eV, dIdV)."""
+        from .kondospectrumtk.edkondo import KondoSpectrum
+        from .kondospectrumtk import conductance
+        if order not in (2, 3): raise ValueError("order must be 2 or 3")
+        ks = KondoSpectrum(self, site, T, kB=kB)
+        eV = np.asarray(eV, dtype=float)
+        dIdV = conductance.second_order_dIdV(ks, eV, T0=T0, U=U)
+        if order == 3:
+            dIdV = dIdV + conductance.third_order_kondo_dIdV(
+                    ks, eV, Jrho_s, T0=T0, omega0=omega0, Gamma0=Gamma0)
+            if U != 0.0:
+                dIdV = dIdV + conductance.third_order_potential_dIdV(
+                        ks, eV, Jrho_s, U, T0=T0, omega0=omega0,
+                        Gamma0=Gamma0)
+        return eV, dIdV
 
 Spin_Hamiltonian = Spin_Chain # backwards compatibility

--- a/src/dmrgpy/spinchain.py
+++ b/src/dmrgpy/spinchain.py
@@ -185,16 +185,20 @@ class Spin_Chain(Many_Body_Chain):
         Returns (eV, dIdV)."""
         from .kondospectrumtk.edkondo import KondoSpectrum
         from .kondospectrumtk import conductance
+        from .kondospectrumtk.stepfunctions import FBuilder
         if order not in (2, 3): raise ValueError("order must be 2 or 3")
         ks = KondoSpectrum(self, site, T, kB=kB)
         eV = np.asarray(eV, dtype=float)
         dIdV = conductance.second_order_dIdV(ks, eV, T0=T0, U=U)
         if order == 3:
+            # shared between both calls below: building it tabulates an
+            # expensive adaptive-quadrature integral (see FBuilder)
+            Fb = FBuilder(T, omega0=omega0, Gamma0=Gamma0, kB=kB)
             dIdV = dIdV + conductance.third_order_kondo_dIdV(
-                    ks, eV, Jrho_s, T0=T0, omega0=omega0, Gamma0=Gamma0)
+                    ks, eV, Jrho_s, T0=T0, omega0=omega0, Gamma0=Gamma0, Fb=Fb)
             if U != 0.0:
                 dIdV = dIdV + conductance.third_order_potential_dIdV(
-                        ks, eV, Jrho_s, U, T0=T0, omega0=omega0,
+                        ks, eV, Jrho_s, U, T0=T0, omega0=omega0, Fb=Fb,
                         Gamma0=Gamma0)
         return eV, dIdV
 

--- a/src/dmrgpy/spinchain.py
+++ b/src/dmrgpy/spinchain.py
@@ -198,7 +198,13 @@ class Spin_Chain(Many_Body_Chain):
               that function's docstring -- and must be supplied when
               order requests it); `dt2`, `n_t2_half`, `dtau`, `n_tau_half`
               to kondospectrumtk.dmrgtwotime.two_time_kondo_term_dmrg for
-              the third-order term. Validated against ITensor v3 once a
+              the third-order term (order=3) -- these four also have no
+              safe default (see that function's docstring: a grid fine/
+              wide enough for the default omega0/Gamma0 is computationally
+              infeasible to pick automatically, while a small fast
+              default silently returns a badly wrong result instead of
+              erroring) and must be supplied explicitly. Validated
+              against ITensor v3 once a
               compiled backend became available (see
               test_kondo_spectrum_dmrgtwotime.py and
               kondospectrumtk/dmrgtwotime.py's module docstring for what
@@ -241,8 +247,8 @@ class Spin_Chain(Many_Body_Chain):
         return eV, dIdV
     def _get_kondo_spectrum_dmrg(self, eV, site, Jrho_s, U, T0, omega0,
                                   Gamma0, order, submode="KPM", delta=2e-6,
-                                  es=None, dt2=1.0, n_t2_half=200, dtau=1.0,
-                                  n_tau_half=200):
+                                  es=None, dt2=None, n_t2_half=None,
+                                  dtau=None, n_tau_half=None):
         from .kondospectrumtk.secondorder_dc import second_order_dIdV_dc
         if U != 0.0 and order == 3:
             raise NotImplementedError(

--- a/src/dmrgpy/spinchain.py
+++ b/src/dmrgpy/spinchain.py
@@ -151,15 +151,10 @@ class Spin_Chain(Many_Body_Chain):
         return out # return multioperator
     def get_kondo_spectrum(self, eV, site=0, Jrho_s=0.0, U=0.0, T=1.0,
                             T0=1.0, omega0=20e-3, Gamma0=5e-6, order=3,
-                            kB=8.617333262e-5):
+                            kB=8.617333262e-5, mode="ED", **kwargs):
         """Third-order STM/Kondo perturbation-theory tunneling spectrum
         dI/dV(eV) for a single impurity site under the tip, following
-        Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430. Always
-        uses full ED diagonalization of this chain's Hamiltonian (every
-        eigenstate is needed as a possible virtual intermediate state, not
-        just the low-energy ones DMRG/Lanczos-type ED would target), via
-        kondospectrumtk.edkondo.KondoSpectrum -- independent of this
-        chain's own itensor_version/DMRG-vs-ED mode setting.
+        Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430.
 
         Parameters (see kondospectrumtk.conductance for the underlying
         equations):
@@ -169,7 +164,8 @@ class Spin_Chain(Many_Body_Chain):
           Jrho_s: dimensionless Kondo exchange coupling (J*rho_sample)
           U: dimensionless potential-scattering ratio (eq. "Matrix1")
           T: temperature in Kelvin (kB below is eV/K by default; pass a
-             matching kB if your Hamiltonian is in different energy units)
+             matching kB if your Hamiltonian is in different energy units).
+             T=0 is a valid, exact limit, not an error.
           T0: overall tunneling-strength scale (only sets the absolute
               scale of the returned dI/dV, in units of 2*pi*e^2*T0^2/hbar)
           omega0, Gamma0: band cutoff and lifetime broadening for the
@@ -181,25 +177,80 @@ class Spin_Chain(Many_Body_Chain):
               paper never gives a general t<->s formula for them); the
               second-order term is the full, bidirectional net-current
               derivative.
+          mode: "ED" (default) always uses full ED diagonalization of this
+              chain's Hamiltonian (every eigenstate is needed as a
+              possible virtual intermediate state), via
+              kondospectrumtk.edkondo.KondoSpectrum -- independent of this
+              chain's own itensor_version/DMRG-vs-ED mode setting, and
+              valid at any T>=0.
+              "DMRG" instead uses itensor_version=3 real time evolution
+              throughout, never diagonalizing beyond the ground state --
+              see kondospectrumtk/twotime.py's module docstring for the
+              construction. Only T=0 is supported (the T>0 excited-state
+              Boltzmann sum this feature was originally scoped around was
+              never built for DMRG -- T=0 turned out to admit a cleaner,
+              diagonalization-free construction instead, which is what
+              shipped), and the potential-interference term (U!=0,
+              order=3) is ED-only -- not implemented for DMRG. Extra
+              kwargs are forwarded: `submode` (default "KPM"), `delta`,
+              `es` to kondospectrumtk.secondorder_dc.second_order_dIdV_dc
+              for the second-order term (`es` has no safe default -- see
+              that function's docstring -- and must be supplied when
+              order requests it); `dt2`, `n_t2_half`, `dtau`, `n_tau_half`
+              to kondospectrumtk.dmrgtwotime.two_time_kondo_term_dmrg for
+              the third-order term. The DMRG path was written against
+              this codebase's existing, verified DMRG API but could not
+              be executed/validated in ITensor v3, treat it as
+              provisional pending independent confirmation.
 
         Returns (eV, dIdV)."""
+        if order not in (2, 3): raise ValueError("order must be 2 or 3")
+        eV = np.asarray(eV, dtype=float)
+        if mode == "ED":
+            return self._get_kondo_spectrum_ed(eV, site, Jrho_s, U, T, T0,
+                                                omega0, Gamma0, order, kB)
+        elif mode == "DMRG":
+            if T != 0.:
+                raise ValueError("mode=\"DMRG\" only supports T=0")
+            return self._get_kondo_spectrum_dmrg(eV, site, Jrho_s, U, T0,
+                                                  omega0, Gamma0, order,
+                                                  **kwargs)
+        else: raise ValueError("mode must be \"ED\" or \"DMRG\"")
+    def _get_kondo_spectrum_ed(self, eV, site, Jrho_s, U, T, T0, omega0,
+                                Gamma0, order, kB):
         from .kondospectrumtk.edkondo import KondoSpectrum
         from .kondospectrumtk import conductance
         from .kondospectrumtk.stepfunctions import FBuilder
-        if order not in (2, 3): raise ValueError("order must be 2 or 3")
         ks = KondoSpectrum(self, site, T, kB=kB)
-        eV = np.asarray(eV, dtype=float)
         dIdV = conductance.second_order_dIdV(ks, eV, T0=T0, U=U)
         if order == 3:
             # shared between both calls below: building it tabulates an
             # expensive adaptive-quadrature integral (see FBuilder)
-            Fb = FBuilder(T, omega0=omega0, Gamma0=Gamma0, kB=kB)
+            Fb = FBuilder(T, omega0=omega0, Gamma0=Gamma0, kB=kB) if T>0. else None
             dIdV = dIdV + conductance.third_order_kondo_dIdV(
                     ks, eV, Jrho_s, T0=T0, omega0=omega0, Gamma0=Gamma0, Fb=Fb)
             if U != 0.0:
                 dIdV = dIdV + conductance.third_order_potential_dIdV(
                         ks, eV, Jrho_s, U, T0=T0, omega0=omega0, Fb=Fb,
                         Gamma0=Gamma0)
+        return eV, dIdV
+    def _get_kondo_spectrum_dmrg(self, eV, site, Jrho_s, U, T0, omega0,
+                                  Gamma0, order, submode="KPM", delta=2e-6,
+                                  es=None, dt2=1.0, n_t2_half=200, dtau=1.0,
+                                  n_tau_half=200):
+        from .kondospectrumtk.secondorder_dc import second_order_dIdV_dc
+        if U != 0.0 and order == 3:
+            raise NotImplementedError(
+                "the potential-interference term (U!=0, order=3) is not "
+                "implemented for mode=\"DMRG\"")
+        dIdV = second_order_dIdV_dc(self, site, eV, T0=T0, U=U, mode="DMRG",
+                                     submode=submode, delta=delta, es=es)
+        if order == 3:
+            from .kondospectrumtk.dmrgtwotime import two_time_kondo_term_dmrg
+            term = two_time_kondo_term_dmrg(
+                    self, site, eV, omega0=omega0, Gamma0=Gamma0, dt2=dt2,
+                    n_t2_half=n_t2_half, dtau=dtau, n_tau_half=n_tau_half)
+            dIdV = dIdV + 4*np.pi*T0**2*Jrho_s*term
         return eV, dIdV
 
 Spin_Hamiltonian = Spin_Chain # backwards compatibility

--- a/src/dmrgpy/spinchain.py
+++ b/src/dmrgpy/spinchain.py
@@ -190,28 +190,44 @@ class Spin_Chain(Many_Body_Chain):
               Boltzmann sum this feature was originally scoped around was
               never built for DMRG -- T=0 turned out to admit a cleaner,
               diagonalization-free construction instead, which is what
-              shipped), and the potential-interference term (U!=0,
-              order=3) is ED-only -- not implemented for DMRG. Extra
+              shipped). The potential-interference term (U!=0, order=3)
+              is also supported for DMRG, via
+              kondospectrumtk.potentialdc.third_order_potential_dIdV_dc --
+              like the second-order term, its T=0 limit collapses to a
+              dynamical-correlator convolution (against the F0 kernel
+              instead of a Theta0-weighted cumulative sum), so it needs
+              no excited-state enumeration either; it carries the same
+              general-S-extrapolation caveat as
+              conductance.third_order_potential_dIdV (see that
+              function's docstring). Extra
               kwargs are forwarded: `submode` (default "KPM"), `delta`,
               `es` to kondospectrumtk.secondorder_dc.second_order_dIdV_dc
-              for the second-order term (`es` has no safe default -- see
-              that function's docstring -- and must be supplied when
-              order requests it); `dt2`, `n_t2_half`, `dtau`, `n_tau_half`
+              (second-order term) and
+              kondospectrumtk.potentialdc.third_order_potential_dIdV_dc
+              (potential-interference term, if U!=0) (`es` has no safe
+              default -- see either function's docstring -- and must be
+              supplied when order requests it). Any further kwargs (e.g.
+              `n`, the number of KPM moments -- its own default of 1000
+              is accurate but expensive; a compiled-backend smoke test
+              may want far fewer) are forwarded on to
+              chain.get_dynamical_correlator via both of the above, for
+              whichever mode/submode combination is in use. `dt2`, `n_t2_half`,
+              `dtau`, `n_tau_half`
               to kondospectrumtk.dmrgtwotime.two_time_kondo_term_dmrg for
-              the third-order term (order=3) -- these four also have no
-              safe default (see that function's docstring: a grid fine/
-              wide enough for the default omega0/Gamma0 is computationally
-              infeasible to pick automatically, while a small fast
-              default silently returns a badly wrong result instead of
-              erroring) and must be supplied explicitly. Validated
-              against ITensor v3 once a
+              the third-order Kondo term (order=3) -- these four also have
+              no safe default (see that function's docstring: a grid
+              fine/wide enough for the default omega0/Gamma0 is
+              computationally infeasible to pick automatically, while a
+              small fast default silently returns a badly wrong result
+              instead of erroring) and must be supplied explicitly.
+              Validated against ITensor v3 once a
               compiled backend became available (see
               test_kondo_spectrum_dmrgtwotime.py and
               kondospectrumtk/dmrgtwotime.py's module docstring for what
-              that surfaced and fixed): the third-order term's G(t2,tau)
-              matches the ED reference to ~1e-9-1e-10, and the swept
-              second-order term (KPM) agrees to within a few tens of
-              percent at thresholds, consistent with the expected
+              that surfaced and fixed): the third-order Kondo term's
+              G(t2,tau) matches the ED reference to ~1e-9-1e-10, and the
+              swept second-order term (KPM) agrees to within a few tens
+              of percent at thresholds, consistent with the expected
               delta-broadening/moment-truncation error.
 
         Returns (eV, dIdV)."""
@@ -248,20 +264,23 @@ class Spin_Chain(Many_Body_Chain):
     def _get_kondo_spectrum_dmrg(self, eV, site, Jrho_s, U, T0, omega0,
                                   Gamma0, order, submode="KPM", delta=2e-6,
                                   es=None, dt2=None, n_t2_half=None,
-                                  dtau=None, n_tau_half=None):
+                                  dtau=None, n_tau_half=None, **dc_kwargs):
         from .kondospectrumtk.secondorder_dc import second_order_dIdV_dc
-        if U != 0.0 and order == 3:
-            raise NotImplementedError(
-                "the potential-interference term (U!=0, order=3) is not "
-                "implemented for mode=\"DMRG\"")
         dIdV = second_order_dIdV_dc(self, site, eV, T0=T0, U=U, mode="DMRG",
-                                     submode=submode, delta=delta, es=es)
+                                     submode=submode, delta=delta, es=es,
+                                     **dc_kwargs)
         if order == 3:
             from .kondospectrumtk.dmrgtwotime import two_time_kondo_term_dmrg
             term = two_time_kondo_term_dmrg(
                     self, site, eV, omega0=omega0, Gamma0=Gamma0, dt2=dt2,
                     n_t2_half=n_t2_half, dtau=dtau, n_tau_half=n_tau_half)
             dIdV = dIdV + 4*np.pi*T0**2*Jrho_s*term
+            if U != 0.0:
+                from .kondospectrumtk.potentialdc import third_order_potential_dIdV_dc
+                dIdV = dIdV + third_order_potential_dIdV_dc(
+                        self, site, eV, Jrho_s, U, T0=T0, omega0=omega0,
+                        Gamma0=Gamma0, mode="DMRG", submode=submode,
+                        delta=delta, es=es, **dc_kwargs)
         return eV, dIdV
 
 Spin_Hamiltonian = Spin_Chain # backwards compatibility

--- a/src/dmrgpy/spinchain.py
+++ b/src/dmrgpy/spinchain.py
@@ -198,10 +198,15 @@ class Spin_Chain(Many_Body_Chain):
               that function's docstring -- and must be supplied when
               order requests it); `dt2`, `n_t2_half`, `dtau`, `n_tau_half`
               to kondospectrumtk.dmrgtwotime.two_time_kondo_term_dmrg for
-              the third-order term. The DMRG path was written against
-              this codebase's existing, verified DMRG API but could not
-              be executed/validated in ITensor v3, treat it as
-              provisional pending independent confirmation.
+              the third-order term. Validated against ITensor v3 once a
+              compiled backend became available (see
+              test_kondo_spectrum_dmrgtwotime.py and
+              kondospectrumtk/dmrgtwotime.py's module docstring for what
+              that surfaced and fixed): the third-order term's G(t2,tau)
+              matches the ED reference to ~1e-9-1e-10, and the swept
+              second-order term (KPM) agrees to within a few tens of
+              percent at thresholds, consistent with the expected
+              delta-broadening/moment-truncation error.
 
         Returns (eV, dIdV)."""
         if order not in (2, 3): raise ValueError("order must be 2 or 3")

--- a/tests/test_kondo_spectrum.py
+++ b/tests/test_kondo_spectrum.py
@@ -1,0 +1,142 @@
+"""Coverage for the third-order STM/Kondo perturbation-theory spectrum
+(kondospectrumtk/, Spin_Chain.get_kondo_spectrum), following Ternes, New
+J. Phys. 17 063016 (2015), arXiv:1505.04430.
+
+These checks are analytic/structural, not golden-value regressions: for
+a single S=1/2 impurity the second-order term's plateau values can be
+worked out exactly by hand (see second_order_dIdV's own derivation in
+kondospectrumtk/conductance.py), and several qualitative features (the
+paper's own Fig. 2/3) are unambiguous enough to assert on directly:
+Theta(x) must be a bounded, symmetric step; F(eps,T) must be a positive,
+peaked, decaying function (checked against digitized-by-eye values from
+the paper's own Fig. F); the zero-field third-order Kondo term must be a
+peak at eV=0; the potential-interference term must vanish at U=0 and be
+bias-asymmetric at U!=0.
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import spinchain
+from dmrgpy.kondospectrumtk.stepfunctions import Theta, Theta_prime, F
+from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum
+from dmrgpy.kondospectrumtk.conductance import (
+    second_order_dIdV, third_order_kondo_dIdV, third_order_potential_dIdV)
+
+G = 2.0
+MUB = 5.7883818066e-5 # eV/T
+KB = 8.617333262e-5 # eV/K
+
+
+def _single_spin_half(B, T=1.0):
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*B*sc.Sz[0])
+    return KondoSpectrum(sc, site=0, T=T)
+
+
+def test_theta_bounded_and_symmetric():
+    xs = np.linspace(-30, 30, 61)
+    th = Theta(xs)
+    assert np.all(th >= 0.) and np.all(th <= 1.)
+    assert np.allclose(th + Theta(-xs), 1.)
+    assert Theta(np.array([0.]))[0] == pytest.approx(0.5)
+
+
+def test_theta_prime_matches_finite_difference():
+    xs = np.linspace(-5, 5, 21)
+    h = 1e-6
+    fd = (Theta(xs+h) - Theta(xs-h))/(2*h)
+    assert np.allclose(Theta_prime(xs), fd, atol=1e-4)
+
+
+def test_F_matches_figure_F_reference_values():
+    # digitized from the paper's own Fig. F(b), T=1K, omega0=200meV,
+    # Gamma0=5ueV curve: F(0)~7.5, F(10meV)~3.1
+    vals = F(np.array([0., 10e-3]), T=1.0, omega0=0.2, Gamma0=5e-6)
+    assert vals[0] == pytest.approx(7.5, abs=0.1)
+    assert vals[1] == pytest.approx(3.1, abs=0.2)
+    assert vals[0] > vals[1] > 0. # peaked and positive
+
+
+def test_F_decays_away_from_the_peak():
+    # F is "electron-like" (equ. "F_1" uses 1-f(ep',T) in its numerator,
+    # not the symmetrized combination with the "hole-like" equ. "F_1h"),
+    # so it is NOT expected to be even in x=eV-eps_m -- only decay away
+    # from its peak at x=0 in both directions.
+    xs = np.array([0., 1e-3, 1.])
+    vals = F(xs, T=1.0, omega0=0.2, Gamma0=5e-6)
+    assert vals[0] > vals[1] > vals[2] # monotonically decaying away from 0
+    assert vals[0] > 0. and vals[1] > 0. # positive near the peak
+    neg_vals = F(np.array([-1e-3, -1.]), T=1.0, omega0=0.2, Gamma0=5e-6)
+    assert vals[0] > neg_vals[0] > neg_vals[1]
+
+
+def test_second_order_zeeman_step_plateaus():
+    """Analytic plateaus for a single S=1/2 impurity, unpolarized leads,
+    U=0, field large compared to kT (so the ground state is essentially
+    fully occupied): at large positive bias only the t->s direction is
+    above threshold for both its elastic (weight 0.25) and spin-flip
+    (weight 0.5) channels, while s->t is deep below its own threshold
+    (Theta(-eV-eps_if)~0) -- giving 2*pi*0.75. Exactly at eV=0 only the
+    elastic channel sits at its own threshold in *both* directions at
+    once (Theta(0)=1/2 each), giving 2*pi*2*(0.25*0.5) = pi/2."""
+    ks = _single_spin_half(B=10.0, T=1.0)
+    eVs = np.array([0., 5.0*G*MUB*10.0])
+    dIdV = second_order_dIdV(ks, eVs, T0=1.0, U=0.0)
+    assert dIdV[0] == pytest.approx(np.pi/2, abs=1e-3)
+    assert dIdV[1] == pytest.approx(2*np.pi*0.75, abs=1e-3)
+
+
+def test_second_order_symmetric_and_positive():
+    ks = _single_spin_half(B=3.0, T=1.0)
+    eVs = np.linspace(-1e-3, 1e-3, 41)
+    dIdV = second_order_dIdV(ks, eVs, T0=1.0, U=0.15)
+    assert np.all(dIdV > 0.)
+    assert np.allclose(dIdV, dIdV[::-1], atol=1e-8)
+
+
+def test_third_order_kondo_zero_field_has_a_zero_bias_feature():
+    """Fig. 3a/b: at zero field the third-order Kondo term produces a
+    zero-bias resonance. This term is d(I^{t->s})/dV only (see
+    third_order_kondo_dIdV's docstring), so unlike the full, bidirectional
+    Fig. 3b curve it is not itself symmetric in eV -- Theta(eV-eps_if) is
+    a one-sided step -- so the peak sits strictly inside the swept window
+    rather than exactly at eV=0, but should be far above both the Jrho_s=0
+    baseline (zero) and the window edges."""
+    ks = _single_spin_half(B=0.0, T=1.0)
+    span = 3e-3
+    eVs = np.linspace(-span, span, 41)
+    d3 = third_order_kondo_dIdV(ks, eVs, Jrho_s=-0.05, T0=1.0)
+    assert np.all(third_order_kondo_dIdV(ks, eVs, Jrho_s=0., T0=1.0) == 0.)
+    imax = np.argmax(d3)
+    assert 0 < imax < len(eVs) - 1 # peak strictly inside the window
+    assert d3[imax] > d3[0] and d3[imax] > d3[-1]
+
+
+def test_third_order_potential_vanishes_at_U0_and_is_asymmetric():
+    ks = _single_spin_half(B=10.0, T=1.0)
+    eVs = np.linspace(-2e-3, 2e-3, 21)
+    dU0 = third_order_potential_dIdV(ks, eVs, Jrho_s=-0.05, U=0.0, T0=1.0)
+    assert np.allclose(dU0, 0.)
+    dU = third_order_potential_dIdV(ks, eVs, Jrho_s=-0.05, U=0.25, T0=1.0)
+    assert not np.allclose(dU, dU[::-1], atol=1e-8) # bias asymmetric
+
+
+def test_get_kondo_spectrum_order2_matches_second_order_dIdV():
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*5.0*sc.Sz[0])
+    eVs = np.linspace(-1e-3, 1e-3, 11)
+    eV_out, dIdV = sc.get_kondo_spectrum(eVs, site=0, T=1.0, order=2)
+    ks = KondoSpectrum(sc, site=0, T=1.0)
+    ref = second_order_dIdV(ks, eVs, T0=1.0, U=0.0)
+    assert np.allclose(eV_out, eVs)
+    assert np.allclose(dIdV, ref)
+
+
+def test_get_kondo_spectrum_order3_is_finite_and_real():
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*5.0*sc.Sz[0])
+    eVs = np.linspace(-2e-3, 2e-3, 21)
+    eV_out, dIdV = sc.get_kondo_spectrum(
+            eVs, site=0, Jrho_s=-0.05, U=0.2, T=1.0, order=3)
+    assert dIdV.dtype == np.float64
+    assert np.all(np.isfinite(dIdV))

--- a/tests/test_kondo_spectrum.py
+++ b/tests/test_kondo_spectrum.py
@@ -132,6 +132,55 @@ def test_get_kondo_spectrum_order2_matches_second_order_dIdV():
     assert np.allclose(dIdV, ref)
 
 
+def test_third_order_kondo_eps_if_sign_on_asymmetric_spectrum():
+    """Regression test for a real sign bug: third_order_kondo_dIdV used
+    to build eps_if as e_i-e_f instead of e_f-e_i (the convention its own
+    module docstring and second_order_dIdV both state), silently -- every
+    other test/example here only exercises symmetric two-level (S=1/2)
+    systems, where swapping i<->f just permutes which pair gets which
+    energy and the bug has no effect on the Boltzmann-weighted sum. An
+    S=1 impurity with both anisotropy and a field has a non-degenerate,
+    asymmetric-under-relabeling spectrum, so it does distinguish the two
+    conventions: cross-check third_order_kondo_dIdV against an
+    independently written reference that only uses the (m,i) energy
+    differences and Boltzmann weights, not the module's own eps_if."""
+    sc = spinchain.Spin_Chain(["1"])
+    D, B = 3e-4, 4.0
+    sc.set_hamiltonian(D*sc.Sz[0]*sc.Sz[0] + G*MUB*B*sc.Sz[0])
+    ks = KondoSpectrum(sc, site=0, T=1.0)
+    assert len(set(np.round(ks.e, 12))) == ks.dim # genuinely non-degenerate
+
+    eVs = np.linspace(-2e-3, 2e-3, 11)
+    Jrho_s = -0.05
+    got = third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=1.0)
+
+    # independent reference: same physics, written from scratch here
+    Xi = np.stack([ks.Sx, ks.Sy, ks.Sz], axis=-1)
+    eps3 = np.zeros((3, 3, 3))
+    for a, b, c in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]:
+        eps3[a, b, c] = 1.
+    for a, b, c in [(0, 2, 1), (2, 1, 0), (1, 0, 2)]:
+        eps3[a, b, c] = -1.
+    coeff = np.imag(np.einsum('jkl,ifl,fmk,mij->ifm', eps3, Xi, Xi, Xi))/4.
+    kT = ks.kB*ks.T
+    from dmrgpy.kondospectrumtk.stepfunctions import FBuilder
+    Fb = FBuilder(ks.T) # build once, reuse (F() alone would be far too slow here)
+    ref = np.zeros(len(eVs))
+    for e_idx, eV in enumerate(eVs):
+        acc = 0.
+        for i in range(ks.dim):
+            for f in range(ks.dim):
+                eps_if_ref = ks.e[f] - ks.e[i] # unambiguous by construction
+                th = Theta(np.array([(eV - eps_if_ref)/kT]))[0]
+                for m in range(ks.dim):
+                    eps_im_ref = ks.e[m] - ks.e[i]
+                    fsum = (Fb(np.array([eV - eps_im_ref]))[0]
+                            + Fb(np.array([eV + eps_im_ref]))[0])
+                    acc += ks.p[i]*coeff[i, f, m]*th*fsum
+        ref[e_idx] = 4*np.pi*1.0**2*Jrho_s*acc
+    assert np.allclose(got, ref, atol=1e-8)
+
+
 def test_get_kondo_spectrum_order3_is_finite_and_real():
     sc = spinchain.Spin_Chain(["1/2"])
     sc.set_hamiltonian(G*MUB*5.0*sc.Sz[0])

--- a/tests/test_kondo_spectrum.py
+++ b/tests/test_kondo_spectrum.py
@@ -215,3 +215,20 @@ def test_get_kondo_spectrum_mode_dmrg_rejects_nonzero_T_and_U():
         sc.get_kondo_spectrum(eVs, site=0, T=0.0, U=0.1, order=3, mode="DMRG")
     with pytest.raises(ValueError):
         sc.get_kondo_spectrum(eVs, site=0, mode="bogus")
+
+
+def test_two_time_kondo_term_dmrg_requires_explicit_grid():
+    """dt2/n_t2_half/dtau/n_tau_half have no numeric default (see
+    two_time_kondo_term_dmrg's docstring in dmrgtwotime.py): a small, fast
+    default silently returns a badly wrong result for the also-default
+    omega0/Gamma0 instead of erroring, so all four are mandatory. This
+    check fires before the (here, nonsense) chain/site arguments are ever
+    touched, so it needs no compiled itensor_version=3 backend -- unlike
+    the rest of dmrgtwotime.py's coverage in
+    test_kondo_spectrum_dmrgtwotime.py, which is skipped without one."""
+    from dmrgpy.kondospectrumtk.dmrgtwotime import two_time_kondo_term_dmrg
+    with pytest.raises(ValueError):
+        two_time_kondo_term_dmrg(None, 0, [0.0])
+    with pytest.raises(ValueError):
+        two_time_kondo_term_dmrg(None, 0, [0.0], dt2=1.0, n_t2_half=5,
+                                  dtau=1.0, n_tau_half=None)

--- a/tests/test_kondo_spectrum.py
+++ b/tests/test_kondo_spectrum.py
@@ -189,3 +189,29 @@ def test_get_kondo_spectrum_order3_is_finite_and_real():
             eVs, site=0, Jrho_s=-0.05, U=0.2, T=1.0, order=3)
     assert dIdV.dtype == np.float64
     assert np.all(np.isfinite(dIdV))
+
+
+def test_get_kondo_spectrum_mode_ed_T0_matches_direct_call():
+    """mode="ED" (the default) accepts T=0 directly, matching a manual
+    KondoSpectrum(T=0) + conductance call."""
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*5.0*sc.Sz[0])
+    eVs = np.linspace(-1e-3, 1e-3, 11)
+    eV_out, dIdV = sc.get_kondo_spectrum(eVs, site=0, Jrho_s=-0.05, T=0.0,
+                                          order=3)
+    ks = KondoSpectrum(sc, site=0, T=0.0)
+    ref = (second_order_dIdV(ks, eVs, T0=1.0, U=0.0)
+           + third_order_kondo_dIdV(ks, eVs, -0.05, T0=1.0))
+    assert np.allclose(dIdV, ref)
+
+
+def test_get_kondo_spectrum_mode_dmrg_rejects_nonzero_T_and_U():
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*5.0*sc.Sz[0])
+    eVs = np.linspace(-1e-3, 1e-3, 5)
+    with pytest.raises(ValueError):
+        sc.get_kondo_spectrum(eVs, site=0, T=1.0, mode="DMRG")
+    with pytest.raises(NotImplementedError):
+        sc.get_kondo_spectrum(eVs, site=0, T=0.0, U=0.1, order=3, mode="DMRG")
+    with pytest.raises(ValueError):
+        sc.get_kondo_spectrum(eVs, site=0, mode="bogus")

--- a/tests/test_kondo_spectrum.py
+++ b/tests/test_kondo_spectrum.py
@@ -205,16 +205,69 @@ def test_get_kondo_spectrum_mode_ed_T0_matches_direct_call():
     assert np.allclose(dIdV, ref)
 
 
-def test_get_kondo_spectrum_mode_dmrg_rejects_nonzero_T_and_U():
+def test_get_kondo_spectrum_mode_dmrg_rejects_nonzero_T_and_missing_kwargs():
     sc = spinchain.Spin_Chain(["1/2"])
     sc.set_hamiltonian(G*MUB*5.0*sc.Sz[0])
     eVs = np.linspace(-1e-3, 1e-3, 5)
     with pytest.raises(ValueError):
         sc.get_kondo_spectrum(eVs, site=0, T=1.0, mode="DMRG")
-    with pytest.raises(NotImplementedError):
+    # U!=0, order=3 is implemented for mode="DMRG" (potentialdc.py), but
+    # still requires the same mandatory `es` kwarg as the plain
+    # second-order term (checked before the potential term is reached) --
+    # see test_kondo_spectrum_potentialdc.py and
+    # test_kondo_spectrum_dmrgtwotime.py for the functional coverage of
+    # this path with a compiled backend.
+    with pytest.raises(ValueError):
         sc.get_kondo_spectrum(eVs, site=0, T=0.0, U=0.1, order=3, mode="DMRG")
     with pytest.raises(ValueError):
         sc.get_kondo_spectrum(eVs, site=0, mode="bogus")
+
+
+def test_get_kondo_spectrum_dmrg_combines_terms_correctly(monkeypatch):
+    """Unit-level check of Spin_Chain._get_kondo_spectrum_dmrg's wiring --
+    the correct linear combination of the second-order term, third-order
+    Kondo term, and (if U!=0) the potential-interference term -- with the
+    three underlying (expensive) computations monkeypatched out entirely.
+    The individual pieces are numerically validated against their ED
+    references elsewhere (test_kondo_spectrum_potentialdc.py,
+    test_kondo_spectrum_dmrgtwotime.py); a real end-to-end run through
+    mode="DMRG" submode="KPM" was tried here first and found
+    impractically expensive for a routine test -- a single KPM dynamical-
+    correlator call took ~40s on this repo's test hardware even with a
+    trivially small number of moments, confirmed directly -- so this
+    checks the arithmetic only, with no real DMRG computation and no
+    compiled-backend dependency (the local `from .kondospectrumtk.X
+    import Y` imports inside _get_kondo_spectrum_dmrg re-resolve Y from
+    X's namespace on every call, so patching X.Y here is picked up)."""
+    import dmrgpy.kondospectrumtk.secondorder_dc as secondorder_dc
+    import dmrgpy.kondospectrumtk.potentialdc as potentialdc
+    import dmrgpy.kondospectrumtk.dmrgtwotime as dmrgtwotime
+
+    eVs = np.linspace(-1e-3, 1e-3, 3)
+    monkeypatch.setattr(secondorder_dc, "second_order_dIdV_dc",
+                         lambda *a, **kw: np.full(len(eVs), 1.0))
+    monkeypatch.setattr(dmrgtwotime, "two_time_kondo_term_dmrg",
+                         lambda *a, **kw: np.full(len(eVs), 2.0))
+    monkeypatch.setattr(potentialdc, "third_order_potential_dIdV_dc",
+                         lambda *a, **kw: np.full(len(eVs), 3.0))
+
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*5.0*sc.Sz[0])
+    T0, Jrho_s = 2.0, 0.5
+    common = dict(es=np.array([0.]), dt2=1., n_t2_half=1, dtau=1.,
+                  n_tau_half=1)
+
+    _, dIdV = sc._get_kondo_spectrum_dmrg(eVs, 0, Jrho_s, 0.0, T0, 20e-3,
+                                           5e-6, order=3, **common)
+    assert np.allclose(dIdV, 1.0 + 4*np.pi*T0**2*Jrho_s*2.0) # U=0: no potential term
+
+    _, dIdV = sc._get_kondo_spectrum_dmrg(eVs, 0, Jrho_s, 0.3, T0, 20e-3,
+                                           5e-6, order=3, **common)
+    assert np.allclose(dIdV, 1.0 + 4*np.pi*T0**2*Jrho_s*2.0 + 3.0)
+
+    _, dIdV = sc._get_kondo_spectrum_dmrg(eVs, 0, Jrho_s, 0.3, T0, 20e-3,
+                                           5e-6, order=2, **common)
+    assert np.allclose(dIdV, 1.0) # order=2: no third-order terms at all
 
 
 def test_two_time_kondo_term_dmrg_requires_explicit_grid():

--- a/tests/test_kondo_spectrum_dmrgtwotime.py
+++ b/tests/test_kondo_spectrum_dmrgtwotime.py
@@ -3,20 +3,46 @@ construction of the third-order Kondo term
 (kondospectrumtk/dmrgtwotime.py), following Ternes, New J. Phys. 17
 063016 (2015), arXiv:1505.04430.
 
-IMPORTANT: dmrgtwotime.py was developed and written against the same
-verified DMRG API already used elsewhere in this codebase (toMPO,
-tdvp_step, MPS operator application/overlap -- see that module's own
-docstring for the exact API citations) but could NOT be executed or
-numerically validated in the environment it was developed in (no
-compiled C++ backend: cppext.available(3) is False there). This test is
-therefore the actual first real check of that code -- skipped entirely
-when no compiled itensor_version=3 backend is available, rather than
-silently claiming coverage that was never exercised.
+This module was written against the verified DMRG API (toMPO, tdvp_step,
+MPS operator application/overlap) but could not be exercised until a
+compiled itensor_version=3 backend was available. Once compiled, running
+this test surfaced three real, now-fixed bugs, none of which showed up
+in earlier ED-only testing:
 
-Compares against the fully-validated ED two-time reference
-(edtwotimeref.py, itself checked to ~0.01-1%% against the excited-state-
-sum third_order_kondo_dIdV) on the smallest nontrivial system (a single
-S=1/2 impurity), with deliberately modest, fast grid parameters.
+  - tdvp_step silently renormalizes its output to unit norm on every
+    single call. Sj|GS> (the state each two-time trajectory starts from)
+    is generally NOT unit-norm (Sj isn't norm-preserving), so letting
+    that renormalization stand silently discarded the true amplitude at
+    every step -- confirmed directly, it produced overlaps exactly a
+    factor of 2 too large end to end for a state of norm 0.5. Fixed in
+    _tdvp_trajectory by evolving a normalized copy and rescaling every
+    returned checkpoint by the true original norm.
+  - The forward/backward time-stepping loop shared one running `times`
+    list, so the "backward" branch kept counting down from the forward
+    branch's endpoint instead of from t=0 -- it never actually reached
+    negative times at all (e.g. n_half=3, dt=1000 produced
+    times=[0,0,1000,1000,2000,2000,3000], not the intended symmetric
+    [-3000,...,3000]). Fixed by walking forward and backward from t=0
+    independently and merging afterward.
+  - twotime.py's t2-integral used np.trapz per chunk, which is exactly 0
+    for a single-point chunk (no width to integrate over) -- and DMRG
+    chunks are always single-point (each t2 checkpoint is its own real
+    trajectory), so this silently zeroed the entire third-order Kondo
+    term end to end. Fixed in kondo_term_from_two_time with a uniform
+    Riemann-sum accumulation (trapezoidal endpoint correction only at
+    the true global first/last t2 points) that is well defined for any
+    chunk size.
+
+After these fixes, the two-time G(t2,tau) construction matches the ED
+reference (edtwotimeref.py) to ~1e-9-1e-10 pointwise, and the full
+eV-swept third-order Kondo term matches to ~1e-10 when compared against
+a grid-consistent ED reference (same t2/tau grid convention on both
+sides -- an earlier attempt using edtwotimeref.py's own
+width/npts-based grid builder directly showed an O(0.01-0.1) spurious
+mismatch purely from the two grid builders using different endpoint
+conventions at nominally "matching" resolution, not a physics bug; see
+the grid-consistent construction below, which sidesteps that by
+building both G(t2,tau) datasets on the literal same array).
 """
 import numpy as np
 import pytest
@@ -24,7 +50,8 @@ import pytest
 from dmrgpy import spinchain
 from dmrgpy import cppext
 from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum
-from dmrgpy.kondospectrumtk.edtwotimeref import two_time_kondo_term_ed
+from dmrgpy.kondospectrumtk.twotime import kondo_term_from_two_time
+from dmrgpy.kondospectrumtk.edtwotimeref import _levi_civita_coeff_G_chunk
 
 pytestmark = pytest.mark.skipif(
     not cppext.available(3),
@@ -35,29 +62,121 @@ G = 2.0
 MUB = 5.7883818066e-5 # eV/T
 
 
-def test_two_time_kondo_term_dmrg_matches_ed_reference():
-    from dmrgpy.kondospectrumtk.dmrgtwotime import two_time_kondo_term_dmrg
+def _build_chain(itensor_version):
+    """A 3-site (not 1-site: ITensor v3's two-site DMRG/TDVP can't handle
+    chains shorter than 3 sites -- confirmed directly, a 1-site chain hit
+    an internal C++ index error building the Hamiltonian MPO) S=1/2
+    chain: a Zeeman-split impurity at site 0 (the tip-coupled site) with
+    a weak Heisenberg coupling to two spectator sites, giving DMRG a
+    properly-sized system to operate on without changing the impurity
+    physics much."""
+    sc = spinchain.Spin_Chain(["1/2", "1/2", "1/2"], itensor_version=itensor_version)
+    h = G*MUB*10.0*sc.Sz[0]
+    for i in range(2):
+        h = h + 0.01*(sc.Sx[i]*sc.Sx[i+1] + sc.Sy[i]*sc.Sy[i+1] + sc.Sz[i]*sc.Sz[i+1])
+    sc.set_hamiltonian(h)
+    return sc
 
-    sc = spinchain.Spin_Chain(["1/2"], itensor_version=3)
-    sc.set_hamiltonian(G*MUB*10.0*sc.Sz[0])
-    sc.get_gs() # ensure the ground state (and self.e0) are computed
 
+def test_tdvp_trajectory_matches_ed_time_evolution():
+    """Direct check of the fixed _tdvp_trajectory: <ref|exp(-iHt)Sj|GS>
+    at every checkpoint of a forward+backward trajectory, for an
+    operator combination with a genuinely nonzero overlap (some
+    combinations vanish by a symmetry of this particular Hamiltonian --
+    confirmed directly; Sx-Sx does not)."""
+    from dmrgpy.kondospectrumtk.dmrgtwotime import _tdvp_trajectory
+
+    sc = _build_chain(3)
+    gs = sc.get_gs()
+    E0 = sc.gs_energy()
+    Hop = sc.toMPO(sc.hamiltonian - E0)
     ks = KondoSpectrum(sc, site=0, T=0.0)
 
-    Jrho_s, T0 = -0.05, 1.0
+    psi0 = sc.Sx[0]*gs
+    dt, n_half = 1000.0, 3
+    times, wfs = _tdvp_trajectory(sc, Hop, psi0, dt, n_half)
+    assert np.allclose(times, dt*np.arange(-n_half, n_half+1))
+
+    ref = sc.Sx[0]*gs
+    ref_vec = ks.Sx[:, 0]
+    v0 = ks.Sx[:, 0]
+    for t, wf in zip(times, wfs):
+        got = ref.dot(wf)
+        expected = np.conjugate(ref_vec).dot(v0*np.exp(-1j*ks.e*t))
+        assert got == pytest.approx(expected, abs=1e-6)
+
+
+def test_two_time_G_matches_ed_reference_pointwise():
+    """The full Levi-Civita-contracted G(t2,tau) construction
+    (_levi_civita_coeff_G_batches_dmrg), compared point by point against
+    the ED reference on a small grid."""
+    from dmrgpy.kondospectrumtk.dmrgtwotime import _levi_civita_coeff_G_batches_dmrg
+
+    sc = _build_chain(3)
+    sc.get_gs()
+    ks = KondoSpectrum(sc, site=0, T=0.0)
+
+    dt2, n_t2_half = 500.0, 2
+    dtau, n_tau_half = 300.0, 2
+    dmrg_rows = list(_levi_civita_coeff_G_batches_dmrg(
+            sc, 0, dt2, n_t2_half, dtau, n_tau_half))
+
+    e = ks.e
+    axes = ["Sx", "Sy", "Sz"]
+    Sops = {"Sx": ks.Sx, "Sy": ks.Sy, "Sz": ks.Sz}
+    eps3 = np.zeros((3, 3, 3))
+    for a, b, c in [(0, 1, 2), (1, 2, 0), (2, 0, 1)]: eps3[a, b, c] = 1.
+    for a, b, c in [(0, 2, 1), (2, 1, 0), (1, 0, 2)]: eps3[a, b, c] = -1.
+
+    def coeffG_ed(t2, tau):
+        total = 0j
+        for jj, j in enumerate(axes):
+            v_t2 = Sops[j][:, 0]*np.exp(-1j*e*t2)
+            for kk, k in enumerate(axes):
+                phi_tau = (Sops[k]@v_t2)*np.exp(-1j*e*tau)
+                for ll, l in enumerate(axes):
+                    c = eps3[jj, kk, ll]
+                    if c == 0.: continue
+                    total += c*np.conjugate(Sops[l][:, 0]).dot(phi_tau)
+        return total
+
+    maxdiff = 0.
+    for t2_chunk, tau_row, G_chunk in dmrg_rows:
+        t2 = t2_chunk[0]
+        for it, tau in enumerate(tau_row):
+            diff = abs(G_chunk[0, it] - coeffG_ed(t2, tau))
+            maxdiff = max(maxdiff, diff)
+    assert maxdiff < 1e-6
+
+
+def test_two_time_kondo_term_dmrg_matches_grid_consistent_ed_reference():
+    """End-to-end: the full eV-swept third-order Kondo term via
+    two_time_kondo_term_dmrg, against an ED reference built on the
+    literal same (t2,tau) grid (not edtwotimeref.py's own width/npts
+    grid builder, whose endpoint convention differs from
+    dmrgtwotime.py's at nominally "matching" resolution -- see this
+    module's docstring)."""
+    from dmrgpy.kondospectrumtk.dmrgtwotime import two_time_kondo_term_dmrg
+
+    sc = _build_chain(3)
+    sc.get_gs()
+    ks = KondoSpectrum(sc, site=0, T=0.0)
+
     omega0, Gamma0 = 2e-3, 5e-6
-    eVs = np.linspace(-2e-3, 2e-3, 9)
+    n_t2_half, n_tau_half = 10, 15
+    dt2 = 25./Gamma0/n_t2_half
+    dtau = (2*np.pi/2e-5)/n_tau_half
+    eVs = np.linspace(-2e-3, 2e-3, 5)
 
     dmrg_term = two_time_kondo_term_dmrg(
             sc, 0, eVs, omega0=omega0, Gamma0=Gamma0,
-            dt2=25./Gamma0/200, n_t2_half=200,
-            dtau=(2*np.pi/2e-5)/500, n_tau_half=500)
-    mine = 4*np.pi*T0**2*Jrho_s*dmrg_term
+            dt2=dt2, n_t2_half=n_t2_half, dtau=dtau, n_tau_half=n_tau_half)
 
-    ed_term = two_time_kondo_term_ed(
-            ks, eVs, omega0=omega0, Gamma0=Gamma0,
-            t2_width=25/Gamma0, t2_npts=40_000, t2_batch=10_000,
-            tau_width=2*np.pi/2e-5, tau_npts=1_000)
-    ref = 4*np.pi*T0**2*Jrho_s*ed_term
+    t2_grid = dt2*np.arange(-n_t2_half, n_t2_half+1)
+    tau_grid = dtau*np.arange(-n_tau_half, n_tau_half+1)
+    def batches():
+        yield t2_grid, _levi_civita_coeff_G_chunk(ks, t2_grid, tau_grid)
+    ed_term = kondo_term_from_two_time(t2_grid, tau_grid, batches(), eVs,
+                                        omega0, Gamma0)
 
-    assert np.max(np.abs(mine-ref)) < 0.1
+    assert np.max(np.abs(dmrg_term - ed_term)) < 1e-4

--- a/tests/test_kondo_spectrum_dmrgtwotime.py
+++ b/tests/test_kondo_spectrum_dmrgtwotime.py
@@ -1,0 +1,63 @@
+"""Coverage for the DMRG (itensor_version=3) two-time-correlator
+construction of the third-order Kondo term
+(kondospectrumtk/dmrgtwotime.py), following Ternes, New J. Phys. 17
+063016 (2015), arXiv:1505.04430.
+
+IMPORTANT: dmrgtwotime.py was developed and written against the same
+verified DMRG API already used elsewhere in this codebase (toMPO,
+tdvp_step, MPS operator application/overlap -- see that module's own
+docstring for the exact API citations) but could NOT be executed or
+numerically validated in the environment it was developed in (no
+compiled C++ backend: cppext.available(3) is False there). This test is
+therefore the actual first real check of that code -- skipped entirely
+when no compiled itensor_version=3 backend is available, rather than
+silently claiming coverage that was never exercised.
+
+Compares against the fully-validated ED two-time reference
+(edtwotimeref.py, itself checked to ~0.01-1%% against the excited-state-
+sum third_order_kondo_dIdV) on the smallest nontrivial system (a single
+S=1/2 impurity), with deliberately modest, fast grid parameters.
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import spinchain
+from dmrgpy import cppext
+from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum
+from dmrgpy.kondospectrumtk.edtwotimeref import two_time_kondo_term_ed
+
+pytestmark = pytest.mark.skipif(
+    not cppext.available(3),
+    reason="the DMRG two-time construction needs a compiled itensor_version=3 backend",
+)
+
+G = 2.0
+MUB = 5.7883818066e-5 # eV/T
+
+
+def test_two_time_kondo_term_dmrg_matches_ed_reference():
+    from dmrgpy.kondospectrumtk.dmrgtwotime import two_time_kondo_term_dmrg
+
+    sc = spinchain.Spin_Chain(["1/2"], itensor_version=3)
+    sc.set_hamiltonian(G*MUB*10.0*sc.Sz[0])
+    sc.get_gs() # ensure the ground state (and self.e0) are computed
+
+    ks = KondoSpectrum(sc, site=0, T=0.0)
+
+    Jrho_s, T0 = -0.05, 1.0
+    omega0, Gamma0 = 2e-3, 5e-6
+    eVs = np.linspace(-2e-3, 2e-3, 9)
+
+    dmrg_term = two_time_kondo_term_dmrg(
+            sc, 0, eVs, omega0=omega0, Gamma0=Gamma0,
+            dt2=25./Gamma0/200, n_t2_half=200,
+            dtau=(2*np.pi/2e-5)/500, n_tau_half=500)
+    mine = 4*np.pi*T0**2*Jrho_s*dmrg_term
+
+    ed_term = two_time_kondo_term_ed(
+            ks, eVs, omega0=omega0, Gamma0=Gamma0,
+            t2_width=25/Gamma0, t2_npts=40_000, t2_batch=10_000,
+            tau_width=2*np.pi/2e-5, tau_npts=1_000)
+    ref = 4*np.pi*T0**2*Jrho_s*ed_term
+
+    assert np.max(np.abs(mine-ref)) < 0.1

--- a/tests/test_kondo_spectrum_potentialdc.py
+++ b/tests/test_kondo_spectrum_potentialdc.py
@@ -1,0 +1,51 @@
+"""Coverage for the T=0 third-order potential-interference dI/dV computed
+via the dynamical correlator (kondospectrumtk/potentialdc.py) instead of
+the explicit excited-state sum (conductance.third_order_potential_dIdV),
+following Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430.
+
+At T=0 the excited-state sum collapses to a convolution of the T=0
+dynamical structure factor against the F0 kernel (see potentialdc.py's
+module docstring) -- this is the DMRG-side route to this term
+(mode="DMRG", submode="KPM"/"CVM") that needs no diagonalization beyond
+the ground state, filling the gap Spin_Chain.get_kondo_spectrum's
+mode="DMRG" path previously raised NotImplementedError for. Tested here
+with mode="ED", submode="ED" (exact except for the numerical `delta`
+broadening), since that is what's actually runnable without a compiled
+C++ DMRG backend -- but the function itself is backend-agnostic.
+"""
+import numpy as np
+
+from dmrgpy import spinchain
+from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum
+from dmrgpy.kondospectrumtk.conductance import third_order_potential_dIdV
+from dmrgpy.kondospectrumtk.potentialdc import third_order_potential_dIdV_dc
+
+G = 2.0
+MUB = 5.7883818066e-5 # eV/T
+
+
+def test_third_order_potential_dc_matches_excited_state_sum():
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*10.0*sc.Sz[0])
+    ks = KondoSpectrum(sc, site=0, T=0.0)
+
+    eVs = np.linspace(-1e-3, 2e-3, 21)
+    delta = 2e-6
+    es = np.linspace(-1e-3, 3e-3, 40_000) # must cover the Zeeman gap (~1.16e-3)
+    Jrho_s, U = 0.1, 0.3
+    mine = third_order_potential_dIdV_dc(sc, 0, eVs, Jrho_s, U, T0=1.0,
+                                          mode="ED", submode="ED",
+                                          delta=delta, es=es)
+    ref = third_order_potential_dIdV(ks, eVs, Jrho_s, U, T0=1.0)
+
+    assert np.max(np.abs(mine-ref)) < 0.01
+    assert np.max(np.abs(mine-ref)) < 0.01*np.max(np.abs(ref))
+
+
+def test_third_order_potential_dc_requires_es():
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*10.0*sc.Sz[0])
+    import pytest
+    with pytest.raises(ValueError):
+        third_order_potential_dIdV_dc(sc, 0, np.array([0.0]), 0.1, 0.3,
+                                       mode="ED", submode="ED")

--- a/tests/test_kondo_spectrum_secondorder_dc.py
+++ b/tests/test_kondo_spectrum_secondorder_dc.py
@@ -1,0 +1,55 @@
+"""Coverage for the T=0 second-order dI/dV computed via the dynamical
+correlator (kondospectrumtk/secondorder_dc.py) instead of the explicit
+excited-state sum (conductance.second_order_dIdV), following Ternes, New
+J. Phys. 17 063016 (2015), arXiv:1505.04430.
+
+At T=0 only the ground state is populated, so
+sum_f |<f|S_alpha|GS>|^2 Theta0(eV-eps_f0) is exactly a Theta0-weighted
+cumulative integral of the T=0 dynamical structure factor -- this exists
+as the natural DMRG-side route to the second-order term (via
+mode="DMRG", submode="KPM"/"CVM") that needs no diagonalization beyond
+the ground state, unlike the excited-state-sum route. Tested here with
+mode="ED", submode="ED" (exact except for the numerical `delta`
+broadening), since that is what's actually runnable without a compiled
+C++ DMRG backend -- but the function itself is backend-agnostic (any
+mode/submode chain.get_dynamical_correlator accepts).
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import spinchain
+from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum
+from dmrgpy.kondospectrumtk.conductance import second_order_dIdV
+from dmrgpy.kondospectrumtk.secondorder_dc import second_order_dIdV_dc
+
+G = 2.0
+MUB = 5.7883818066e-5 # eV/T
+
+
+def test_second_order_dc_matches_excited_state_sum():
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*10.0*sc.Sz[0])
+    ks = KondoSpectrum(sc, site=0, T=0.0)
+
+    eVs = np.linspace(-1e-3, 2e-3, 21)
+    delta = 2e-6
+    es = np.linspace(-1e-3, 3e-3, 40_000) # must cover the Zeeman gap (~1.16e-3)
+    mine = second_order_dIdV_dc(sc, 0, eVs, T0=1.0, U=0.2, mode="ED",
+                                 submode="ED", delta=delta, es=es)
+    ref = second_order_dIdV(ks, eVs, T0=1.0, U=0.2)
+
+    assert np.max(np.abs(mine-ref)) < 0.05
+    assert np.max(np.abs(mine-ref)) < 0.01*np.max(np.abs(ref))
+
+
+def test_second_order_dc_zero_at_U0_below_threshold():
+    """Sanity check independent of the excited-state-sum reference: well
+    below the Zeeman threshold and with no potential scattering, only the
+    elastic channel is open, giving the same pi/2 plateau derived by hand
+    in test_kondo_spectrum.py's analogous finite-T test."""
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*10.0*sc.Sz[0])
+    es = np.linspace(-1e-3, 3e-3, 40_000) # must cover the Zeeman gap (~1.16e-3)
+    val = second_order_dIdV_dc(sc, 0, np.array([0.0]), T0=1.0, U=0.0,
+                                mode="ED", submode="ED", delta=2e-6, es=es)[0]
+    assert val == pytest.approx(np.pi/2, abs=0.03)

--- a/tests/test_kondo_spectrum_twotime.py
+++ b/tests/test_kondo_spectrum_twotime.py
@@ -1,0 +1,96 @@
+"""Coverage for the T=0 two-time-correlator construction of the
+third-order Kondo term (kondospectrumtk/twotime.py, edtwotimeref.py),
+following Ternes, New J. Phys. 17 063016 (2015), arXiv:1505.04430.
+
+This is a *different* way of computing the same third-order Kondo term
+already covered (and validated against Fig. 3a/b) by
+conductance.third_order_kondo_dIdV, which sums explicitly over
+eigenstates. The two-time construction instead builds a Heisenberg
+three-point function G(t2,tau)=<GS|Sl(t2+tau)Sk(t2)Sj(0)|GS> via real-time
+evolution and extracts the same physical quantity through two closed-form
+time-domain kernels (a Hilbert-transform-based Theta0 filter and a direct
+K_W convolution) -- see twotime.py's module docstring for the full
+derivation. It exists because, unlike the eigenstate-sum approach, it
+generalizes to DMRG without ever diagonalizing/enumerating excited
+states (the actual DMRG side reuses the same kernel machinery on top of
+real TDVP time evolution instead of ED's eigenbasis-exact evolution).
+
+The ED-based G(t2,tau) here (edtwotimeref.py) is deliberately built via
+exact eigenbasis time evolution rather than any excited-state
+diagonalization shortcut, so this test is a genuine end-to-end check of
+the two-time/kernel pipeline itself, not just of ED's (already validated
+elsewhere) ability to compute transition matrix elements directly.
+
+These tests use deliberately modest grid resolution (fast: a few to ~20s
+per test) and correspondingly loose tolerances -- finer grids converge
+tighter (verified interactively during development: ~0.01% agreement at
+higher resolution) but are too slow for routine test runs. See PR
+history / kondospectrumtk module docstrings for the resolution/accuracy
+tradeoffs (K_W needs t2 spacing finer than 1/omega0 and a range wider
+than several/Gamma0; the Hilbert-transform-based Theta0 filter converges
+much faster than that and is not the bottleneck).
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import spinchain
+from dmrgpy.kondospectrumtk.edkondo import KondoSpectrum
+from dmrgpy.kondospectrumtk.conductance import third_order_kondo_dIdV
+from dmrgpy.kondospectrumtk.edtwotimeref import two_time_kondo_term_ed
+from dmrgpy.kondospectrumtk.twotime import theta0_filter, K_W
+from dmrgpy.kondospectrumtk.stepfunctions import Theta0, F0
+
+G = 2.0
+MUB = 5.7883818066e-5 # eV/T
+
+
+def test_theta0_filter_reproduces_theta0_on_pure_exponentials():
+    """Unit check of the Hilbert-transform-based Theta0 filter alone:
+    for a pure exponential exp(-i*eps*tau) (a single "eigenstate" term),
+    the filter should reproduce Theta0(eV-eps) essentially exactly (this
+    is the piece that converges to machine precision even on coarse
+    grids -- confirmed during development; the K_W piece is the one that
+    needs a fine/wide grid)."""
+    tau_grid = np.linspace(-2*np.pi/1e-5, 2*np.pi/1e-5, 4000, endpoint=False)
+    eps = 3e-4
+    eV = 5e-4
+    signal = np.exp(-1j*eps*tau_grid)
+    val = theta0_filter(tau_grid, signal, eV)
+    assert val == pytest.approx(Theta0(np.array([eV-eps]))[0], abs=1e-6)
+
+
+def test_K_W_matches_F0_pm_via_direct_integration():
+    """Unit check of the K_W kernel alone: integrating K_W(t2;eV) against
+    exp(-i*wm*t2) over t2 should reproduce F0(eV-wm)+F0(eV+wm)."""
+    from scipy import integrate
+    omega0, Gamma0 = 0.2, 5e-6
+    eV, wm = 3e-4, 1.6e-4
+    expected = F0(np.array([eV-wm]), omega0, Gamma0)[0] + F0(np.array([eV+wm]), omega0, Gamma0)[0]
+    T = 30/Gamma0
+    re, _ = integrate.quad(lambda t2: K_W(np.array([t2]), eV, omega0, Gamma0)[0]*np.cos(wm*t2),
+                            -T, T, limit=2000, points=[0.])
+    assert re == pytest.approx(expected, rel=2e-3)
+
+
+def test_two_time_kondo_term_matches_eigenstate_sum():
+    """End-to-end check: the two-time-correlator construction (real-time
+    evolution + kernel extraction) must agree with the already-validated
+    excited-state-sum third_order_kondo_dIdV for the same system, at
+    T=0. Uses a small S=1/2 system and modest grid resolution (see module
+    docstring) -- loose (but not vacuous) tolerance."""
+    sc = spinchain.Spin_Chain(["1/2"])
+    sc.set_hamiltonian(G*MUB*10.0*sc.Sz[0])
+    ks = KondoSpectrum(sc, site=0, T=0.0)
+
+    Jrho_s, T0 = -0.05, 1.0
+    omega0, Gamma0 = 2e-3, 5e-6
+    eVs = np.linspace(-2e-3, 2e-3, 9)
+
+    mine = 4*np.pi*T0**2*Jrho_s*two_time_kondo_term_ed(
+        ks, eVs, omega0=omega0, Gamma0=Gamma0,
+        t2_width=25/Gamma0, t2_npts=40_000, t2_batch=10_000,
+        tau_width=2*np.pi/2e-5, tau_npts=1_000)
+    ref = third_order_kondo_dIdV(ks, eVs, Jrho_s, T0=T0, omega0=omega0, Gamma0=Gamma0)
+
+    assert np.max(np.abs(mine-ref)) < 0.02
+    assert np.max(np.abs(mine-ref)) < 0.05*np.max(np.abs(ref)) # also a relative check


### PR DESCRIPTION
## Summary

**ED path (finite T, any temperature):**
- Implements `Spin_Chain.get_kondo_spectrum`, computing the STM tunneling `dI/dV(eV)` spectrum via full-ED Fermi's-golden-rule perturbation theory to second and third order in the tunneling amplitude, following Ternes, *New J. Phys.* **17**, 063016 (2015), [arXiv:1505.04430](https://arxiv.org/abs/1505.04430).
- Second order: standard spin-flip/potential-scattering conductance (bidirectional, exact).
- Third order: a Kondo term (Levi-Civita triple product summed over *all* eigenstates as virtual intermediate states) plus a potential-scattering interference term producing a bias-asymmetric lineshape.
- Two of the paper's own closed-form equations for supporting numerical functions (`Theta(x)`, `F(eps,T)`) don't reproduce the physics the paper itself describes; `kondospectrumtk/stepfunctions.py` re-derives both from the paper's own defining integrals, verified against digitized values from the paper's own figures.

**T=0 / DMRG path (`mode="DMRG"`, `itensor_version=3`):** at T=0 only the ground state is populated, simplifying both terms enough to avoid diagonalizing beyond the ground state:
- Second order via the dynamical correlator (`secondorder_dc.py`): a `Theta0`-weighted cumulative integral of the ordinary T=0 dynamical structure factor, reusing `get_dynamical_correlator` (KPM/CVM) as-is.
- Third order via a **two-time correlator** (`twotime.py`, `edtwotimeref.py`, `dmrgtwotime.py`): `G(t2,tau)=<GS|Sl(t2+tau)Sk(t2)Sj(0)|GS>` built via real TDVP time evolution ("checkpoint-and-branch"), extracted via closed-form time-domain kernels (an FFT-based Hilbert transform for the `Theta0` piece — a naive pointwise-frequency-grid approach was tried first and did not converge robustly) rather than frequency-grid evaluation.

**Now genuinely validated against a compiled ITensor v3 backend** (compiled and tested during this session, not just written-against-the-API): found and fixed three real bugs that no amount of ED-only testing could have caught —
1. `tdvp_step` silently renormalizes every step to unit norm, discarding `Sj|GS>`'s true (non-unit) amplitude unless corrected for explicitly (was producing overlaps exactly 2x too large).
2. A forward/backward time-stepping bug meant "backward" trajectory checkpoints never actually reached negative times.
3. A per-chunk `np.trapz` integral is exactly 0 for the single-`t2`-point chunks real-time evolution necessarily produces, silently zeroing the entire third-order term.

After these fixes, `G(t2,tau)` matches the ED reference to `~1e-9`–`1e-10` pointwise, and the full eV-swept third-order Kondo term matches a grid-consistent ED reference to `~1e-10`. The second-order (KPM) DMRG path was also spot-checked, and the full `get_kondo_spectrum(mode="DMRG")` integration runs end-to-end.

Scope limitations (documented in `docs/user_guide.md` §17): single tip-coupled chain site; third-order terms are `∂I^{t→s}/∂V` only; the potential-interference term's general-spin closed form is an extrapolation from the paper's worked `S=1/2` example (ED-only, not implemented for DMRG); DMRG mode requires `T=0` and chains with ≥3 sites (ITensor v3 limitation); the potential-interference term is now also implemented for DMRG (see below).

**Second code-review round, fixed:**
- `two_time_kondo_term_dmrg`'s `dt2`/`n_t2_half`/`dtau`/`n_tau_half` had a
  small, fast default that was wildly under-resolved for the also-default
  `omega0`/`Gamma0`, silently returning a finite-but-wrong result instead
  of erroring. Made all four mandatory (raises `ValueError` if omitted),
  matching the precedent already set by `es` on the second-order path.
- The `(j,k)` loop building `G(t2,tau)` always ran the expensive `tau`
  TDVP trajectory even when `j==k`, where the Levi-Civita coefficient is
  provably zero for every `l` — 3 of 9 branches wasted. Now skipped
  before the trajectory runs, not just in the already-guarded sum after.
- Minor: aliased two textually-identical `eps_if`/`eps_im` computations
  in `third_order_kondo_dIdV` into one line.

**Third round: potential-interference term now implemented for DMRG.**
Filled the one remaining documented gap in the `mode="DMRG"` path:
`third_order_potential_dIdV` (`U!=0`, `order=3`) previously raised
`NotImplementedError` there. At `T=0` its excited-state sum collapses to
a convolution of the same `T=0` dynamical structure factor against the
`F0` kernel (instead of `Theta0`'s cumulative-sum weighting used by the
second-order term), so it reuses `get_dynamical_correlator` the same way
`secondorder_dc.py` does for the second-order term — no excited-state
enumeration, no new DMRG-side primitive (`kondospectrumtk/potentialdc.py`).
Verified (`mode="ED"`, `submode="ED"`) against the excited-state-sum
`conductance.third_order_potential_dIdV` to ~0.07% relative error.
`Spin_Chain._get_kondo_spectrum_dmrg` now also forwards arbitrary
dynamical-correlator kwargs (e.g. KPM's `n` moment count) through both
DC calls — needed after a real end-to-end `mode="DMRG"`/`submode="KPM"`
run turned out to cost ~40s per correlator call even with very few
moments, which is what pushed the wiring test for the combined
three-term sum to mock out the underlying (expensive) calls rather than
run them for real.

## Test plan
- [x] `pytest tests/test_kondo_spectrum*.py` after adding the potential-interference DMRG term — 25 passed; `pytest tests` — 111 passed, 8 skipped, same 1 pre-existing unrelated failure
- [x] `pytest tests/test_kondo_spectrum*.py` after the second code-review round — 22 passed (new test locks in the `ValueError` fix); `pytest tests` — 108 passed, 8 skipped, same 1 pre-existing unrelated failure
- [x] `pytest tests/test_kondo_spectrum*.py` — 21 tests, all pass (0 skipped, now that `itensor_version=3` is compiled)
- [x] `pytest tests` — 86 passed, 8 skipped, 1 failed; the 1 failure (`test_tdz_dynamical_correlator_peak_matches_exact_gap[2]`) predates this work and is unrelated — no regressions, compiling the backend newly unlocked coverage that was skipped before
- [x] `examples/kondo_spectrum_VS_paper/main.py` — extended with T=0 and two-time-vs-excited-state-sum checks, runs clean
- [x] `docs/user_guide.tex` and `docs/documentation.tex` both compile cleanly with `pdflatex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YBjtW6Ce7pvemxo28BCQR

