### PR TITLE
Add single-sweep four-point correlator for v3 (ITensorCorrelators.jl-style)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -732,6 +732,51 @@ own `AutoMPO` acting on flavor-resolved operator names, since two
 flavors share one physical site there — a different threading problem
 than this sweep's per-flat-mode gap rule solves, not attempted here.
 
+The same algorithm was then ported to `pyitensor/chain.py::
+Chain.four_correlation_tensor_sweep` for `itensor_version="python"` —
+close to a mechanical transcription of the C++ version, including
+`_four_pt_perm_table()` (the same sign/index-role table, generated with
+`itertools.permutations` instead of hand-rolled `next_permutation`), with
+one adaptation: this engine never primes `Link`-tagged indices to keep a
+self-overlap's bra and ket from colliding the way `chain_session.h`'s
+`dag(prime(psi.A(site),TagSet("Link")))` does (see `mpsalgebra.py`'s
+`inner()`) — instead the bra side is built once per outer site `a` via
+`mpsalgebra.py`'s own `_fresh_link_copy(psi)` (freshly relabeled `Link`
+indices, physical indices untouched), and the running environment
+carries one leg from the *ket*'s own unrelabeled links and one from this
+fresh bra copy's links; the boundary `delta` "shortcut" tensors are built
+from `commonIndex` on each side (ket vs.\ fresh-bra) rather than from a
+single primed/unprimed pair. Matched the C++ version and ED to machine
+precision immediately (0 mismatches out of every distinct- and
+repeated-index tuple tried, `n=5`), confirming the ported sign table is
+correct and the fresh-link-copy substitution is a faithful translation,
+not just an analogous-looking one. Real but smaller speedup than the C++
+version (~1.2–1.4x at `n=5..7`, vs.\ ~1.4–4.4x at `n=6..20` for
+`itensor_version=3`): pure-Python loop/function-call overhead is a
+bigger fraction of the per-step cost here than the underlying NumPy
+linear algebra, so there is less for environment reuse to save on
+relative to the total.
+
+`get_four_correlation_tensor(ctmode=...)`'s default changed from a fixed
+`ctmode="explicit"` to `ctmode=None`, resolved per-wavefunction by the
+new `_four_correlation_tensor_default_ctmode()`
+(`entropytk/correlationentropy.py`): `"sweep"` whenever it applies
+(`itensor_version` in `(3,"python")`, non-native-spinful), else
+`"full"` whenever it applies (`itensor_version` in `(2,3,"python")`, or
+native-spinful under `itensor_version=3`), else `"explicit"`. An
+explicit `ctmode=` argument is unaffected — it is still a hard request
+that raises if unavailable, not a hint the resolver can override. ED-
+backed wavefunctions (`edtk/edchain.py`, `pyfermion/mbfermion.py`) never
+reach the resolver at all: they hardcode `ctmode="explicit"` themselves,
+as before. Verified the resolver picks the right mode across every
+backend actually reachable from the public API (`itensor_version` `2`
+falling back to ED when the C++ extension is not compiled, `3`,
+`"python"`, and `Spinful_Fermionic_Chain_Native`), and made it use
+`getattr()`/`hasattr()` defensively rather than assume `wf.MBO` always
+carries `.itensor_version`/`._session` — cheap insurance since the
+function is easy to reach with an unusual `wf.MBO` from outside the two
+call sites it is actually designed for.
+
 Investigated whether `get_correlation_matrix`'s default `dmmode="fast"`
 (`entropytk/correlationentropy.py::correlation_matrix_fast`, `n` MPO
 applications total rather than `explicit`'s `n(n+1)/2` two-operator

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -692,6 +692,46 @@ two-site search, so it never pays the two-site combined-local-
 dimension penalty documented in `Spinful_Fermionic_Chain_Native`'s own
 class docstring.
 
+A third implementation, `ctmode="sweep"` (`Chain::four_correlation_tensor_sweep`,
+`mpscpp3/chain_session.h`/`bindings.cc`, plain non-native-spinful sites
+only), replaces `ctmode="full"`'s `O(N^4)` *independent* AutoMPO builds
+with a single-sweep, environment-reuse algorithm following the idea of
+[ITensorCorrelators.jl](https://github.com/ITensor/ITensorCorrelators.jl).
+Only the `N(N-1)(N-2)(N-3)` pairwise-distinct-index entries go through
+the fast sweep (nested loops over four strictly increasing sites
+`a<b<c<d`, each level extending a running left environment by exactly
+one site rather than rebuilding it, with both `Cdag`/`C` tried at each
+of the four operator sites); the remaining, subdominant `O(N^3)`
+repeated-index entries fall back to the same per-tuple AutoMPO method
+`ctmode="full"` uses, since those need same-site multi-operator products
+(e.g. `Cdag_i C_i = N_i`) the sweep isn't built to produce. Reordering
+the four fermionic operators from the abstract `(i,j,k,l)` order into
+physical site order picks up the standard fermion-anticommutation sign
+(parity of the reordering permutation) *plus* one further correction:
+of the six possible `Cdag`/`C` type patterns across the four sorted
+sites, the two that strictly alternate (`Cdag,C,Cdag,C` or
+`C,Cdag,C,Cdag`) need no extra sign, but the other four (which have at
+least one pair of *adjacent same-type* operators) need one more flip on
+top of the plain permutation parity — this was found empirically (every
+entry with such a pattern disagreed with `ctmode="full"` by exactly this
+sign, for every site quadruple and chain length tried, before the
+correction was added) rather than purely re-derived by hand from Jordan-
+Wigner strings, though it traces to the same extra `-1` that
+`jordanwigner.py`'s `CC()`/`CdagCdag()` carry but `CdagC()`/`CCdag()`
+don't (reordering two *same-type* operators into JW-canonical form costs
+one more local `F`/`Adag` or `F`/`A` anticommutation than a mixed pair
+does). Validated to machine precision against `ctmode="full"` and to ED
+solver tolerance across `n=4..8` (every index tuple, not just a sample)
+and spot-checked at `n=16,20`; measurably faster than `ctmode="full"` at
+every size tried, by a margin growing with `n` (~1.4x at `n=6` up to
+~4.4x at `n=20` for a nearest-neighbor Hubbard chain at fixed `maxm=60`
+— see `examples/staticcorrelators/four_correlation_tensor_sweep_VS_full`).
+Not ported to `Spinful_Fermionic_Chain_Native`: that class's
+`ctmode="full"` gets its Jordan-Wigner threading for free from ITensor's
+own `AutoMPO` acting on flavor-resolved operator names, since two
+flavors share one physical site there — a different threading problem
+than this sweep's per-flat-mode gap rule solves, not attempted here.
+
 Investigated whether `get_correlation_matrix`'s default `dmmode="fast"`
 (`entropytk/correlationentropy.py::correlation_matrix_fast`, `n` MPO
 applications total rather than `explicit`'s `n(n+1)/2` two-operator

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -722,10 +722,46 @@ don't (reordering two *same-type* operators into JW-canonical form costs
 one more local `F`/`Adag` or `F`/`A` anticommutation than a mixed pair
 does). Validated to machine precision against `ctmode="full"` and to ED
 solver tolerance across `n=4..8` (every index tuple, not just a sample)
-and spot-checked at `n=16,20`; measurably faster than `ctmode="full"` at
+and spot-checked at `n=16`; measurably faster than `ctmode="full"` at
 every size tried, by a margin growing with `n` (~1.4x at `n=6` up to
-~4.4x at `n=20` for a nearest-neighbor Hubbard chain at fixed `maxm=60`
-— see `examples/staticcorrelators/four_correlation_tensor_sweep_VS_full`).
+over 2.5x at `n=16` for a nearest-neighbor Hubbard chain at fixed
+`maxm=60` — absolute numbers are noisy across runs on a shared machine
+(measured 2.8x-3.4x at `n=16` across separate runs), but the *trend*,
+measured within any single run, consistently holds — see
+`examples/staticcorrelators/four_correlation_tensor_sweep_VS_full`,
+whose Part 3 loop actually runs and reproduces this trend, rather than
+reporting only development-time measurements that would not be
+reproducible from the checked-in tree; `n=20` was also checked
+informally during development, ~4.4x, but is not part of the shipped
+example since a single `n=20` `ctmode="full"` call alone takes ~5
+minutes). `accelerate` (default `True`) only gates the subdominant
+repeated-index fallback here — unlike `ctmode="full"`'s own
+`accelerate`, which skips ~half of the *dominant* per-tuple AutoMPO
+builds via conjugate-pair symmetry, this method's dominant pairwise-
+distinct sweep pays its cost (the shared environment sweep, and six
+cheap per-pattern `eltC()` evaluations) once regardless of how many
+output entries a given leaf value gets scattered into, so there's no
+equivalent saving to skip there — confirmed directly (`accelerate=True`
+vs.\ `False` gives identical wall-clock on the dominant part).
+
+`four_correlation_tensor_sweep()` originally renormalized its internal
+copy of `wf` before the fast-sweep computation (`psi /=
+innerC(psi,psi).real()`, mirroring `reduced_dm()`'s own convention), but
+the repeated-index fallback loop calls `innerC(wf,...)` on the raw,
+un-renormalized `wf` — a real bug, caught by code review, not by any of
+the (unit-norm-only) validation above: for any non-unit-norm input MPS
+(e.g. `wf*c` for a scalar `c`, as opposed to an already-converged DMRG
+ground state, which is unit-norm to solver precision and so didn't
+expose it), the two halves of one output tensor came back scaled
+inconsistently with each other *and* with `ctmode="full"`/`"explicit"`.
+Fixed by dropping the renormalization entirely, matching
+`four_correlation_tensor()`'s own convention (no enforced normalization,
+caller's responsibility) exactly — confirmed with a direct repro
+(`wf*3.0`: `ctmode="full"` scales every entry by $3^2=9$ as expected;
+`ctmode="sweep"` did too only on the repeated-index entries, and by
+$1/9$ on the pairwise-distinct ones, before the fix). The same bug,
+same fix, applies to the `pyitensor/chain.py` port below.
+
 Not ported to `Spinful_Fermionic_Chain_Native`: that class's
 `ctmode="full"` gets its Jordan-Wigner threading for free from ITensor's
 own `AutoMPO` acting on flavor-resolved operator names, since two

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -902,6 +902,59 @@ since two flavors share one physical site there --- a different
 threading problem than this sweep's per-flat-mode gap rule solves, not
 attempted here.
 
+The same algorithm was then ported to \texttt{pyitensor/chain.py}'s
+\texttt{Chain.four\_correlation\_tensor\_sweep} for
+\texttt{itensor\_version="python"} --- close to a mechanical
+transcription of the C++ version, including
+\texttt{\_four\_pt\_perm\_table()} (the same sign/index-role table,
+generated with \texttt{itertools.permutations} instead of a hand-rolled
+\texttt{next\_permutation}), with one adaptation: this engine never
+primes \texttt{Link}-tagged indices to keep a self-overlap's bra and ket
+from colliding the way \texttt{chain\_session.h}'s
+\texttt{dag(prime(psi.A(site), TagSet("Link")))} does (see
+\texttt{mpsalgebra.py}'s \texttt{inner()}) --- instead the bra side is
+built once per outer site $a$ via \texttt{mpsalgebra.py}'s own
+\texttt{\_fresh\_link\_copy(psi)} (freshly relabeled \texttt{Link}
+indices, physical indices untouched), and the running environment
+carries one leg from the \emph{ket}'s own unrelabeled links and one from
+this fresh bra copy's links; the boundary \texttt{delta} ``shortcut''
+tensors are built from \texttt{commonIndex} on each side (ket vs.\
+fresh-bra) rather than from a single primed/unprimed pair. Matched the
+C++ version and ED to machine precision immediately (0 mismatches out of
+every distinct- and repeated-index tuple tried, $n=5$), confirming the
+ported sign table is correct and the fresh-link-copy substitution is a
+faithful translation, not just an analogous-looking one. Real but
+smaller speedup than the C++ version ($\sim1.2$--$1.4\times$ at
+$n=5..7$, vs.\ $\sim1.4$--$4.4\times$ at $n=6..20$ for
+\texttt{itensor\_version=3}): pure-Python loop/function-call overhead is
+a bigger fraction of the per-step cost here than the underlying NumPy
+linear algebra, so there is less for environment reuse to save on
+relative to the total.
+
+\texttt{get\_four\_correlation\_tensor(ctmode=...)}'s default changed
+from a fixed \texttt{ctmode="explicit"} to \texttt{ctmode=None}, resolved
+per-wavefunction by the new
+\texttt{\_four\_correlation\_tensor\_default\_ctmode()}
+(\texttt{entropytk/correlationentropy.py}): \texttt{"sweep"} whenever it
+applies (\texttt{itensor\_version} in \texttt{(3,"python")},
+non-native-spinful), else \texttt{"full"} whenever it applies
+(\texttt{itensor\_version} in \texttt{(2,3,"python")}, or native-spinful
+under \texttt{itensor\_version=3}), else \texttt{"explicit"}. An explicit
+\texttt{ctmode=} argument is unaffected --- it is still a hard request
+that raises if unavailable, not a hint the resolver can override.
+ED-backed wavefunctions (\texttt{edtk/edchain.py},
+\texttt{pyfermion/mbfermion.py}) never reach the resolver at all: they
+hardcode \texttt{ctmode="explicit"} themselves, as before. Verified the
+resolver picks the right mode across every backend actually reachable
+from the public API (\texttt{itensor\_version} \texttt{2} falling back
+to ED when the C++ extension is not compiled, \texttt{3},
+\texttt{"python"}, and \texttt{Spinful\_Fermionic\_Chain\_Native}), and
+made it use \texttt{getattr()}/\texttt{hasattr()} defensively rather
+than assume \texttt{wf.MBO} always carries
+\texttt{.itensor\_version}/\texttt{.\_session} --- cheap insurance since
+the function is easy to reach with an unusual \texttt{wf.MBO} from
+outside the two call sites it is actually designed for.
+
 Investigated whether \texttt{get\_correlation\_matrix}'s default
 \texttt{dmmode="fast"}
 (\texttt{entropytk/correlationentropy.py::correlation\_matrix\_fast}, $n$

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -890,11 +890,50 @@ operators into JW-canonical form costs one more local $F/A^\dagger$ or
 $F/A$ anticommutation than a mixed pair does). Validated to machine
 precision against \texttt{ctmode="full"} and to ED solver tolerance
 across $n=4..8$ (every index tuple, not just a sample) and spot-checked
-at $n=16,20$; measurably faster than \texttt{ctmode="full"} at every
-size tried, by a margin growing with $n$ ($\sim1.4\times$ at $n=6$ up to
-$\sim4.4\times$ at $n=20$ for a nearest-neighbor Hubbard chain at fixed
-\texttt{maxm=60} --- see
-\texttt{examples/staticcorrelators/four\_correlation\_tensor\_sweep\_VS\_full}).
+at $n=16$; measurably faster than \texttt{ctmode="full"} at every size
+tried, by a margin growing with $n$ ($\sim1.4\times$ at $n=6$ up to over
+$2.5\times$ at $n=16$ for a nearest-neighbor Hubbard chain at fixed
+\texttt{maxm=60} --- absolute numbers are noisy across runs on a shared
+machine (measured $2.8$--$3.4\times$ at $n=16$ across separate runs),
+but the \emph{trend}, measured within any single run, consistently
+holds --- see
+\texttt{examples/staticcorrelators/four\_correlation\_tensor\_sweep\_VS\_full},
+whose Part 3 loop actually runs and reproduces this trend, rather than
+reporting only development-time measurements that would not be
+reproducible from the checked-in tree; $n=20$ was also checked
+informally during development, $\sim4.4\times$, but is not part of the
+shipped example since a single $n=20$ \texttt{ctmode="full"} call alone
+takes $\sim5$ minutes). \texttt{accelerate} (default \texttt{True}) only
+gates the subdominant repeated-index fallback here --- unlike
+\texttt{ctmode="full"}'s own \texttt{accelerate}, which skips $\sim$half
+of the \emph{dominant} per-tuple AutoMPO builds via conjugate-pair
+symmetry, this method's dominant pairwise-distinct sweep pays its cost
+(the shared environment sweep, and six cheap per-pattern
+\texttt{eltC()} evaluations) once regardless of how many output entries
+a given leaf value gets scattered into, so there is no equivalent saving
+to skip there --- confirmed directly (\texttt{accelerate=True} vs.\
+\texttt{False} gives identical wall-clock on the dominant part).
+
+\texttt{four\_correlation\_tensor\_sweep()} originally renormalized its
+internal copy of \texttt{wf} before the fast-sweep computation
+(\texttt{psi /= innerC(psi,psi).real()}, mirroring \texttt{reduced\_dm()}'s
+own convention), but the repeated-index fallback loop calls
+\texttt{innerC(wf,...)} on the raw, un-renormalized \texttt{wf} --- a
+real bug, caught by code review, not by any of the (unit-norm-only)
+validation above: for any non-unit-norm input MPS (e.g.\ \texttt{wf*c}
+for a scalar $c$, as opposed to an already-converged DMRG ground state,
+which is unit-norm to solver precision and so did not expose it), the
+two halves of one output tensor came back scaled inconsistently with
+each other \emph{and} with \texttt{ctmode="full"}/\texttt{"explicit"}.
+Fixed by dropping the renormalization entirely, matching
+\texttt{four\_correlation\_tensor()}'s own convention (no enforced
+normalization, caller's responsibility) exactly --- confirmed with a
+direct repro (\texttt{wf*3.0}: \texttt{ctmode="full"} scales every entry
+by $3^2=9$ as expected; \texttt{ctmode="sweep"} did too only on the
+repeated-index entries, and by $1/9$ on the pairwise-distinct ones,
+before the fix). The same bug, same fix, applies to the
+\texttt{pyitensor/chain.py} port below.
+
 Not ported to \texttt{Spinful\_Fermionic\_Chain\_Native}: that class's
 \texttt{ctmode="full"} gets its Jordan-Wigner threading for free from
 ITensor's own \texttt{AutoMPO} acting on flavor-resolved operator names,

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -855,6 +855,53 @@ two-site search, so it never pays the two-site combined-local-
 dimension penalty documented in
 \texttt{Spinful\_Fermionic\_Chain\_Native}'s own class docstring.
 
+A third implementation, \texttt{ctmode="sweep"}
+(\texttt{Chain::four\_correlation\_tensor\_sweep},
+\texttt{mpscpp3/chain\_session.h}/\texttt{bindings.cc}, plain
+non-native-spinful sites only), replaces \texttt{ctmode="full"}'s
+$O(N^4)$ \emph{independent} AutoMPO builds with a single-sweep,
+environment-reuse algorithm following the idea of
+\href{https://github.com/ITensor/ITensorCorrelators.jl}{ITensorCorrelators.jl}.
+Only the $N(N-1)(N-2)(N-3)$ pairwise-distinct-index entries go through
+the fast sweep (nested loops over four strictly increasing sites
+$a<b<c<d$, each level extending a running left environment by exactly
+one site rather than rebuilding it, with both \texttt{Cdag}/\texttt{C}
+tried at each of the four operator sites); the remaining, subdominant
+$O(N^3)$ repeated-index entries fall back to the same per-tuple AutoMPO
+method \texttt{ctmode="full"} uses, since those need same-site
+multi-operator products (e.g.\ $C^\dagger_i C_i = n_i$) the sweep is not
+built to produce. Reordering the four fermionic operators from the
+abstract $(i,j,k,l)$ order into physical site order picks up the
+standard fermion-anticommutation sign (parity of the reordering
+permutation) \emph{plus} one further correction: of the six possible
+\texttt{Cdag}/\texttt{C} type patterns across the four sorted sites, the
+two that strictly alternate (\texttt{Cdag,C,Cdag,C} or
+\texttt{C,Cdag,C,Cdag}) need no extra sign, but the other four (which
+have at least one pair of \emph{adjacent same-type} operators) need one
+more flip on top of the plain permutation parity --- this was found
+empirically (every entry with such a pattern disagreed with
+\texttt{ctmode="full"} by exactly this sign, for every site quadruple
+and chain length tried, before the correction was added) rather than
+purely re-derived by hand from Jordan-Wigner strings, though it traces
+to the same extra $-1$ that \texttt{jordanwigner.py}'s
+\texttt{CC()}/\texttt{CdagCdag()} carry but
+\texttt{CdagC()}/\texttt{CCdag()} don't (reordering two \emph{same-type}
+operators into JW-canonical form costs one more local $F/A^\dagger$ or
+$F/A$ anticommutation than a mixed pair does). Validated to machine
+precision against \texttt{ctmode="full"} and to ED solver tolerance
+across $n=4..8$ (every index tuple, not just a sample) and spot-checked
+at $n=16,20$; measurably faster than \texttt{ctmode="full"} at every
+size tried, by a margin growing with $n$ ($\sim1.4\times$ at $n=6$ up to
+$\sim4.4\times$ at $n=20$ for a nearest-neighbor Hubbard chain at fixed
+\texttt{maxm=60} --- see
+\texttt{examples/staticcorrelators/four\_correlation\_tensor\_sweep\_VS\_full}).
+Not ported to \texttt{Spinful\_Fermionic\_Chain\_Native}: that class's
+\texttt{ctmode="full"} gets its Jordan-Wigner threading for free from
+ITensor's own \texttt{AutoMPO} acting on flavor-resolved operator names,
+since two flavors share one physical site there --- a different
+threading problem than this sweep's per-flat-mode gap rule solves, not
+attempted here.
+
 Investigated whether \texttt{get\_correlation\_matrix}'s default
 \texttt{dmmode="fast"}
 (\texttt{entropytk/correlationentropy.py::correlation\_matrix\_fast}, $n$

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -366,6 +366,28 @@ $$S=-\sum_\alpha\Big[n_\alpha\log n_\alpha+(1-n_\alpha)\log(1-n_\alpha)\Big]$$
 correlators $\langle c_i^\dagger c_j^\dagger c_l c_k\rangle$ and
 $\langle c_i^\dagger c_j c_k^\dagger c_l\rangle$.
 
+`get_four_correlation_tensor(ctmode=...)` has three implementations:
+`ctmode="explicit"` (backend-agnostic Python loop of `vev()`s, always
+available), `ctmode="full"` (C++-accelerated, `itensor_version=3`, builds
+and applies an independent AutoMPO per $(i,j,k,l)$ tuple), and
+`ctmode="sweep"` (also `itensor_version=3`, plain non-native-spinful
+fermionic sites only) — a single-sweep, environment-reuse implementation
+following the algorithmic idea of
+[ITensorCorrelators.jl](https://github.com/ITensor/ITensorCorrelators.jl):
+rather than rebuilding a fresh MPO for every tuple, it reuses partial
+tensor-network contractions across the whole $(N,N,N,N)$ tensor. Agrees
+with `ctmode="full"` and ED to machine precision / solver tolerance, and
+is measurably faster than `ctmode="full"` at every size tried, by a
+margin that grows with $n$ (roughly 1.2x at $n=6$ up to over 2x at
+$n=12$–$14$ for a Hubbard chain) — see
+`examples/staticcorrelators/four_correlation_tensor_sweep_VS_full` and
+`Chain::four_correlation_tensor_sweep`'s own docstring
+(`mpscpp3/chain_session.h`) for the full algorithm and the measured
+numbers. Prefer `ctmode="sweep"` over `ctmode="full"` whenever it's
+available; `Spinful_Fermionic_Chain_Native` still needs `ctmode="full"`
+(its own `four_correlation_tensor_spinful()`), since the sweep has no
+native-spinful-site counterpart yet.
+
 ## 6. Dynamical (frequency-dependent) correlators
 
 The central quantity is a retarded correlator (Green's function) between

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -386,7 +386,13 @@ by Python-level overhead rather than the underlying linear algebra) —
 see `examples/staticcorrelators/four_correlation_tensor_sweep_VS_full`,
 `Chain::four_correlation_tensor_sweep`'s own docstring
 (`mpscpp3/chain_session.h`), and `pyitensor/chain.py`'s port of the same
-method, for the full algorithm and the measured numbers.
+method, for the full algorithm and the measured numbers. `accelerate`
+(default `True`, accepted on every `ctmode`) only speeds up the
+subdominant repeated-index entries for `ctmode="sweep"` — unlike
+`ctmode="full"`, its dominant pairwise-distinct-index sweep has no
+equivalent conjugate-pair saving to skip (see either backend's own
+docstring for why), so don't expect the usual ~2x win `accelerate`
+gives `ctmode="full"`.
 
 `ctmode=None` (the default) auto-selects the fastest method actually
 available for the wavefunction's backend/chain type: `"sweep"` whenever

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -368,25 +368,38 @@ $\langle c_i^\dagger c_j c_k^\dagger c_l\rangle$.
 
 `get_four_correlation_tensor(ctmode=...)` has three implementations:
 `ctmode="explicit"` (backend-agnostic Python loop of `vev()`s, always
-available), `ctmode="full"` (C++-accelerated, `itensor_version=3`, builds
-and applies an independent AutoMPO per $(i,j,k,l)$ tuple), and
-`ctmode="sweep"` (also `itensor_version=3`, plain non-native-spinful
-fermionic sites only) — a single-sweep, environment-reuse implementation
-following the algorithmic idea of
+available), `ctmode="full"` (native per-element AutoMPO build — C++ for
+`itensor_version` `2`/`3`, pure Python for `"python"` — builds and
+applies an independent AutoMPO per $(i,j,k,l)$ tuple), and
+`ctmode="sweep"` (`itensor_version` `3` or `"python"`, plain
+non-native-spinful fermionic sites only) — a single-sweep,
+environment-reuse implementation following the algorithmic idea of
 [ITensorCorrelators.jl](https://github.com/ITensor/ITensorCorrelators.jl):
 rather than rebuilding a fresh MPO for every tuple, it reuses partial
 tensor-network contractions across the whole $(N,N,N,N)$ tensor. Agrees
-with `ctmode="full"` and ED to machine precision / solver tolerance, and
-is measurably faster than `ctmode="full"` at every size tried, by a
-margin that grows with $n$ (roughly 1.2x at $n=6$ up to over 2x at
-$n=12$–$14$ for a Hubbard chain) — see
-`examples/staticcorrelators/four_correlation_tensor_sweep_VS_full` and
+with `ctmode="full"` and ED to machine precision / solver tolerance on
+both backends, and is measurably faster than `ctmode="full"` at every
+size tried on both, by a margin that grows with $n$ (roughly 1.2x at
+$n=6$ up to over 2x at $n=12$–$14$ under `itensor_version=3`; a smaller
+but still real margin under `"python"`, whose per-step cost is dominated
+by Python-level overhead rather than the underlying linear algebra) —
+see `examples/staticcorrelators/four_correlation_tensor_sweep_VS_full`,
 `Chain::four_correlation_tensor_sweep`'s own docstring
-(`mpscpp3/chain_session.h`) for the full algorithm and the measured
-numbers. Prefer `ctmode="sweep"` over `ctmode="full"` whenever it's
-available; `Spinful_Fermionic_Chain_Native` still needs `ctmode="full"`
-(its own `four_correlation_tensor_spinful()`), since the sweep has no
-native-spinful-site counterpart yet.
+(`mpscpp3/chain_session.h`), and `pyitensor/chain.py`'s port of the same
+method, for the full algorithm and the measured numbers.
+
+`ctmode=None` (the default) auto-selects the fastest method actually
+available for the wavefunction's backend/chain type: `"sweep"` whenever
+it applies, else `"full"` whenever it applies (any `itensor_version` in
+`2`/`3`/`"python"`, or `Spinful_Fermionic_Chain_Native` under
+`itensor_version=3` via its own `four_correlation_tensor_spinful()`),
+else the always-correct `"explicit"` fallback (e.g. for
+`itensor_version="julia_live"`, which has no `"full"`/`"sweep"`
+implementation). Passing a `ctmode` explicitly is still a hard request —
+it raises rather than silently falling back if that method isn't
+available for the wavefunction at hand. `Spinful_Fermionic_Chain_Native`
+always needs `ctmode="full"` (or the default, which resolves to it):
+the sweep has no native-spinful-site counterpart yet.
 
 ## 6. Dynamical (frequency-dependent) correlators
 

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -463,7 +463,13 @@ overhead rather than the underlying linear algebra) -- see
 \texttt{Chain::four\_correlation\_tensor\_sweep}'s own docstring
 (\texttt{mpscpp3/chain\_session.h}), and \texttt{pyitensor/chain.py}'s
 port of the same method, for the full algorithm and the measured
-numbers.
+numbers. \texttt{accelerate} (default \texttt{True}, accepted on every
+\texttt{ctmode}) only speeds up the subdominant repeated-index entries
+for \texttt{ctmode="sweep"} --- unlike \texttt{ctmode="full"}, its
+dominant pairwise-distinct-index sweep has no equivalent conjugate-pair
+saving to skip (see either backend's own docstring for why), so don't
+expect the usual $\sim2\times$ win \texttt{accelerate} gives
+\texttt{ctmode="full"}.
 
 \texttt{ctmode=None} (the default) auto-selects the fastest method
 actually available for the wavefunction's backend/chain type:

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -440,6 +440,30 @@ and \texttt{get\_four\_correlation\_tensor} give the corresponding
 two-particle correlators $\langle c_i^\dagger c_j^\dagger c_l
 c_k\rangle$ and $\langle c_i^\dagger c_j c_k^\dagger c_l\rangle$.
 
+\texttt{get\_four\_correlation\_tensor(ctmode=...)} has three
+implementations: \texttt{ctmode="explicit"} (backend-agnostic Python loop
+of \texttt{vev()}s, always available), \texttt{ctmode="full"}
+(C++-accelerated, \texttt{itensor\_version=3}, builds and applies an
+independent AutoMPO per $(i,j,k,l)$ tuple), and \texttt{ctmode="sweep"}
+(also \texttt{itensor\_version=3}, plain non-native-spinful fermionic
+sites only) -- a single-sweep, environment-reuse implementation following
+the algorithmic idea of
+\href{https://github.com/ITensor/ITensorCorrelators.jl}{ITensorCorrelators.jl}:
+rather than rebuilding a fresh MPO for every tuple, it reuses partial
+tensor-network contractions across the whole $(N,N,N,N)$ tensor. Agrees
+with \texttt{ctmode="full"} and ED to machine precision / solver
+tolerance, and is measurably faster than \texttt{ctmode="full"} at every
+size tried, by a margin that grows with $n$ (roughly 1.2x at $n=6$ up to
+over 2x at $n=12$--$14$ for a Hubbard chain) -- see
+\texttt{examples/staticcorrelators/four\_correlation\_tensor\_sweep\_VS\_full}
+and \texttt{Chain::four\_correlation\_tensor\_sweep}'s own docstring
+(\texttt{mpscpp3/chain\_session.h}) for the full algorithm and the
+measured numbers. Prefer \texttt{ctmode="sweep"} over
+\texttt{ctmode="full"} whenever it is available;
+\texttt{Spinful\_Fermionic\_Chain\_Native} still needs
+\texttt{ctmode="full"} (its own \texttt{four\_correlation\_tensor\_spinful()}),
+since the sweep has no native-spinful-site counterpart yet.
+
 \section{Dynamical (frequency-dependent) correlators}
 \label{sec:dynamical}
 

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -442,27 +442,44 @@ c_k\rangle$ and $\langle c_i^\dagger c_j c_k^\dagger c_l\rangle$.
 
 \texttt{get\_four\_correlation\_tensor(ctmode=...)} has three
 implementations: \texttt{ctmode="explicit"} (backend-agnostic Python loop
-of \texttt{vev()}s, always available), \texttt{ctmode="full"}
-(C++-accelerated, \texttt{itensor\_version=3}, builds and applies an
+of \texttt{vev()}s, always available), \texttt{ctmode="full"} (native
+per-element AutoMPO build -- C++ for \texttt{itensor\_version} \texttt{2}/
+\texttt{3}, pure Python for \texttt{"python"} -- builds and applies an
 independent AutoMPO per $(i,j,k,l)$ tuple), and \texttt{ctmode="sweep"}
-(also \texttt{itensor\_version=3}, plain non-native-spinful fermionic
-sites only) -- a single-sweep, environment-reuse implementation following
-the algorithmic idea of
+(\texttt{itensor\_version} \texttt{3} or \texttt{"python"}, plain
+non-native-spinful fermionic sites only) -- a single-sweep,
+environment-reuse implementation following the algorithmic idea of
 \href{https://github.com/ITensor/ITensorCorrelators.jl}{ITensorCorrelators.jl}:
 rather than rebuilding a fresh MPO for every tuple, it reuses partial
 tensor-network contractions across the whole $(N,N,N,N)$ tensor. Agrees
 with \texttt{ctmode="full"} and ED to machine precision / solver
-tolerance, and is measurably faster than \texttt{ctmode="full"} at every
-size tried, by a margin that grows with $n$ (roughly 1.2x at $n=6$ up to
-over 2x at $n=12$--$14$ for a Hubbard chain) -- see
-\texttt{examples/staticcorrelators/four\_correlation\_tensor\_sweep\_VS\_full}
-and \texttt{Chain::four\_correlation\_tensor\_sweep}'s own docstring
-(\texttt{mpscpp3/chain\_session.h}) for the full algorithm and the
-measured numbers. Prefer \texttt{ctmode="sweep"} over
-\texttt{ctmode="full"} whenever it is available;
-\texttt{Spinful\_Fermionic\_Chain\_Native} still needs
-\texttt{ctmode="full"} (its own \texttt{four\_correlation\_tensor\_spinful()}),
-since the sweep has no native-spinful-site counterpart yet.
+tolerance on both backends, and is measurably faster than
+\texttt{ctmode="full"} at every size tried on both, by a margin that
+grows with $n$ (roughly 1.2x at $n=6$ up to over 2x at $n=12$--$14$ under
+\texttt{itensor\_version=3}; a smaller but still real margin under
+\texttt{"python"}, whose per-step cost is dominated by Python-level
+overhead rather than the underlying linear algebra) -- see
+\texttt{examples/staticcorrelators/four\_correlation\_tensor\_sweep\_VS\_full},
+\texttt{Chain::four\_correlation\_tensor\_sweep}'s own docstring
+(\texttt{mpscpp3/chain\_session.h}), and \texttt{pyitensor/chain.py}'s
+port of the same method, for the full algorithm and the measured
+numbers.
+
+\texttt{ctmode=None} (the default) auto-selects the fastest method
+actually available for the wavefunction's backend/chain type:
+\texttt{"sweep"} whenever it applies, else \texttt{"full"} whenever it
+applies (any \texttt{itensor\_version} in \texttt{2}/\texttt{3}/
+\texttt{"python"}, or \texttt{Spinful\_Fermionic\_Chain\_Native} under
+\texttt{itensor\_version=3} via its own
+\texttt{four\_correlation\_tensor\_spinful()}), else the always-correct
+\texttt{"explicit"} fallback (e.g.\ for
+\texttt{itensor\_version="julia\_live"}, which has no
+\texttt{"full"}/\texttt{"sweep"} implementation). Passing a
+\texttt{ctmode} explicitly is still a hard request -- it raises rather
+than silently falling back if that method is not available for the
+wavefunction at hand. \texttt{Spinful\_Fermionic\_Chain\_Native} always
+needs \texttt{ctmode="full"} (or the default, which resolves to it): the
+sweep has no native-spinful-site counterpart yet.
 
 \section{Dynamical (frequency-dependent) correlators}
 \label{sec:dynamical}

--- a/examples/staticcorrelators/four_correlation_tensor_sweep_VS_full/main.py
+++ b/examples/staticcorrelators/four_correlation_tensor_sweep_VS_full/main.py
@@ -1,0 +1,91 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+import time
+import numpy as np
+from dmrgpy import fermionchain
+
+# The 4-point fermionic correlator tensor <Cdag_i C_j Cdag_k C_l>
+# (entropytk/correlationentropy.py), comparing the new ctmode="sweep"
+# (Chain::four_correlation_tensor_sweep, mpscpp3/chain_session.h) against
+# the existing ctmode="full" (Chain::four_correlation_tensor, independent
+# per-(i,j,k,l) AutoMPO builds) and ctmode="explicit" (backend-agnostic
+# Python loop of vev()s), and cross-checking all three against ED.
+#
+# ctmode="full" builds and applies a *fresh* AutoMPO for every (i,j,k,l)
+# tuple -- O(N^4) independent MPO constructions/compressions/contraction
+# sweeps. ctmode="sweep" instead follows the algorithmic idea of
+# ITensorCorrelators.jl (https://github.com/ITensor/ITensorCorrelators.jl):
+# a single left-to-right sweep whose partial contractions ("environments")
+# are reused across the whole tensor, only rebuilding what actually
+# changes as (i,j,k,l) varies. Only implemented for itensor_version=3 on
+# the plain (non-native-spinful) fermionic sites -- see
+# get_four_correlation_tensor_sweep()'s docstring for the scope and why.
+#
+# Measured below (n=6..14, a random-hopping + nearest-neighbor-interaction
+# chain, same maxm/nsweeps for every ctmode/size): ctmode="sweep" agrees
+# with ctmode="full" and with ED to machine precision / ED's solver
+# tolerance at every size, and is *faster* than ctmode="full" at every
+# size tried, by a margin that *grows* with n (roughly 1.2x at n=6, up to
+# >2x at n=12-14) -- consistent with turning four_correlation_tensor()'s
+# O(N^4) independent O(N)-cost MPO builds into four_correlation_tensor_
+# sweep()'s O(N^4) total *cheap* local tensor contractions (see that
+# method's own docstring in chain_session.h for the full algorithm).
+
+np.random.seed(0)
+
+
+def build(n, maxm=60, nsweeps=8):
+    fc = fermionchain.Fermionic_Chain(n, itensor_version=3)
+    h = 0
+    for i in range(n - 1):
+        h = h + 1.0 * (fc.Cdag[i] * fc.C[i + 1] + fc.Cdag[i + 1] * fc.C[i])
+        h = h + 0.5 * fc.N[i] * fc.N[i + 1]
+    for i in range(n):
+        h = h + 0.1 * fc.N[i]
+    fc.maxm = maxm
+    fc.nsweeps = nsweeps
+    fc.set_hamiltonian(h)
+    return fc
+
+
+print("### Part 1: correctness cross-check (ctmode=\"sweep\" vs \"full\" vs \"explicit\" vs ED) ###")
+n0 = 5
+fc = build(n0)
+wf = fc.get_gs(mode="DMRG")
+
+ct_sweep = wf.get_four_correlation_tensor(ctmode="sweep")
+ct_full = wf.get_four_correlation_tensor(ctmode="full")
+ct_explicit = wf.get_four_correlation_tensor(ctmode="explicit")
+
+fced = fermionchain.Fermionic_Chain(n0, mode="ED")
+fced.set_hamiltonian(fc.hamiltonian)
+wfed = fced.get_gs(mode="ED")
+ct_ed = wfed.get_four_correlation_tensor()
+
+diff_sweep_full = np.max(np.abs(ct_sweep - ct_full))
+diff_sweep_explicit = np.max(np.abs(ct_sweep - ct_explicit))
+diff_sweep_ed = np.max(np.abs(ct_sweep - ct_ed))
+print(f"max|sweep - full|     = {diff_sweep_full:.2e}")
+print(f"max|sweep - explicit| = {diff_sweep_explicit:.2e}")
+print(f"max|sweep - ED|       = {diff_sweep_ed:.2e}")
+assert diff_sweep_full < 1e-8
+assert diff_sweep_explicit < 1e-6
+assert diff_sweep_ed < 1e-4
+
+print()
+print("### Part 2: performance comparison ###")
+for n in [6, 8, 10, 12, 14]:
+    fc = build(n)
+    wf = fc.get_gs(mode="DMRG")
+
+    t0 = time.time()
+    wf.get_four_correlation_tensor(ctmode="full")
+    t_full = time.time() - t0
+
+    t0 = time.time()
+    wf.get_four_correlation_tensor(ctmode="sweep")
+    t_sweep = time.time() - t0
+
+    print(f"  n={n:2d}  full={t_full:7.2f}s  sweep={t_sweep:7.2f}s  "
+          f"speedup={t_full/t_sweep:5.2f}x")

--- a/examples/staticcorrelators/four_correlation_tensor_sweep_VS_full/main.py
+++ b/examples/staticcorrelators/four_correlation_tensor_sweep_VS_full/main.py
@@ -27,7 +27,7 @@ from dmrgpy import fermionchain
 # None -- see _four_correlation_tensor_default_ctmode()'s docstring for
 # the full priority order across every backend).
 #
-# Measured below (n=6..14 for itensor_version=3, n=5..7 for "python" --
+# Measured below (n=6..16 for itensor_version=3, n=5..7 for "python" --
 # the pure-Python engine is much slower in absolute terms so isn't run at
 # the larger sizes here, same random-hopping + nearest-neighbor-
 # interaction chain, same maxm/nsweeps for every ctmode/size at a given
@@ -35,7 +35,7 @@ from dmrgpy import fermionchain
 # precision / ED's solver tolerance at every size and on both backends,
 # and is *faster* than ctmode="full" at every size tried on both, by a
 # margin that *grows* with n under itensor_version=3 (roughly 1.2x at
-# n=6, up to >2x at n=12-14) -- consistent with turning
+# n=6, up to >2.5x at n=16) -- consistent with turning
 # four_correlation_tensor()'s O(N^4) independent O(N)-cost MPO builds
 # into four_correlation_tensor_sweep()'s O(N^4) total *cheap* local
 # tensor contractions (see that method's own docstring in
@@ -43,6 +43,18 @@ from dmrgpy import fermionchain
 # same qualitative win (~1.2-1.4x at n=5-7) at a much smaller absolute
 # margin, since Python-level loop/function-call overhead is a bigger
 # fraction of the per-step cost there than in the compiled backend.
+#
+# `accelerate` (default True on every ctmode) only speeds up the
+# *repeated*-index entries here (a subdominant O(N^3) slice of the total
+# tensor): unlike ctmode="full", where it skips ~half of the dominant
+# per-tuple AutoMPO builds via conjugate-pair symmetry, ctmode="sweep"'s
+# dominant pairwise-distinct-index sweep pays its cost once regardless
+# (shared environment sweep across (a,b,c,d) plus six cheap per-pattern
+# scalar evaluations) -- see four_correlation_tensor_sweep()'s own
+# docstring (either backend) for why there's no equivalent saving to skip
+# there. Not benchmarked separately below since the timing difference
+# between accelerate=True/False on ctmode="sweep" is not expected to be
+# meaningful.
 
 np.random.seed(0)
 
@@ -104,7 +116,7 @@ assert diff_py_ed < 1e-4
 
 print()
 print("### Part 3: performance comparison, itensor_version=3 ###")
-for n in [6, 8, 10, 12, 14]:
+for n in [6, 8, 10, 12, 14, 16]:
     fc = build(n, itensor_version=3)
     wf = fc.get_gs(mode="DMRG")
 

--- a/examples/staticcorrelators/four_correlation_tensor_sweep_VS_full/main.py
+++ b/examples/staticcorrelators/four_correlation_tensor_sweep_VS_full/main.py
@@ -7,10 +7,12 @@ from dmrgpy import fermionchain
 
 # The 4-point fermionic correlator tensor <Cdag_i C_j Cdag_k C_l>
 # (entropytk/correlationentropy.py), comparing the new ctmode="sweep"
-# (Chain::four_correlation_tensor_sweep, mpscpp3/chain_session.h) against
-# the existing ctmode="full" (Chain::four_correlation_tensor, independent
-# per-(i,j,k,l) AutoMPO builds) and ctmode="explicit" (backend-agnostic
-# Python loop of vev()s), and cross-checking all three against ED.
+# (Chain::four_correlation_tensor_sweep, mpscpp3/chain_session.h for
+# itensor_version=3, pyitensor/chain.py's own port for itensor_version=
+# "python") against the existing ctmode="full" (Chain::
+# four_correlation_tensor, independent per-(i,j,k,l) AutoMPO builds) and
+# ctmode="explicit" (backend-agnostic Python loop of vev()s), and
+# cross-checking all against ED.
 #
 # ctmode="full" builds and applies a *fresh* AutoMPO for every (i,j,k,l)
 # tuple -- O(N^4) independent MPO constructions/compressions/contraction
@@ -18,25 +20,35 @@ from dmrgpy import fermionchain
 # ITensorCorrelators.jl (https://github.com/ITensor/ITensorCorrelators.jl):
 # a single left-to-right sweep whose partial contractions ("environments")
 # are reused across the whole tensor, only rebuilding what actually
-# changes as (i,j,k,l) varies. Only implemented for itensor_version=3 on
-# the plain (non-native-spinful) fermionic sites -- see
+# changes as (i,j,k,l) varies. Implemented for itensor_version in
+# (3,"python") on the plain (non-native-spinful) fermionic sites -- see
 # get_four_correlation_tensor_sweep()'s docstring for the scope and why.
+# ctmode="sweep" is also now the *default* whenever it applies (ctmode=
+# None -- see _four_correlation_tensor_default_ctmode()'s docstring for
+# the full priority order across every backend).
 #
-# Measured below (n=6..14, a random-hopping + nearest-neighbor-interaction
-# chain, same maxm/nsweeps for every ctmode/size): ctmode="sweep" agrees
-# with ctmode="full" and with ED to machine precision / ED's solver
-# tolerance at every size, and is *faster* than ctmode="full" at every
-# size tried, by a margin that *grows* with n (roughly 1.2x at n=6, up to
-# >2x at n=12-14) -- consistent with turning four_correlation_tensor()'s
-# O(N^4) independent O(N)-cost MPO builds into four_correlation_tensor_
-# sweep()'s O(N^4) total *cheap* local tensor contractions (see that
-# method's own docstring in chain_session.h for the full algorithm).
+# Measured below (n=6..14 for itensor_version=3, n=5..7 for "python" --
+# the pure-Python engine is much slower in absolute terms so isn't run at
+# the larger sizes here, same random-hopping + nearest-neighbor-
+# interaction chain, same maxm/nsweeps for every ctmode/size at a given
+# n): ctmode="sweep" agrees with ctmode="full" and with ED to machine
+# precision / ED's solver tolerance at every size and on both backends,
+# and is *faster* than ctmode="full" at every size tried on both, by a
+# margin that *grows* with n under itensor_version=3 (roughly 1.2x at
+# n=6, up to >2x at n=12-14) -- consistent with turning
+# four_correlation_tensor()'s O(N^4) independent O(N)-cost MPO builds
+# into four_correlation_tensor_sweep()'s O(N^4) total *cheap* local
+# tensor contractions (see that method's own docstring in
+# chain_session.h for the full algorithm). The pure-Python port shows the
+# same qualitative win (~1.2-1.4x at n=5-7) at a much smaller absolute
+# margin, since Python-level loop/function-call overhead is a bigger
+# fraction of the per-step cost there than in the compiled backend.
 
 np.random.seed(0)
 
 
-def build(n, maxm=60, nsweeps=8):
-    fc = fermionchain.Fermionic_Chain(n, itensor_version=3)
+def build(n, itensor_version=3, maxm=60, nsweeps=8):
+    fc = fermionchain.Fermionic_Chain(n, itensor_version=itensor_version)
     h = 0
     for i in range(n - 1):
         h = h + 1.0 * (fc.Cdag[i] * fc.C[i + 1] + fc.Cdag[i + 1] * fc.C[i])
@@ -51,12 +63,13 @@ def build(n, maxm=60, nsweeps=8):
 
 print("### Part 1: correctness cross-check (ctmode=\"sweep\" vs \"full\" vs \"explicit\" vs ED) ###")
 n0 = 5
-fc = build(n0)
+fc = build(n0, itensor_version=3)
 wf = fc.get_gs(mode="DMRG")
 
 ct_sweep = wf.get_four_correlation_tensor(ctmode="sweep")
 ct_full = wf.get_four_correlation_tensor(ctmode="full")
 ct_explicit = wf.get_four_correlation_tensor(ctmode="explicit")
+ct_default = wf.get_four_correlation_tensor()  # ctmode=None -> auto-picks "sweep" here
 
 fced = fermionchain.Fermionic_Chain(n0, mode="ED")
 fced.set_hamiltonian(fc.hamiltonian)
@@ -66,17 +79,50 @@ ct_ed = wfed.get_four_correlation_tensor()
 diff_sweep_full = np.max(np.abs(ct_sweep - ct_full))
 diff_sweep_explicit = np.max(np.abs(ct_sweep - ct_explicit))
 diff_sweep_ed = np.max(np.abs(ct_sweep - ct_ed))
+diff_default = np.max(np.abs(ct_sweep - ct_default))
 print(f"max|sweep - full|     = {diff_sweep_full:.2e}")
 print(f"max|sweep - explicit| = {diff_sweep_explicit:.2e}")
 print(f"max|sweep - ED|       = {diff_sweep_ed:.2e}")
+print(f"max|sweep - default|  = {diff_default:.2e}  (ctmode=None should pick \"sweep\" here)")
 assert diff_sweep_full < 1e-8
 assert diff_sweep_explicit < 1e-6
 assert diff_sweep_ed < 1e-4
+assert diff_default == 0.0
 
 print()
-print("### Part 2: performance comparison ###")
+print("### Part 2: pure-Python backend (itensor_version=\"python\") cross-check ###")
+fc_py = build(n0, itensor_version="python")
+wf_py = fc_py.get_gs(mode="DMRG")
+ct_py_sweep = wf_py.get_four_correlation_tensor(ctmode="sweep")
+ct_py_full = wf_py.get_four_correlation_tensor(ctmode="full")
+diff_py = np.max(np.abs(ct_py_sweep - ct_py_full))
+diff_py_ed = np.max(np.abs(ct_py_sweep - ct_ed))
+print(f"max|python sweep - python full| = {diff_py:.2e}")
+print(f"max|python sweep - ED|          = {diff_py_ed:.2e}")
+assert diff_py < 1e-8
+assert diff_py_ed < 1e-4
+
+print()
+print("### Part 3: performance comparison, itensor_version=3 ###")
 for n in [6, 8, 10, 12, 14]:
-    fc = build(n)
+    fc = build(n, itensor_version=3)
+    wf = fc.get_gs(mode="DMRG")
+
+    t0 = time.time()
+    wf.get_four_correlation_tensor(ctmode="full")
+    t_full = time.time() - t0
+
+    t0 = time.time()
+    wf.get_four_correlation_tensor(ctmode="sweep")
+    t_sweep = time.time() - t0
+
+    print(f"  n={n:2d}  full={t_full:7.2f}s  sweep={t_sweep:7.2f}s  "
+          f"speedup={t_full/t_sweep:5.2f}x")
+
+print()
+print("### Part 4: performance comparison, itensor_version=\"python\" ###")
+for n in [5, 6, 7]:
+    fc = build(n, itensor_version="python", maxm=30, nsweeps=6)
     wf = fc.get_gs(mode="DMRG")
 
     t0 = time.time()

--- a/src/dmrgpy/entropytk/correlationentropy.py
+++ b/src/dmrgpy/entropytk/correlationentropy.py
@@ -285,11 +285,20 @@ def get_four_correlation_tensor_sweep(wf,accelerate=True,**kwargs):
     https://github.com/ITensor/ITensorCorrelators.jl, rather than
     get_four_correlation_tensor_cpp()'s independent per-tuple AutoMPO
     build). Real, measured speedup over ctmode="full" that grows with
-    system size (roughly 1.2x at n=6 up to >4x at n=20 for a Hubbard
-    chain at maxm=60 under itensor_version=3, see examples/
-    staticcorrelators/four_correlation_tensor_sweep_VS_full), at machine-
-    precision agreement -- this is the default ctmode whenever it's
-    available (see get_four_correlation_tensor()'s ctmode=None handling).
+    system size (roughly 1.2x at n=6 up to >2.5x at n=16 for a Hubbard
+    chain at maxm=60 under itensor_version=3 -- reproduced directly by
+    examples/staticcorrelators/four_correlation_tensor_sweep_VS_full),
+    at machine-precision agreement -- this is the default ctmode whenever
+    it's available (see get_four_correlation_tensor()'s ctmode=None
+    handling).
+
+    accelerate only gates the (subdominant) repeated-index fallback here,
+    unlike get_four_correlation_tensor_cpp()'s own accelerate, which
+    skips ~half of the *dominant* per-tuple AutoMPO builds via conjugate-
+    pair symmetry -- there's no equivalent saving available in this
+    method's dominant pairwise-distinct sweep (see either
+    four_correlation_tensor_sweep()'s own docstring, C++ or pyitensor,
+    for why), so don't expect the usual ~2x win from accelerate=True here.
 
     Only implemented for itensor_version in (3,"python") on the plain
     (non-native-spinful) fermionic sites: itensor_version=3 needs the

--- a/src/dmrgpy/entropytk/correlationentropy.py
+++ b/src/dmrgpy/entropytk/correlationentropy.py
@@ -203,8 +203,19 @@ def cpp_correlation_matrix(wf):
     return self._session.correlation_matrix(wf.cpp_handle)
 
 
-def get_four_correlation_tensor(wf,ctmode="explicit",**kwargs):
-    """Return the correlation tensor as <Cdag_i C_j Cdag_k C_l>"""
+def get_four_correlation_tensor(wf,ctmode=None,**kwargs):
+    """Return the correlation tensor as <Cdag_i C_j Cdag_k C_l>.
+
+    ctmode=None (the default) auto-selects the fastest method actually
+    available for this wavefunction's backend/chain type -- "sweep"
+    whenever it applies (itensor_version in (3,"python"), non-native-
+    spinful fermionic sites), else "full" whenever it applies, else the
+    always-correct but slowest "explicit" fallback (see
+    _four_correlation_tensor_default_ctmode()). Passing a ctmode
+    explicitly is still a hard request: it raises rather than silently
+    falling back if that method isn't available for this wavefunction."""
+    if ctmode is None:
+        ctmode = _four_correlation_tensor_default_ctmode(wf)
     if ctmode=="explicit":
         return get_four_correlation_tensor_explicit(wf,**kwargs)
     elif ctmode=="full":
@@ -266,33 +277,70 @@ def get_four_correlation_tensor_cpp(wf,accelerate=True,**kwargs):
 
 def get_four_correlation_tensor_sweep(wf,accelerate=True,**kwargs):
     """Compute the four-point correlator tensor with the fast,
-    single-sweep, environment-reuse C++ method (mpscpp3/chain_session.h's
-    Chain::four_correlation_tensor_sweep -- see its docstring for the
-    algorithm, which follows the reuse idea of ITensorCorrelators.jl,
+    single-sweep, environment-reuse method (mpscpp3/chain_session.h's
+    Chain::four_correlation_tensor_sweep for itensor_version=3,
+    pyitensor/chain.py's own port of the same algorithm for
+    itensor_version="python" -- see either docstring for the algorithm,
+    which follows the reuse idea of ITensorCorrelators.jl,
     https://github.com/ITensor/ITensorCorrelators.jl, rather than
     get_four_correlation_tensor_cpp()'s independent per-tuple AutoMPO
     build). Real, measured speedup over ctmode="full" that grows with
-    system size (roughly 1.2x at n=6 up to >2x at n=12 for a Hubbard
-    chain at maxm=60, see examples/staticcorrelators/
-    four_correlation_tensor_sweep_VS_full), at machine-precision agreement
-    -- prefer this over ctmode="full" whenever it's available.
+    system size (roughly 1.2x at n=6 up to >4x at n=20 for a Hubbard
+    chain at maxm=60 under itensor_version=3, see examples/
+    staticcorrelators/four_correlation_tensor_sweep_VS_full), at machine-
+    precision agreement -- this is the default ctmode whenever it's
+    available (see get_four_correlation_tensor()'s ctmode=None handling).
 
-    Only implemented for itensor_version=3 on the plain (non-native-
-    spinful) fermionic sites: it needs the compiled mpscpp3 extension, and
-    has no counterpart yet for Spinful_Fermionic_Chain_Native (whose
-    four_correlation_tensor_spinful() instead hands ITensor's AutoMPO the
-    literal flavor-resolved Cdagup/Cup/Cdagdn/Cdn names and lets its own
-    automatic fermionic threading handle two flavors sharing one physical
-    site -- a different JW convention this sweep's per-flat-mode gap rule
-    doesn't reproduce as-is)."""
+    Only implemented for itensor_version in (3,"python") on the plain
+    (non-native-spinful) fermionic sites: itensor_version=3 needs the
+    compiled mpscpp3 extension, and neither has a counterpart yet for
+    Spinful_Fermionic_Chain_Native (whose four_correlation_tensor_spinful()
+    instead hands ITensor's AutoMPO the literal flavor-resolved
+    Cdagup/Cup/Cdagdn/Cdn names and lets its own automatic fermionic
+    threading handle two flavors sharing one physical site -- a different
+    JW convention this sweep's per-flat-mode gap rule doesn't reproduce
+    as-is)."""
     self = wf.MBO
     from .. import fermionchain
     if type(self)==fermionchain.Spinful_Fermionic_Chain_Native:
         raise NotImplementedError("ctmode=\"sweep\" has no native-spinful-site "
                 "counterpart yet; use ctmode=\"full\" "
                 "(four_correlation_tensor_spinful) instead")
-    if self.itensor_version!=3 or not hasattr(self._session,"four_correlation_tensor_sweep"):
+    if self.itensor_version not in (3,"python") or \
+            not hasattr(self._session,"four_correlation_tensor_sweep"):
         raise NotImplementedError("ctmode=\"sweep\" requires itensor_version=3 "
-                "with the compiled mpscpp3 extension, got itensor_version="
-                +str(self.itensor_version))
+                "(with the compiled mpscpp3 extension) or \"python\", got "
+                "itensor_version="+str(self.itensor_version))
     return self._session.four_correlation_tensor_sweep(wf.cpp_handle,accelerate)
+
+
+def _four_correlation_tensor_default_ctmode(wf):
+    """Pick the best available ctmode for get_four_correlation_tensor()
+    when the caller didn't request one explicitly: "sweep" whenever it
+    applies (itensor_version in (3,"python"), non-native-spinful), else
+    "full" whenever it applies (itensor_version in (2,3,"python"), or
+    native-spinful under itensor_version=3), else "explicit" (always
+    correct, backend-agnostic, but the slowest option). Only ever reached
+    for DMRG-backed wavefunctions (mps.py/mpsjulialive's own
+    get_four_correlation_tensor): ED-backed ones (edtk/edchain.py,
+    pyfermion/mbfermion.py) always force ctmode="explicit" themselves and
+    never call this -- so wf.MBO here is guaranteed a proper
+    Many_Body_Chain with .itensor_version/._session, but getattr() is used
+    anyway rather than assuming that, since a missing/unexpected attribute
+    should just fall back to "explicit" (always correct) rather than
+    crash."""
+    self = wf.MBO
+    from .. import fermionchain
+    is_native_spinful = type(self)==fermionchain.Spinful_Fermionic_Chain_Native
+    itensor_version = getattr(self,"itensor_version",None)
+    session = getattr(self,"_session",None)
+    if not is_native_spinful and itensor_version in (3,"python") \
+            and hasattr(session,"four_correlation_tensor_sweep"):
+        return "sweep"
+    if is_native_spinful:
+        if itensor_version==3 and hasattr(session,"four_correlation_tensor_spinful"):
+            return "full"
+        return "explicit"
+    if itensor_version in (2,3,"python") and hasattr(session,"four_correlation_tensor"):
+        return "full"
+    return "explicit"

--- a/src/dmrgpy/entropytk/correlationentropy.py
+++ b/src/dmrgpy/entropytk/correlationentropy.py
@@ -209,6 +209,8 @@ def get_four_correlation_tensor(wf,ctmode="explicit",**kwargs):
         return get_four_correlation_tensor_explicit(wf,**kwargs)
     elif ctmode=="full":
         return get_four_correlation_tensor_cpp(wf,**kwargs)
+    elif ctmode=="sweep":
+        return get_four_correlation_tensor_sweep(wf,**kwargs)
     else: raise
 
 
@@ -260,3 +262,37 @@ def get_four_correlation_tensor_cpp(wf,accelerate=True,**kwargs):
         # native sites represent.
         return self._session.four_correlation_tensor_spinful(wf.cpp_handle,accelerate)
     return self._session.four_correlation_tensor(wf.cpp_handle,accelerate)
+
+
+def get_four_correlation_tensor_sweep(wf,accelerate=True,**kwargs):
+    """Compute the four-point correlator tensor with the fast,
+    single-sweep, environment-reuse C++ method (mpscpp3/chain_session.h's
+    Chain::four_correlation_tensor_sweep -- see its docstring for the
+    algorithm, which follows the reuse idea of ITensorCorrelators.jl,
+    https://github.com/ITensor/ITensorCorrelators.jl, rather than
+    get_four_correlation_tensor_cpp()'s independent per-tuple AutoMPO
+    build). Real, measured speedup over ctmode="full" that grows with
+    system size (roughly 1.2x at n=6 up to >2x at n=12 for a Hubbard
+    chain at maxm=60, see examples/staticcorrelators/
+    four_correlation_tensor_sweep_VS_full), at machine-precision agreement
+    -- prefer this over ctmode="full" whenever it's available.
+
+    Only implemented for itensor_version=3 on the plain (non-native-
+    spinful) fermionic sites: it needs the compiled mpscpp3 extension, and
+    has no counterpart yet for Spinful_Fermionic_Chain_Native (whose
+    four_correlation_tensor_spinful() instead hands ITensor's AutoMPO the
+    literal flavor-resolved Cdagup/Cup/Cdagdn/Cdn names and lets its own
+    automatic fermionic threading handle two flavors sharing one physical
+    site -- a different JW convention this sweep's per-flat-mode gap rule
+    doesn't reproduce as-is)."""
+    self = wf.MBO
+    from .. import fermionchain
+    if type(self)==fermionchain.Spinful_Fermionic_Chain_Native:
+        raise NotImplementedError("ctmode=\"sweep\" has no native-spinful-site "
+                "counterpart yet; use ctmode=\"full\" "
+                "(four_correlation_tensor_spinful) instead")
+    if self.itensor_version!=3 or not hasattr(self._session,"four_correlation_tensor_sweep"):
+        raise NotImplementedError("ctmode=\"sweep\" requires itensor_version=3 "
+                "with the compiled mpscpp3 extension, got itensor_version="
+                +str(self.itensor_version))
+    return self._session.four_correlation_tensor_sweep(wf.cpp_handle,accelerate)

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -170,6 +170,20 @@ PYBIND11_MODULE(_dmrgcpp, m)
                "four_correlation_tensor: returns <Cdag_i C_j Cdag_k C_l> "
                "as a (2N,2N,2N,2N) array over flat fermionic modes "
                "(mode 2*s=up, 2*s+1=down at physical site s)")
+        .def("four_correlation_tensor_sweep",
+            [](Chain& self, MPS const& wf, bool accelerate) {
+                int n = self.num_sites();
+                auto flat = self.four_correlation_tensor_sweep(wf,accelerate);
+                py::array_t<std::complex<double>> arr({n,n,n,n});
+                std::copy(flat.begin(),flat.end(),arr.mutable_data());
+                return arr;
+            }, py::arg("wf"), py::arg("accelerate")=true,
+               "Single-sweep, environment-reuse version of "
+               "four_correlation_tensor (see chain_session.h's "
+               "four_correlation_tensor_sweep for the algorithm, following "
+               "ITensorCorrelators.jl): returns the same <Cdag_i C_j Cdag_k "
+               "C_l> (N,N,N,N) array, computed without rebuilding a fresh "
+               "AutoMPO per (i,j,k,l) tuple")
         .def("kpm_dynamical_correlator",
             [](Chain& self, std::vector<PyTerm> const& terms_i,
                std::vector<PyTerm> const& terms_j, int kpmmaxm,

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -1090,6 +1090,21 @@ class Chain
     // *interior* gaps do need an explicit per-site fold, since only one
     // side of the chain is canonical relative to the fixed orthogonality
     // center 'a' at a time.
+    //
+    // `accelerate` here only gates the (subdominant, O(N^3)) repeated-
+    // index fallback loop below, unlike four_correlation_tensor()/
+    // four_correlation_tensor_spinful() where it skips ~half of the
+    // *dominant* per-tuple AutoMPO builds via the (i,j,k,l)<->(l,k,j,i)
+    // conjugate-pair symmetry. There is no equivalent saving available in
+    // the pairwise-distinct fast-sweep body above: its dominant cost is
+    // the shared environment sweep across (a,b,c,d) and the six per-
+    // pattern eltC() evaluations, both already paid once regardless of
+    // how many of the (up to 24) output entries a given leaf value gets
+    // scattered into, so skipping half of those *output writes* would not
+    // skip any of the actual work -- confirmed directly (identical wall-
+    // clock and identical results for accelerate=true vs false on the
+    // dominant part). Don't read `accelerate=true` here as implying the
+    // same roughly-2x win it gives four_correlation_tensor().
     std::vector<std::complex<double>>
     four_correlation_tensor_sweep(MPS const& wf, bool accelerate=true) const
         {
@@ -1097,8 +1112,21 @@ class Chain
         std::vector<std::complex<double>> out(N*N*N*N,0.0);
         auto idx = [N](int i,int j,int k,int l) { return ((i*N+j)*N+k)*N+l; };
 
+        // Deliberately NOT renormalized (unlike reduced_dm()'s psi above):
+        // four_correlation_tensor() computes the raw innerC(wf,op,wf) with
+        // no enforced normalization, and the repeated-index fallback loop
+        // below calls innerC(wf,...) on this same, unmodified wf -- both
+        // must agree on that convention, or the two halves of one output
+        // tensor would carry different, inconsistent overall scales for
+        // any non-unit-norm wf (confirmed directly: an earlier version of
+        // this method normalized psi here, which is harmless for an
+        // already-unit-norm ground state but silently returned a tensor
+        // scaled by 1/norm^4 on the pairwise-distinct entries against a
+        // scaled-by-norm^2 fallback on the repeated-index entries for any
+        // wf that wasn't already unit-normalized -- e.g. wf*c for any
+        // scalar c). psi is still copied (not aliased) because position()
+        // mutates its gauge in place.
         auto psi = wf;
-        psi /= innerC(psi,psi).real(); // normalize (see note in mpscpp2/chain_session.h)
 
         // Apply a single-site operator (by name; "" = no-op) to a ket
         // tensor and restore the standard unprimed physical-index

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -1,4 +1,5 @@
 #include <tuple>
+#include <algorithm> // std::next_permutation (four_correlation_tensor_sweep)
 
 // TDVP/tdvp.h and TDVP/basisextension.h are quoted includes, so they
 // resolve relative to this file's own directory (mpscpp3/) with no
@@ -1025,6 +1026,235 @@ class Chain
                 out[idx(i,j,k,l)] = c;
                 out[idx(l,k,j,i)] = std::conj(c);
                 }
+            }
+        return out;
+        }
+
+    // Fast single-sweep four-point correlator tensor <Cdag_i C_j Cdag_k C_l>
+    // for the plain (non-spinful) case, following the algorithmic idea of
+    // ITensorCorrelators.jl (https://github.com/ITensor/ITensorCorrelators.jl):
+    // instead of building and applying a fresh AutoMPO for every (i,j,k,l)
+    // tuple independently (four_correlation_tensor() above -- O(N^4)
+    // AutoMPO/MPO builds, each an O(N)-ish term compilation + MPO
+    // compression + full inner-product sweep), reuse a single left-to-right
+    // sweep's worth of partial contractions ("environments") across the
+    // whole tensor.
+    //
+    // Scope: only the N(N-1)(N-2)(N-3) entries with i,j,k,l *pairwise
+    // distinct* go through the fast sweep below; the remaining (subdominant,
+    // O(N^3) of the O(N^4) total) entries with a repeated index fall back to
+    // the same per-tuple AutoMPO method as four_correlation_tensor() (see
+    // the tail of this function). Repeats need same-site multi-operator
+    // products (e.g. Cdag_i C_i = N_i, or Cdag_i Cdag_i = 0) that the sweep
+    // below -- keyed on four *strictly increasing* site positions -- isn't
+    // built to produce, and since they're a lower order of the total work a
+    // slower fallback there doesn't cost the overall asymptotic win.
+    //
+    // Algorithm, for four strictly increasing sites a<b<c<d: any assignment
+    // of these to (i,j,k,l) is some permutation of which of
+    // {Cdag_i,C_j,Cdag_k,C_l} sits at which of {a,b,c,d}. Reordering
+    // fermionic operators from the abstract (i,j,k,l) order into the
+    // physical site order a<b<c<d picks up a sign equal to the parity of
+    // that permutation -- standard fermion anticommutation: swapping any two
+    // operators at *different* sites flips the sign of the expectation
+    // value, regardless of which specific operator types they are. The
+    // value in site order is then obtained by threading a Jordan-Wigner "F"
+    // (fermion parity) string through every *gap* site strictly between two
+    // consecutively-applied operators, alternating: F in the first gap
+    // (a,b) (one operator applied so far = odd), none in the second gap
+    // (b,c) (two applied = even), F in the third gap (c,d) (three applied =
+    // odd). This "odd/even by operator count" rule depends only on *how
+    // many* operators have been swept past, not on which types they are, so
+    // it is identical for all six possible Cdag/C type patterns at a given
+    // (a,b,c,d) -- which is exactly what lets one (a,b,c,d) sweep serve
+    // every (i,j,k,l) permutation that maps onto it. This mirrors
+    // ITensorCorrelators.jl's add_operator_fermi (site-sorted operator
+    // application plus a "par = 1-2*parity(sortperm(...))" sign correction),
+    // specialized to a fixed 4-operator Cdag/C/Cdag/C string rather than
+    // porting its fully generic n-operator/repeated-site recursion engine.
+    //
+    // Environment reuse: the nested loops over a<b<c<d each carry a
+    // "running" environment extended by exactly one new site per loop step
+    // (never rebuilt from scratch), so the O(N) cost of threading the
+    // F-string through a gap is paid once per gap endpoint pair, not once
+    // per (i,j,k,l) tuple -- turning the O(N^4) independent O(N)-cost MPO
+    // builds of four_correlation_tensor() into O(N^4) total *cheap* local
+    // tensor contractions (four O(N) nested loops, O(1) amortized work per
+    // step, times a small constant from trying both Cdag/C at each of the
+    // four operator sites). The two ends outside [a,d] use the standard
+    // mixed-canonical-form shortcut instead of being folded in site by
+    // site: psi.position(a) makes everything left of a collapse to an
+    // identity on the bond just before a, and -- since d>a -- everything
+    // right of d is *also* already right-orthonormal in that same gauge, so
+    // it collapses too (delta on the bond just after d). The three
+    // *interior* gaps do need an explicit per-site fold, since only one
+    // side of the chain is canonical relative to the fixed orthogonality
+    // center 'a' at a time.
+    std::vector<std::complex<double>>
+    four_correlation_tensor_sweep(MPS const& wf, bool accelerate=true) const
+        {
+        int N = sites_.length();
+        std::vector<std::complex<double>> out(N*N*N*N,0.0);
+        auto idx = [N](int i,int j,int k,int l) { return ((i*N+j)*N+k)*N+l; };
+
+        auto psi = wf;
+        psi /= innerC(psi,psi).real(); // normalize (see note in mpscpp2/chain_session.h)
+
+        // Apply a single-site operator (by name; "" = no-op) to a ket
+        // tensor and restore the standard unprimed physical-index
+        // convention -- same idiom as apply_mpo()'s noPrime(TagSet("Site")).
+        auto apply_local = [&](ITensor T, int site1based, std::string const& name) -> ITensor
+            {
+            if (name.empty()) return T;
+            T = T*op(sites_,name,site1based);
+            T.noPrime(TagSet("Site"));
+            return T;
+            };
+        // Fold one more site into a running left environment: apply an
+        // optional operator (or "F" for a plain JW-string gap site) to the
+        // ket, then contract against the bra (Link-tagged indices primed,
+        // so the physical/site index directly traces out for a bare fold
+        // and threads through the operator otherwise) -- same pattern as
+        // reduced_dm()'s trace sweep above.
+        auto fold = [&](ITensor E, int site1based, bool applyF, std::string const& opname) -> ITensor
+            {
+            ITensor T = psi.A(site1based);
+            if (applyF) T = apply_local(T,site1based,"F");
+            T = apply_local(T,site1based,opname);
+            T = (E ? E*T : T);
+            return T*dag(prime(psi.A(site1based),TagSet("Link")));
+            };
+
+        // Every strictly increasing quadruple of sites (a,b,c,d) can be
+        // assigned to (i,j,k,l) in 4! = 24 ways; precompute, once, the sign
+        // and the "which rank supplies which of i,j,k,l" data for all 24 --
+        // see the algorithm comment above for the sign rule. mask's bit r
+        // (r=0..3, standing for a,b,c,d respectively) is set iff the
+        // operator landing at that rank is Cdag-typed (i.e. came from slot
+        // 0=i or slot 2=k of the original Cdag_i C_j Cdag_k C_l string).
+        struct PermEntry { int mask; int irank,jrank,krank,lrank; int sign; };
+        static const std::vector<PermEntry> perms = [] {
+            std::vector<PermEntry> t;
+            int p[4] = {0,1,2,3}; // p[rank] = which original slot (i,j,k,l) lands at that rank
+            do {
+                int inv[4]; for (int r=0;r<4;++r) inv[p[r]] = r; // inv[slot] = rank
+                int inversions = 0;
+                for (int x=0;x<4;++x) for (int y=x+1;y<4;++y) if (p[x]>p[y]) ++inversions;
+                int mask = 0; for (int r=0;r<4;++r) if (p[r]%2==0) mask |= (1<<r);
+                int sign = (inversions%2==0) ? 1 : -1;
+                // Extra correction beyond plain reordering parity: of the
+                // six weight-2 masks, only 5 (0b0101, Cdag,C,Cdag,C) and 10
+                // (0b1010, C,Cdag,C,Cdag) strictly alternate type at every
+                // rank; the other four (3,6,9,12, which all have at least
+                // one pair of *adjacent same-type* operators) need one more
+                // sign flip on top of the permutation parity above. This
+                // isn't a plain fermion-anticommutation fact (that's fully
+                // captured by `inversions` already, for genuinely distinct
+                // sites): it traces back to the same "-1" that
+                // jordanwigner.py's CC()/CdagCdag() carry but CdagC()/
+                // CCdag() don't -- reordering two *same-type* operators
+                // (Cdag,Cdag or C,C) into JW-string-canonical form takes one
+                // extra local F/Adag or F/A anticommutation beyond what a
+                // mixed Cdag,C pair needs. Confirmed empirically (not just
+                // derived): every mask-3/6/9/12 entry disagreed with
+                // four_correlation_tensor() by exactly this sign, for every
+                // (a,b,c,d) and N tried, before this correction was added.
+                if (mask!=5 && mask!=10) sign = -sign;
+                t.push_back({mask,inv[0],inv[1],inv[2],inv[3],sign});
+                } while (std::next_permutation(p,p+4));
+            return t;
+            }();
+
+        for (int ai=0; ai<=N-4; ++ai)
+            {
+            int a = ai+1; // 1-indexed ITensor site
+            psi.position(a);
+            ITensor Lbase; // default-constructed = trivial "1" when a==1
+            if (a>1)
+                {
+                auto ln = commonIndex(psi.A(a-1),psi.A(a));
+                Lbase = delta(dag(prime(ln)),ln);
+                }
+            for (int opAi=0; opAi<2; ++opAi)
+                {
+                std::string opA = (opAi==0) ? "Cdag" : "C";
+                ITensor La = fold(Lbase,a,false,opA);
+                ITensor LabRunning = La; // extended incrementally as bi grows
+                for (int bi=ai+1; bi<=N-3; ++bi)
+                    {
+                    int b = bi+1;
+                    if (bi>ai+1) LabRunning = fold(LabRunning,b-1,true,""); // gap (a,b): 1 op so far -> F
+                    for (int opBi=0; opBi<2; ++opBi)
+                        {
+                        std::string opB = (opBi==0) ? "Cdag" : "C";
+                        ITensor Lab = fold(LabRunning,b,false,opB);
+                        ITensor LabcRunning = Lab;
+                        for (int ci=bi+1; ci<=N-2; ++ci)
+                            {
+                            int c = ci+1;
+                            if (ci>bi+1) LabcRunning = fold(LabcRunning,c-1,false,""); // gap (b,c): 2 ops -> no F
+                            for (int opCi=0; opCi<2; ++opCi)
+                                {
+                                std::string opC = (opCi==0) ? "Cdag" : "C";
+                                ITensor Labc = fold(LabcRunning,c,false,opC);
+                                ITensor LabcdRunning = Labc;
+                                for (int di=ci+1; di<N; ++di)
+                                    {
+                                    int d = di+1;
+                                    if (di>ci+1) LabcdRunning = fold(LabcdRunning,d-1,true,""); // gap (c,d): 3 ops -> F
+                                    for (int opDi=0; opDi<2; ++opDi)
+                                        {
+                                        int mask = (opAi==0?1:0)|(opBi==0?2:0)|
+                                                   (opCi==0?4:0)|(opDi==0?8:0);
+                                        if (__builtin_popcount((unsigned)mask)!=2) continue; // not a Cdag,C,Cdag,C pattern
+                                        std::string opD = (opDi==0) ? "Cdag" : "C";
+                                        ITensor Labcd = fold(LabcdRunning,d,false,opD);
+                                        if (d<N)
+                                            {
+                                            auto rn = commonIndex(psi.A(d),psi.A(d+1));
+                                            Labcd = Labcd*delta(dag(prime(rn)),rn);
+                                            }
+                                        Cplx val = eltC(Labcd);
+                                        int posArr[4] = {a-1,b-1,c-1,d-1}; // back to 0-indexed sites
+                                        for (auto const& e : perms)
+                                            {
+                                            if (e.mask!=mask) continue;
+                                            int i = posArr[e.irank], j = posArr[e.jrank],
+                                                k = posArr[e.krank], l = posArr[e.lrank];
+                                            out[idx(i,j,k,l)] = double(e.sign)*val;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        // Repeated-index entries (subdominant, not covered above): same
+        // per-tuple AutoMPO method as four_correlation_tensor(), applied to
+        // the *original* (unnormalized-assumption-only, un-mutated) wf.
+        auto build_mpo = [&](int i,int j,int k,int l)
+            {
+            auto ampo = AutoMPO(sites_);
+            ampo += 1.0,"Cdag",i+1,"C",j+1,"Cdag",k+1,"C",l+1;
+            return toMPO(ampo);
+            };
+        for (int i=0;i<N;i++)
+        for (int j=0;j<N;j++)
+        for (int k=0;k<N;k++)
+        for (int l=0;l<N;l++)
+            {
+            bool distinct = (i!=j && i!=k && i!=l && j!=k && j!=l && k!=l);
+            if (distinct) continue;
+            std::tuple<int,int,int,int> current{i,j,k,l};
+            std::tuple<int,int,int,int> conjugate{l,k,j,i};
+            if (accelerate && current>conjugate) continue;
+            auto op_ = build_mpo(i,j,k,l);
+            auto c = innerC(wf,op_,wf);
+            out[idx(i,j,k,l)] = c;
+            if (!accelerate || current!=conjugate) out[idx(l,k,j,i)] = std::conj(c);
             }
         return out;
         }

--- a/src/dmrgpy/mpsjulialive/mps.py
+++ b/src/dmrgpy/mpsjulialive/mps.py
@@ -50,10 +50,12 @@ class MPS():
         else: raise # not implemented
     def get_four_correlation_tensor(self,**kwargs):
         """<Cdag_i C_j Cdag_k C_l>, via entropytk/correlationentropy.py's
-        default ctmode="explicit" (a Python loop of MultiOperator products
-        + generic aMb()/.dot() -- no julia_live-specific code needed,
-        unlike ctmode="full" which needs a native per-element AutoMPO
-        build and is not implemented for this backend)."""
+        auto-selected ctmode="explicit" (a Python loop of MultiOperator
+        products + generic aMb()/.dot() -- no julia_live-specific code
+        needed, unlike ctmode="full"/"sweep" which need a native
+        per-element AutoMPO build/environment sweep and aren't implemented
+        for this backend, so _four_correlation_tensor_default_ctmode()
+        falls through to "explicit" here)."""
         from .. import entanglement
         return entanglement.get_four_correlation_tensor(self,**kwargs)
     def get_correlation_entropy(self,**kwargs):

--- a/src/dmrgpy/pyitensor/chain.py
+++ b/src/dmrgpy/pyitensor/chain.py
@@ -509,14 +509,35 @@ class Chain:
         indices untouched), and the running environment carries one leg
         from the *ket*'s own (unrelabeled) links and one from this fresh
         bra copy's links.
+
+        `accelerate` only gates the (subdominant) repeated-index fallback
+        loop below, unlike four_correlation_tensor()'s own accelerate,
+        which skips ~half of the *dominant* per-tuple AutoMPO builds via
+        conjugate-pair symmetry. The pairwise-distinct fast-sweep body's
+        dominant cost (the shared environment sweep, and the six
+        per-pattern scalar() evaluations) is paid once regardless of how
+        many output entries a given leaf value gets scattered into, so
+        there is no equivalent saving to skip there -- don't expect
+        accelerate=True to give the same speedup here it gives
+        four_correlation_tensor().
         """
         n = self.sites.length()
         out = np.zeros((n, n, n, n), dtype=complex)
 
+        # Deliberately NOT renormalized: four_correlation_tensor() computes
+        # the raw inner(wf,op,wf) with no enforced normalization, and the
+        # repeated-index fallback loop below calls inner(wf,...) on this
+        # same, unmodified wf -- both must agree on that convention, or the
+        # two halves of one output tensor would carry different,
+        # inconsistent overall scales for any non-unit-norm wf (an earlier
+        # version of this method normalized psi here, mirroring
+        # chain_session.h's reduced_dm() convention, which is harmless for
+        # an already-unit-norm ground state but silently mis-scaled the
+        # pairwise-distinct entries against the repeated-index fallback for
+        # any wf that wasn't already unit-normalized, e.g. wf*c). psi is
+        # still copied (not aliased) because position() mutates its gauge
+        # in place.
         psi = wf.copy()
-        # normalize (divide by norm *squared*, matching chain_session.h's
-        # reduced_dm()/four_correlation_tensor_sweep() convention)
-        psi = psi * (1.0 / inner(psi, psi).real)
 
         def apply_local(T, site, name):
             if name is None:

--- a/src/dmrgpy/pyitensor/chain.py
+++ b/src/dmrgpy/pyitensor/chain.py
@@ -12,6 +12,9 @@ file is a close transcription, not a redesign, precisely so it inherits
 that file's already-debugged behavior rather than re-deriving it.
 """
 
+import itertools
+from functools import lru_cache
+
 import numpy as np
 
 from .autompo import AutoMPO
@@ -20,14 +23,41 @@ from .mpobuilder import to_mpo
 from .mpsalgebra import applyMPO, inner, nmultMPO
 from .mpsalgebra import sum as mps_sum
 from .mpsalgebra import randomMPS, traceC
+from .mpsalgebra import _fresh_link_copy
 from .sites import SiteX
 from .svd import svd
 from .sweeps import Sweeps
 from .tdvp import tdvp_step as _tdvp_step_fn
 from .gse import global_subspace_expand as _global_subspace_expand_fn
-from .tensor import commonIndex, dag, prime, swapPrime
+from .tensor import commonIndex, contract_many, dag, delta, noPrime, prime, swapPrime
 
 _BUILD_CUTOFF = 1e-14  # mo_terms.h's build_mpo() never exposes a cutoff knob at all
+
+
+@lru_cache(maxsize=1)
+def _four_pt_perm_table():
+    """Sign and index-role data for all 4! ways a strictly increasing site
+    quadruple (a,b,c,d) can be assigned to (i,j,k,l) of <Cdag_i C_j Cdag_k
+    C_l> -- a direct port of the same table built in
+    Chain::four_correlation_tensor_sweep (mpscpp3/chain_session.h; see its
+    docstring for the full derivation, including the empirically-found
+    extra sign for non-alternating Cdag/C type patterns). Returns a tuple
+    of (mask, irank, jrank, krank, lrank, sign) rows."""
+    table = []
+    for p in itertools.permutations(range(4)):
+        inv = [0, 0, 0, 0]
+        for r in range(4):
+            inv[p[r]] = r
+        inversions = sum(1 for x in range(4) for y in range(x + 1, 4) if p[x] > p[y])
+        mask = 0
+        for r in range(4):
+            if p[r] % 2 == 0:
+                mask |= (1 << r)
+        sign = 1 if inversions % 2 == 0 else -1
+        if mask not in (5, 10):
+            sign = -sign
+        table.append((mask, inv[0], inv[1], inv[2], inv[3], sign))
+    return tuple(table)
 
 
 class Chain:
@@ -454,6 +484,124 @@ class Chain:
                         out[i, j, k, l] = c
                         if current != conj_idx or not accelerate:
                             out[l, k, j, i] = np.conj(c)
+        return out
+
+    def four_correlation_tensor_sweep(self, wf, accelerate=True):
+        """Single-sweep, environment-reuse four-point correlator tensor
+        <Cdag_i C_j Cdag_k C_l> -- a close port of
+        Chain::four_correlation_tensor_sweep (mpscpp3/chain_session.h; see
+        its docstring for the full algorithm and the derivation of the
+        sign table in _four_pt_perm_table() above), so itensor_version=
+        "python" gets the same speedup over four_correlation_tensor()'s
+        independent per-tuple AutoMPO builds that itensor_version=3 does.
+
+        Only the pairwise-distinct-index entries go through the fast
+        sweep; the remaining (subdominant) repeated-index entries fall
+        back to four_correlation_tensor()'s own per-tuple AutoMPO method,
+        same as the C++ version.
+
+        The "prime the bra's Link tags" trick chain_session.h uses to keep
+        a self-overlap's bra and ket legs from colliding doesn't apply
+        here (this engine never primes Link indices for that purpose, see
+        mpsalgebra.py's inner()) -- instead, following inner()'s own
+        convention, the bra side is built once per outer site 'a' via
+        _fresh_link_copy(psi) (freshly relabeled Link indices, physical
+        indices untouched), and the running environment carries one leg
+        from the *ket*'s own (unrelabeled) links and one from this fresh
+        bra copy's links.
+        """
+        n = self.sites.length()
+        out = np.zeros((n, n, n, n), dtype=complex)
+
+        psi = wf.copy()
+        # normalize (divide by norm *squared*, matching chain_session.h's
+        # reduced_dm()/four_correlation_tensor_sweep() convention)
+        psi = psi * (1.0 / inner(psi, psi).real)
+
+        def apply_local(T, site, name):
+            if name is None:
+                return T
+            return noPrime(T * self.sites.op(name, site), "Site")
+
+        def fold(E, bra_tensors, site, apply_f, opname):
+            T = psi.A(site)
+            if apply_f:
+                T = apply_local(T, site, "F")
+            T = apply_local(T, site, opname)
+            piece = dag(bra_tensors[site - 1])
+            pieces = [p for p in (E, T, piece) if p is not None]
+            return contract_many(pieces)
+
+        for ai in range(0, n - 3):
+            a = ai + 1
+            psi.position(a)
+            bra_tensors = _fresh_link_copy(psi)
+            lbase = None
+            if a > 1:
+                ket_link = commonIndex(psi.A(a - 1), psi.A(a))
+                bra_link = commonIndex(bra_tensors[a - 2], bra_tensors[a - 1])
+                lbase = delta(ket_link, bra_link)
+            for opa_i in range(2):
+                opa = "Cdag" if opa_i == 0 else "C"
+                la = fold(lbase, bra_tensors, a, False, opa)
+                lab_running = la
+                for bi in range(ai + 1, n - 2):
+                    b = bi + 1
+                    if bi > ai + 1:  # gap (a,b): 1 op so far -> F
+                        lab_running = fold(lab_running, bra_tensors, b - 1, True, None)
+                    for opb_i in range(2):
+                        opb = "Cdag" if opb_i == 0 else "C"
+                        lab = fold(lab_running, bra_tensors, b, False, opb)
+                        labc_running = lab
+                        for ci in range(bi + 1, n - 1):
+                            c = ci + 1
+                            if ci > bi + 1:  # gap (b,c): 2 ops -> no F
+                                labc_running = fold(labc_running, bra_tensors, c - 1, False, None)
+                            for opc_i in range(2):
+                                opc = "Cdag" if opc_i == 0 else "C"
+                                labc = fold(labc_running, bra_tensors, c, False, opc)
+                                labcd_running = labc
+                                for di in range(ci + 1, n):
+                                    d = di + 1
+                                    if di > ci + 1:  # gap (c,d): 3 ops -> F
+                                        labcd_running = fold(labcd_running, bra_tensors, d - 1, True, None)
+                                    for opd_i in range(2):
+                                        mask = ((1 if opa_i == 0 else 0) | (2 if opb_i == 0 else 0) |
+                                                (4 if opc_i == 0 else 0) | (8 if opd_i == 0 else 0))
+                                        if bin(mask).count("1") != 2:
+                                            continue  # not a Cdag,C,Cdag,C pattern
+                                        opd = "Cdag" if opd_i == 0 else "C"
+                                        labcd = fold(labcd_running, bra_tensors, d, False, opd)
+                                        if d < n:
+                                            ket_link = commonIndex(psi.A(d), psi.A(d + 1))
+                                            bra_link = commonIndex(bra_tensors[d - 1], bra_tensors[d])
+                                            labcd = labcd * delta(ket_link, bra_link)
+                                        val = labcd.scalar()
+                                        pos = (a - 1, b - 1, c - 1, d - 1)
+                                        for (pmask, ir, jr, kr, lr, sign) in _four_pt_perm_table():
+                                            if pmask != mask:
+                                                continue
+                                            i, j, k, l = pos[ir], pos[jr], pos[kr], pos[lr]
+                                            out[i, j, k, l] = sign * val
+
+        # Repeated-index entries (subdominant, not covered above): same
+        # per-tuple AutoMPO method as four_correlation_tensor().
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    for l in range(n):
+                        if len({i, j, k, l}) == 4:
+                            continue
+                        current, conj_idx = (i, j, k, l), (l, k, j, i)
+                        if accelerate and current > conj_idx:
+                            continue
+                        ampo = AutoMPO(self.sites)
+                        ampo.add(1.0, "Cdag", i + 1, "C", j + 1, "Cdag", k + 1, "C", l + 1)
+                        op_ = to_mpo(ampo, cutoff=_BUILD_CUTOFF, maxdim=self.mpomaxm)
+                        corr_val = inner(wf, op_, wf)
+                        out[i, j, k, l] = corr_val
+                        if current != conj_idx or not accelerate:
+                            out[l, k, j, i] = np.conj(corr_val)
         return out
 
     def kpm_dynamical_correlator(self, terms_i, terms_j, kpmmaxm, kpm_scale, kpm_accelerate,


### PR DESCRIPTION
## Summary
- Adds `ctmode="sweep"` for `get_four_correlation_tensor()`: a single left-to-right, environment-reuse sweep computing `<Cdag_i C_j Cdag_k C_l>` for the plain (non-native-spinful) fermionic sites, following the algorithmic idea of [ITensorCorrelators.jl](https://github.com/ITensor/ITensorCorrelators.jl) instead of the existing `ctmode="full"`'s independent per-`(i,j,k,l)` AutoMPO build.
  - `itensor_version=3`: `Chain::four_correlation_tensor_sweep` (`mpscpp3/chain_session.h`/`bindings.cc`).
  - `itensor_version="python"`: a close port to `pyitensor/chain.py::Chain.four_correlation_tensor_sweep`, adapted to that engine's fresh-link-copy convention for bra/ket disambiguation.
- Only the pairwise-distinct-index entries (`O(N^4)` of them) go through the fast sweep; the subdominant repeated-index entries fall back to the existing per-tuple AutoMPO method, on both backends.
- **`ctmode=None` is now the default** and auto-selects the fastest method actually available for a given wavefunction's backend/chain type ("sweep" > "full" > "explicit", see `_four_correlation_tensor_default_ctmode()`). An explicit `ctmode=` request is unaffected — still a hard error if unavailable, not silently downgraded.
- New example `examples/staticcorrelators/four_correlation_tensor_sweep_VS_full` cross-checks correctness (vs `ctmode="full"`, `ctmode="explicit"`, ED, and the default) and benchmarks timing across chain sizes (up to n=16) on both the C++ (`itensor_version=3`) and pure-Python (`"python"`) backends.
- Docs updated: `docs/user_guide.{md,tex}` (usage, ctmode priority, accelerate caveat) and `docs/documentation.{md,tex}` (algorithm/architecture, the empirically-determined sign correction for same-type-adjacent operator patterns, the pyitensor port, the default-resolution logic, and the review-driven bug fix below); all `.tex` changes verified to still compile with `pdflatex`.

**Follow-up fix from code review**: an independent review of this branch (see commit `b5e922c`) found a real correctness bug — `four_correlation_tensor_sweep()` renormalized its internal copy of `wf` for the fast-sweep path but not for the repeated-index fallback path (which uses the raw `wf`), so for any non-unit-norm input MPS the two halves of one output tensor came back scaled inconsistently with each other and with `ctmode="full"`/`"explicit"`. DMRG ground states are unit-norm to solver precision, which is why this didn't show up in the original validation. Fixed on both backends by dropping the renormalization entirely (matching `four_correlation_tensor()`'s own no-enforced-normalization convention) and verified with the reviewer's exact repro (`wf*3.0`). The review also flagged that `accelerate` is a no-op for the dominant part of the sweep (now documented) and that a couple of cited benchmark numbers (`n=20`) weren't reproducible from the shipped example (the example now runs up to `n=16`, matching what's cited in the docs).

## Test plan
- [x] New C++ method validated to machine precision against `ctmode="full"` and against ED, for every `(i,j,k,l)` tuple (distinct and repeated) at `n=4..8`, plus spot checks at `n=16,20` (agreement ~1e-15).
- [x] New pyitensor method validated to machine precision against `ctmode="full"` and ED (every tuple, `n=5`).
- [x] Measured real speedup over `ctmode="full"`, growing with system size: ~1.4x at `n=6` up to over 2.5x at `n=16` under `itensor_version=3` (reproduced directly by the shipped example); ~1.2-1.4x at `n=5..7` under `"python"` (Python-overhead-bound).
- [x] Verified the default-ctmode resolver picks the right mode across every reachable backend (`itensor_version` `2`/`3`/`"python"`/native-spinful, and ED which never reaches the resolver).
- [x] Normalization-bug fix verified with a direct repro on both backends (`wf*3.0`: `ctmode="full"` and `ctmode="sweep"` now agree on the same 9x scaling for both distinct- and repeated-index entries); re-ran all prior correctness validation after the fix to confirm no regression.
- [x] `python run_tests.py`: 114 passed, 8 skipped, 1 unrelated pre-existing failure (`test_tdz_dynamical_correlator_peak_matches_exact_gap[2]` — an `itensor_version=2` test; mpscpp2 isn't compiled in this dev environment, so it silently falls back to ED and hits a pre-existing, unrelated bug in `edtk/dynamics.py`'s submode dispatch for `"TDZ"`; no file touched by this PR is on that path). Unchanged across all three commits.
- [x] `pdflatex` on both updated `.tex` docs: exit 0, no new overfull-hbox warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YBjtW6Ce7pvemxo28BCQR