### PR TITLE
Fix flaky mixed-chain DMRG-vs-ED test by increasing sweeps

### DIFF
--- a/tests/test_mixed_chain.py
+++ b/tests/test_mixed_chain.py
@@ -70,7 +70,10 @@ def test_pure_fermion_degenerate_case_matches_spinful_fermionic_chain_ed():
 
     mc = mixedchain.Mixed_Spin_Fermion_Chain(["F"]*n, itensor_version=3)
     mc.maxm = 60
-    mc.nsweeps = 20
+    mc.nsweeps = 40 # 20 was occasionally missing DMRG_TOL by a few 1e-5
+                     # (run-to-run DMRG convergence noise, confirmed
+                     # directly: the same case passes cleanly in
+                     # isolation) -- doubled for a wider convergence margin
     h_mc = 0
     for i in range(n-1):
         t = 0.6 + 0.3*i


### PR DESCRIPTION
## Summary
- `test_mixed_chain.py::test_pure_fermion_degenerate_case_matches_spinful_fermionic_chain_ed` occasionally missed its `abs=1e-6` DMRG-vs-ED energy tolerance by a few `1e-5` -- confirmed to be run-to-run DMRG convergence noise (the same case passes cleanly in isolation, and 5/5 repeated runs after this fix).
- Doubled `nsweeps` from 20 to 40 for a wider convergence margin. Confirmed 5/5 passes with no measurable slowdown (~0.5s, tiny 3-site system).

## Test plan
- [x] `pytest tests/test_mixed_chain.py::test_pure_fermion_degenerate_case_matches_spinful_fermionic_chain_ed` x5 -- all pass
- [x] `pytest tests/test_mixed_chain.py` -- 10 passed
- [x] `pytest tests` -- 111 passed, 8 skipped, 1 pre-existing unrelated failure (`test_tdz_dynamical_correlator_peak_matches_exact_gap[2]`, needs a compiled `itensor_version=2` backend not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YBjtW6Ce7pvemxo28BCQR