### PR TITLE
Fix silent truncation bug in ED finite-temperature vev

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -811,9 +811,18 @@ from dmrgpy import thermal
 tc = thermal.Thermal_Spin_Chain(spins, T=0.1)
 ```
 
-`T=0` recovers ordinary ground-state DMRG. For small systems ($n\lesssim
-14$), `get_correlation_matrix(T=...)` instead computes the exact thermal
-average directly by brute-force ED, $\rho=\sum_nZ^{-1}e^{-E_n/T}|n\rangle\langle n|$ — a useful cross-check of the purification approach.
+`T=0` recovers ordinary ground-state DMRG. For small systems (Hilbert
+space dimension $\lesssim2000$, `algebra.maxsize`), `get_correlation_matrix(T=...)`
+(ED only, `entropytk/correlationentropy.py`'s `get_correlation_matrix_finiteT`)
+instead computes the exact thermal average directly by brute-force ED,
+$\rho=\sum_nP_n|n\rangle\langle n|$, $P_n=Z^{-1}e^{-(E_n-E_0)/T}$ — a
+useful cross-check of the purification approach, following the same
+excited-states pattern as `vev(mode="ED", T=...)` below (full spectrum
+whenever it's small enough to diagonalize exactly, an explicit `n=` and
+a `RuntimeError` on inadequate truncation otherwise). Automatic default
+operators (no `operators=` kwarg) are only defined for fermionic chains
+today (`self.C`); on a `Spin_Chain`/`Thermal_Spin_Chain` pass an explicit
+`operators=[...]` (e.g.\ `[sc.Sz[i] for i in range(n)]`).
 
 **`vev(O, mode="ED", T=...)`** is a second, independent way to get the
 same brute-force ED thermal average

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -815,6 +815,24 @@ tc = thermal.Thermal_Spin_Chain(spins, T=0.1)
 14$), `get_correlation_matrix(T=...)` instead computes the exact thermal
 average directly by brute-force ED, $\rho=\sum_nZ^{-1}e^{-E_n/T}|n\rangle\langle n|$ — a useful cross-check of the purification approach.
 
+**`vev(O, mode="ED", T=...)`** is a second, independent way to get the
+same brute-force ED thermal average
+$\langle O\rangle=\sum_nP_n\langle n|O|n\rangle$, $P_n=Z^{-1}e^{-(E_n-E_0)/T}$,
+for a single operator rather than the whole correlation matrix
+(`edtk/edchain.py`'s `EDchain.vev` → `vevtk/thermalvev.py`'s
+`thermal_vev_ex`). The sum only ever runs over a finite set of exact
+eigenstates obtained from `algebra.lowest_states`; whenever the full
+Hilbert space is small enough to diagonalize exactly anyway (the same
+`maxsize=2000`-state threshold `algebra.lowest_states` itself uses),
+`thermal_vev_ex` defaults to using the *entire* spectrum, so the thermal
+average is exact for any `T`. Above that size only a sparse, truncated
+set of the lowest states is available (an explicit `n=` kwarg, forwarded
+from `vev(...)`, controls how many); `thermal_vev_ex` then checks the
+Boltzmann weight of the highest included state and raises `RuntimeError`
+rather than silently returning a wrong average if that state still
+carries non-negligible weight at the requested `T` — pass a larger `n=`
+in that case.
+
 ## 10. Topological invariants
 
 **Many-body Berry phase.** For a ground state that depends on an

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -958,11 +958,21 @@ from dmrgpy import thermal
 tc = thermal.Thermal_Spin_Chain(spins, T=0.1)
 \end{lstlisting}
 
-$T=0$ recovers ordinary ground-state DMRG. For small systems
-($n\lesssim14$), \texttt{get\_correlation\_matrix(T=...)} instead
-computes the exact thermal average directly by brute-force ED,
-$\rho=\sum_nZ^{-1}e^{-E_n/T}|n\rangle\langle n|$ --- a useful
-cross-check of the purification approach.
+$T=0$ recovers ordinary ground-state DMRG. For small systems (Hilbert
+space dimension $\lesssim2000$, \texttt{algebra.maxsize}),
+\texttt{get\_correlation\_matrix(T=...)} (ED only,
+\texttt{entropytk/correlationentropy.py}'s
+\texttt{get\_correlation\_matrix\_finiteT}) instead computes the exact
+thermal average directly by brute-force ED,
+$\rho=\sum_nP_n|n\rangle\langle n|$, $P_n=Z^{-1}e^{-(E_n-E_0)/T}$ --- a
+useful cross-check of the purification approach, following the same
+excited-states pattern as \texttt{vev(mode="ED", T=...)} below (full
+spectrum whenever it's small enough to diagonalize exactly, an explicit
+\texttt{n=} and a \texttt{RuntimeError} on inadequate truncation
+otherwise). Automatic default operators (no \texttt{operators=} kwarg)
+are only defined for fermionic chains today (\texttt{self.C}); on a
+\texttt{Spin\_Chain}/\texttt{Thermal\_Spin\_Chain} pass an explicit
+\texttt{operators=[...]} (e.g.\ \texttt{[sc.Sz[i] for i in range(n)]}).
 
 \textbf{\texttt{vev(O, mode="ED", T=...)}} is a second, independent way
 to get the same brute-force ED thermal average

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -964,6 +964,26 @@ computes the exact thermal average directly by brute-force ED,
 $\rho=\sum_nZ^{-1}e^{-E_n/T}|n\rangle\langle n|$ --- a useful
 cross-check of the purification approach.
 
+\textbf{\texttt{vev(O, mode="ED", T=...)}} is a second, independent way
+to get the same brute-force ED thermal average
+$\langle O\rangle=\sum_nP_n\langle n|O|n\rangle$,
+$P_n=Z^{-1}e^{-(E_n-E_0)/T}$, for a single operator rather than the whole
+correlation matrix (\texttt{edtk/edchain.py}'s \texttt{EDchain.vev}
+$\to$ \texttt{vevtk/thermalvev.py}'s \texttt{thermal\_vev\_ex}). The sum
+only ever runs over a finite set of exact eigenstates obtained from
+\texttt{algebra.lowest\_states}; whenever the full Hilbert space is small
+enough to diagonalize exactly anyway (the same \texttt{maxsize=2000}-state
+threshold \texttt{algebra.lowest\_states} itself uses),
+\texttt{thermal\_vev\_ex} defaults to using the \emph{entire} spectrum,
+so the thermal average is exact for any $T$. Above that size only a
+sparse, truncated set of the lowest states is available (an explicit
+\texttt{n=} kwarg, forwarded from \texttt{vev(...)}, controls how many);
+\texttt{thermal\_vev\_ex} then checks the Boltzmann weight of the
+highest included state and raises \texttt{RuntimeError} rather than
+silently returning a wrong average if that state still carries
+non-negligible weight at the requested $T$ --- pass a larger \texttt{n=}
+in that case.
+
 \section{Topological invariants}
 
 \textbf{Many-body Berry phase.} For a ground state that depends on an

--- a/src/dmrgpy/edtk/edchain.py
+++ b/src/dmrgpy/edtk/edchain.py
@@ -63,7 +63,7 @@ class EDchain():
           self.e0 = e0
           self.computed_gs = True
           return self.wf0
-    def vev(self,op,T=0.):
+    def vev(self,op,T=0.,**kwargs):
         """Return a vacuum expectation value"""
         if T==0.: # zero temperature
             wf0 = self.get_gs_array()
@@ -71,7 +71,7 @@ class EDchain():
             return algebra.braket_wAw(wf0,op)
         else: # finite temperature
             from ..vevtk.thermalvev import thermal_vev_ex
-            return thermal_vev_ex(self,op,T=T) # return thermal VEV
+            return thermal_vev_ex(self,op,T=T,**kwargs) # return thermal VEV
     def get_excited(self,**kwargs):
         """Excited states"""
         h = self.get_hamiltonian()

--- a/src/dmrgpy/entropytk/correlationentropy.py
+++ b/src/dmrgpy/entropytk/correlationentropy.py
@@ -10,20 +10,43 @@ def get_correlation_matrix(self,T=0.,**kwargs):
 
 
 
-def get_correlation_matrix_finiteT(self,T=1.,**kwargs):
-    """Wrapper for finite temperature"""
-    ### This is currently only implemented with ED
-    n = len(self.C) # number of sites
-    if n>14: raise # not implemented
-    (es,wfs) = self.get_excited_states(mode="ED",n=2**n)
-    dms = [get_correlation_matrix_zeroT(self,wf=wf) for wf in wfs]
-    es = es - np.min(es) # minus ground state energy
-    dm = 0j # initialize
-    Z = 0. # initialize
-    for i in range(len(es)): # loop over energies
-        dm = dm + dms[i]*np.exp(es[i]/T)
-        Z = Z + np.exp(es[i]/T)
-    return dm/Z # return matrix
+def get_correlation_matrix_finiteT(self,T=1.,n=None,**kwargs):
+    """Correlation matrix at finite temperature, ED only: sum
+    Boltzmann-weighted per-eigenstate correlation matrices
+    (get_correlation_matrix_zeroT with wf=eigenstate) over a set of
+    exact eigenstates, exactly the same excited-states pattern as
+    vevtk.thermalvev.thermal_vev_ex -- `n` controls how many eigenstates
+    are summed over (default: the full Hilbert space whenever that's
+    small enough to diagonalize exactly, matching algebra.maxsize;
+    otherwise the same truncated n=10 that algebra.lowest_states falls
+    back to on its own). `**kwargs` (operators=, basis=, dmmode=, ...)
+    is forwarded to get_correlation_matrix_zeroT for each eigenstate,
+    not to the excited-state search.
+
+    A truncated sum whose highest-included state still carries
+    non-negligible Boltzmann weight raises RuntimeError instead of
+    silently returning a wrong average -- pass a larger n= in that case."""
+    from ..algebra.algebra import maxsize
+    dim = self.get_ED_obj().get_hamiltonian().shape[0] # full Hilbert space dimension
+    if n is None: # caller did not request a specific truncation
+        n_used = dim if dim<=maxsize else 10 # matches lowest_states' own default
+    else: n_used = n
+    truncated = n_used<dim # did we actually leave out any eigenstates?
+    (es,wfs) = self.get_excited_states(mode="ED",n=n_used)
+    es = es - np.min(es) # with respect to the GS
+    beta = 1./T
+    P = np.exp(-beta*es) # Boltzmann probabilities
+    P = P/np.sum(P) # normalize
+    if truncated and P[-1]>1e-6*np.max(P):
+        raise RuntimeError(
+            "get_correlation_matrix_finiteT: the "+str(n_used)+" excited states "
+            "computed do not capture the full Boltzmann weight at T="+str(T)+
+            " (highest included state has relative weight "+str(P[-1]/np.max(P))+
+            " of the largest). Pass a larger n= to include more excited states.")
+    dms = [get_correlation_matrix_zeroT(self,wf=wf,**kwargs) for wf in wfs]
+    dm = np.zeros_like(dms[0])
+    for i in range(len(es)): dm = dm + P[i]*dms[i] # Boltzmann-weighted average
+    return dm # return matrix
 
 
 

--- a/src/dmrgpy/vevtk/thermalvev.py
+++ b/src/dmrgpy/vevtk/thermalvev.py
@@ -1,4 +1,5 @@
 import numpy as np
+from ..algebra.algebra import maxsize
 
 
 def thermal_vev(MB,Op,submode="EX",**kwargs):
@@ -12,16 +13,34 @@ def thermal_vev(MB,Op,submode="EX",**kwargs):
 
 def thermal_vev_ex(MB,Op,mode="ED",T=0.,**kwargs):
     """Thermal VEV with excited states"""
+    dim = MB.get_hamiltonian().shape[0] # full Hilbert space dimension
+    n_requested = kwargs.get("n",None)
+    if n_requested is None: # caller did not ask for a specific truncation
+        if dim<=maxsize: # small enough to diagonalize exactly anyway
+            kwargs["n"] = dim # use the full spectrum, no truncation
+            n_used = dim
+        else: n_used = 10 # matches algebra.lowest_states' own default
+    else: n_used = n_requested
+    truncated = n_used<dim # did we actually leave out any eigenstates?
     (es,wfs) = MB.get_excited_states(mode=mode,**kwargs) # get excited states
     es = es - np.min(es) # with respect to the GS
     if T>0.: # finite temperature
         beta = 1./T # beta
         P = np.exp(-beta*es) # Boltzman probabilities
         P = P/np.sum(P) # normalize probabilities
-    else: 
+    else:
         print("Only finite temperature")
         raise # not implemented
-    if T>np.max(es):
-        print("Warning, highest excited state comparable to thermal energy, increase n=",T,np.max(es))
+    if truncated and P[-1]>1e-6*np.max(P):
+        # the highest computed excited state still carries non-negligible
+        # Boltzmann weight, so the states left out by the truncation are
+        # not safe to ignore: summing only over "n_used" would silently
+        # return a wrong thermal average instead of the true Tr(O exp(-beta H))/Z
+        raise RuntimeError(
+            "thermal_vev_ex: the "+str(n_used)+" excited states computed do not "
+            "capture the full Boltzmann weight at T="+str(T)+" (highest included "
+            "state has relative weight "+str(P[-1]/np.max(P))+" of the largest). "
+            "Pass a larger n= to edchain.vev()/thermal_vev_ex() to include more "
+            "excited states.")
     vals = np.array([wf.aMb(Op,wf) for wf in wfs]) # expectation values
     return np.sum(P*vals) # return the expectation value

--- a/tests/test_thermal_correlation_matrix.py
+++ b/tests/test_thermal_correlation_matrix.py
@@ -1,0 +1,118 @@
+"""Regression coverage for Many_Body_Chain.get_correlation_matrix(mode="ED",
+T=...) (entropytk/correlationentropy.py::get_correlation_matrix_finiteT).
+
+Before the fix, this had three independent bugs:
+
+1. Backward Boltzmann sign: `np.exp(es[i]/T)` instead of
+   `np.exp(-es[i]/T)`, so the "thermal" average was actually weighted
+   towards the *highest*-energy eigenstates instead of the lowest --
+   confirmed by comparing against the already-correct thermal `vev`
+   (post its own truncation fix, see test_thermal_vev.py), which for a
+   diagonal entry should agree exactly (`cm[i,i] == vev(N[i], T=...)`).
+2. A Hilbert-space-size guard based on `2**len(self.C)` (site count)
+   requested unconditionally, rather than the actual Hamiltonian
+   dimension against algebra.maxsize like vevtk.thermalvev.thermal_vev_ex
+   does -- for n=11 sites (2**11=2048 > algebra.maxsize=2000) this
+   unconditionally asked algebra.lowest_states for the *entire* spectrum
+   via a sparse ARPACK call requesting k=2048 eigenvectors of a
+   2048-dimensional operator, which scipy rejects outright
+   ("Cannot use scipy.linalg.eig for sparse A with k >= N - 1").
+3. No truncation-safety check at all (the T=0 vev bug's version at
+   least printed a warning): silently wrong for any temperature/size
+   combination where the default excited-state count didn't capture
+   the actual Boltzmann tail.
+
+Fixed by modeling get_correlation_matrix_finiteT directly on
+thermal_vev_ex's already-correct pattern: get the true Hilbert
+dimension from get_ED_obj().get_hamiltonian().shape[0], default to the
+full spectrum only when that's small enough to diagonalize exactly,
+correct the Boltzmann sign, and raise RuntimeError instead of silently
+returning a wrong average when a truncated sum still carries
+non-negligible weight in its highest-included state.
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import fermionchain
+
+
+def _chain(n, bias=0.5):
+    fc = fermionchain.Fermionic_Chain(n)
+    h = 0
+    for i in range(n - 1):
+        h = h + fc.Cdag[i] * fc.C[i + 1] + fc.Cdag[i + 1] * fc.C[i]
+    h = h + bias * fc.N[0]
+    fc.set_hamiltonian(h)
+    return fc
+
+
+def test_correlation_matrix_diagonal_matches_thermal_vev():
+    """cm[i,i] = <N_i> at finite T, which must agree with the
+    independently-implemented, already-fixed thermal vev to machine
+    precision -- this is exactly the sign/normalization cross-check
+    that would have caught the backward-Boltzmann-sign bug (previously
+    cm[0,0] and vev(N[0]) summed to ~1, i.e. exactly swapped)."""
+    n = 6
+    fc = _chain(n)
+
+    for T in (0.01, 0.5, 2.0, 100.0):
+        cm = fc.get_correlation_matrix(T=T, mode="ED")
+        for i in range(n):
+            v = fc.vev(fc.N[i], mode="ED", T=T)
+            assert cm[i, i].real == pytest.approx(v.real, abs=1e-8)
+            assert cm[i, i].imag == pytest.approx(0., abs=1e-8)
+
+
+def test_correlation_matrix_is_hermitian():
+    fc = _chain(6)
+    cm = fc.get_correlation_matrix(T=1.0, mode="ED")
+    assert np.allclose(cm, cm.conj().T, atol=1e-10)
+
+
+def test_correlation_matrix_matches_full_spectrum_reference():
+    """Independent reference built directly with numpy.linalg.eigh on
+    the dense Hamiltonian (bypassing get_correlation_matrix_finiteT and
+    get_correlation_matrix_zeroT entirely), not a regression-pinned
+    golden value."""
+    n = 6
+    fc = _chain(n)
+    T = 0.7
+
+    edobj = fc.get_ED_obj()
+    Hd = np.array(edobj.get_hamiltonian().todense())
+    es, vs = np.linalg.eigh(Hd)
+    es = es - es.min()
+    P = np.exp(-es / T)
+    P /= P.sum()
+    Nd = [np.array(edobj.MO2matrix(fc.N[i]).todense()) for i in range(n)]
+
+    expected_diag = np.zeros(n)
+    for i in range(n):
+        vals = np.array([np.conjugate(vs[:, k]) @ Nd[i] @ vs[:, k] for k in range(len(es))])
+        expected_diag[i] = np.sum(P * vals).real
+
+    cm = fc.get_correlation_matrix(T=T, mode="ED")
+    assert np.diag(cm).real == pytest.approx(expected_diag, abs=1e-8)
+
+
+def test_correlation_matrix_previously_crashing_large_chain_now_works():
+    """n=11 sites -> Hilbert dim 2048 > algebra.maxsize=2000: the old
+    `2**len(self.C)` guard unconditionally requested the full spectrum
+    from a sparse ARPACK call, which scipy rejects for k>=N-1, crashing
+    outright regardless of T. At low enough T the (now dimension-aware)
+    default truncation is adequate and must agree with thermal vev."""
+    n = 11
+    fc = _chain(n)
+    T = 0.01
+
+    cm = fc.get_correlation_matrix(T=T, mode="ED")
+    v = fc.vev(fc.N[0], mode="ED", T=T)
+    assert cm[0, 0].real == pytest.approx(v.real, abs=1e-6)
+
+
+def test_correlation_matrix_raises_instead_of_silently_truncating():
+    """Explicitly requesting too few excited states for the temperature
+    must raise, not silently return a wrong matrix."""
+    fc = _chain(6)
+    with pytest.raises(RuntimeError):
+        fc.get_correlation_matrix(T=2.0, mode="ED", n=5)

--- a/tests/test_thermal_vev.py
+++ b/tests/test_thermal_vev.py
@@ -1,0 +1,111 @@
+"""Regression coverage for Many_Body_Chain.vev(mode="ED", T=...) (finite-
+temperature expectation values via edtk/edchain.py -> vevtk/thermalvev.py).
+
+thermal_vev_ex() sums Boltzmann-weighted <n|O|n> over a set of exact
+eigenstates obtained from algebra.lowest_states(), whose own default is
+n=10 -- previously that default was used unconditionally, so any chain
+with a Hilbert space bigger than 10 states silently summed over an
+arbitrary, temperature-independent 10-state subset instead of the full
+spectrum, giving a wrong thermal average with no error raised (only a
+weak, easy-to-miss "highest excited state comparable to thermal energy"
+print). Fixed by (1) defaulting n to the full Hilbert-space dimension
+whenever that's small enough for exact diagonalization anyway (matching
+what algebra.lowest_states does internally regardless), and (2) raising
+instead of merely printing when the states actually used still carry
+non-negligible Boltzmann weight -- see edtk/edchain.py::EDchain.vev and
+vevtk/thermalvev.py::thermal_vev_ex.
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import spinchain
+
+
+def test_single_spin_thermal_magnetization_matches_analytic():
+    """A single S=1/2 spin in a field, H = B*Sz, has exact eigenvalues
+    +-B/2 with <Sz> = +-1/2, so the thermal average has the textbook
+    closed form <Sz> = -1/2 * tanh(beta*B/2) -- an independent analytic
+    check, not a regression-pinned value."""
+    sc = spinchain.Spin_Chain(["S=1/2"])
+    B = 1.3
+    sc.set_hamiltonian(B * sc.Sz[0])
+
+    for T in (0.3, 0.7, 2.0, 10.0):
+        beta = 1. / T
+        expected = -0.5 * np.tanh(beta * B / 2.)
+        got = sc.vev(sc.Sz[0], mode="ED", T=T)
+        assert got.real == pytest.approx(expected, abs=1e-8)
+        assert got.imag == pytest.approx(0., abs=1e-8)
+
+
+def test_thermal_vev_default_matches_full_spectrum_reference():
+    """6-site Heisenberg chain + field (Hilbert dim 64): before the fix,
+    the default call silently summed over only the 10 lowest eigenstates
+    (algebra.lowest_states' own default) regardless of dim or T, which at
+    T=2.0 here previously returned ~-0.0975 instead of the true thermal
+    average. The chain's Hilbert space is small enough to diagonalize
+    exactly, so the default must now match an independently computed,
+    full-spectrum Boltzmann sum built directly with numpy.linalg.eigh
+    (bypassing thermal_vev_ex entirely) to any numerical precision."""
+    n = 6
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    h = 0
+    for i in range(n - 1):
+        h = h + sc.Sx[i] * sc.Sx[i + 1] + sc.Sy[i] * sc.Sy[i + 1] + sc.Sz[i] * sc.Sz[i + 1]
+    for i in range(n):
+        h = h + 0.3 * sc.Sz[i]
+    sc.set_hamiltonian(h)
+
+    T = 2.0
+    edobj = sc.get_ED_obj()
+    Hd = np.array(edobj.get_hamiltonian().todense())
+    assert Hd.shape[0] == 2 ** n
+
+    es, vs = np.linalg.eigh(Hd)
+    es = es - es.min()
+    P = np.exp(-es / T)
+    P /= P.sum()
+    Opd = np.array(edobj.MO2matrix(sc.Sz[0]).todense())
+    vals = np.array([np.conjugate(vs[:, i]) @ Opd @ vs[:, i] for i in range(len(es))])
+    expected = np.sum(P * vals).real
+
+    got = sc.vev(sc.Sz[0], mode="ED", T=T)
+    assert got.real == pytest.approx(expected, abs=1e-8)
+
+    # explicitly requesting the full spectrum must agree too
+    got_explicit = sc.vev(sc.Sz[0], mode="ED", T=T, n=Hd.shape[0])
+    assert got_explicit.real == pytest.approx(expected, abs=1e-8)
+
+
+def test_thermal_vev_raises_instead_of_silently_truncating():
+    """If the caller explicitly requests too few excited states for the
+    requested temperature, thermal_vev_ex must raise rather than
+    silently return a wrong average (the previous behavior: a print
+    warning, then a wrong number)."""
+    n = 6
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    h = 0
+    for i in range(n - 1):
+        h = h + sc.Sx[i] * sc.Sx[i + 1] + sc.Sy[i] * sc.Sy[i + 1] + sc.Sz[i] * sc.Sz[i + 1]
+    for i in range(n):
+        h = h + 0.3 * sc.Sz[i]
+    sc.set_hamiltonian(h)
+
+    with pytest.raises(RuntimeError):
+        sc.vev(sc.Sz[0], mode="ED", T=2.0, n=5)
+
+    # low enough T that only a handful of states carry any weight: same
+    # small n must NOT raise, and must still match the full-spectrum value
+    edobj = sc.get_ED_obj()
+    Hd = np.array(edobj.get_hamiltonian().todense())
+    es, vs = np.linalg.eigh(Hd)
+    es = es - es.min()
+    T_low = 0.05
+    P = np.exp(-es / T_low)
+    P /= P.sum()
+    Opd = np.array(edobj.MO2matrix(sc.Sz[0]).todense())
+    vals = np.array([np.conjugate(vs[:, i]) @ Opd @ vs[:, i] for i in range(len(es))])
+    expected_low = np.sum(P * vals).real
+
+    got_low = sc.vev(sc.Sz[0], mode="ED", T=T_low, n=5)
+    assert got_low.real == pytest.approx(expected_low, abs=1e-6)


### PR DESCRIPTION
## Summary

**1. `Many_Body_Chain.vev(mode="ED", T=...)` silent truncation bug** (`edtk/edchain.py`, `vevtk/thermalvev.py`)
- Silently summed Boltzmann weights over only the 10 lowest eigenstates by default (`algebra.lowest_states`' own `n=10` default), regardless of Hilbert-space size or temperature, with no way to override it through the public API (`EDchain.vev` dropped `**kwargs`).
- Confirmed numerically: a 6-site Heisenberg+field chain (Hilbert dim 64) at T=2.0 returned `-0.0975` from the default call vs. the true `-0.0328` from a full-spectrum reference — a ~3x error, with only a weak print warning and no error raised.
- Fixed: `thermal_vev_ex` now defaults `n` to the full Hilbert-space dimension whenever it's small enough to diagonalize exactly (same `maxsize=2000` threshold `algebra.lowest_states` uses internally), and raises `RuntimeError` instead of printing when a truncated set of states still carries non-negligible Boltzmann weight. `EDchain.vev` now forwards `**kwargs` so callers can pass `n=` explicitly for large systems.

**2. `get_correlation_matrix(mode="ED", T=...)` — the correlation-matrix counterpart, found to have 3 further bugs** (`entropytk/correlationentropy.py`)
- **Backward Boltzmann sign**: `np.exp(es[i]/T)` instead of `np.exp(-es[i]/T)` — confirmed by comparing against the already-fixed thermal `vev`: `cm[i,i]` and `vev(N_i, T=...)` summed to ~1 (exactly swapped) instead of agreeing.
- **Guessed size guard**: unconditionally requested `2**len(self.C)` (site count) eigenstates instead of checking the true Hamiltonian dimension against `algebra.maxsize` — for 11 sites (2048 > 2000) this asked sparse ARPACK for the entire spectrum (`k=2048` of a 2048-dim operator), which scipy rejects outright, crashing regardless of `T`.
- **No truncation-safety check at all** — silently wrong whenever the (also miscalculated) default excited-state count didn't capture the actual Boltzmann tail.
- Fixed by modeling it directly on `thermal_vev_ex`'s now-correct pattern: true dimension from `get_ED_obj().get_hamiltonian().shape[0]`, full-spectrum default when small enough, corrected sign, and the same `RuntimeError`-on-inadequate-truncation safety net. `**kwargs` (`operators=`, `basis=`, `dmmode=`) now forwarded to the per-eigenstate zero-T calculation instead of silently dropped.

## Tests
- `tests/test_thermal_vev.py` (3 tests): analytically-verifiable single-spin case (`<Sz> = -1/2*tanh(beta*B/2)`), full-spectrum cross-check against an independent `numpy.linalg.eigh` reference, and a regression test that inadequate truncation now raises.
- `tests/test_thermal_correlation_matrix.py` (5 tests): diagonal cross-checked against thermal `vev`, Hermiticity, independent `numpy.linalg.eigh` reference, regression test for the previously-crashing 11-site case, and a truncation-safety test.
- `docs/user_guide.md`/`.tex` (§9 Finite temperature) updated for both fixes; `.tex` verified to compile cleanly with `pdflatex` (no errors/overfull-hbox warnings).

## Test plan
- [x] `python3 -m pytest tests/test_thermal_vev.py tests/test_thermal_correlation_matrix.py -v` — all 8 new tests pass
- [x] `python3 -m pytest tests -q` — same 18 pre-existing/environment failures as on `master` in this environment (uncompiled C++ extension, unrelated bugs — none reference thermal/finite-T `vev`/`correlation_matrix`); 87 passed (was 80 before this branch's tests were added), 0 regressions
- [x] `examples/finite_temperature/thermalvev/main.py` and `examples/finite_temperature/thermal_purification_VS_exact/main.py` still run correctly
- [x] `pdflatex docs/user_guide.tex` compiles with no errors/overfull-hbox warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t