### PR TITLE
Add METTS finite-temperature sampling (pyitensor + ITensor v3)

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -842,6 +842,60 @@ rather than silently returning a wrong average if that state still
 carries non-negligible weight at the requested `T` — pass a larger `n=`
 in that case.
 
+**`metts_vev(O, T, ...)`** is a third, independent finite-temperature
+method: METTS (Minimally Entangled Typical Thermal States, E.M.
+Stoudenmire and S.R. White, *New J. Phys.* **12**, 055026 (2010),
+arXiv:1002.1305), implemented for `itensor_version="python"`
+(`pyitensor/metts.py`) and `itensor_version=3`
+(`mpscpp3/chain_session.h`'s `Chain::metts_vev`, a direct port of the
+same algorithm onto real ITensor v3, not an independent
+reimplementation) — not for `itensor_version=2` (mpscpp2 has no TDVP
+module at all, and METTS needs imaginary-time TDVP). On `itensor_version
+=3`, a chain shorter than 3 sites raises `NotImplementedError` rather
+than crashing: ITensor v3's two-site TDVP hits the same "LocalOp is
+default constructed" abort as its two-site `dmrg()` for such short
+chains (see §Architecture's note on that `mpscpp3` bug). Rather than
+purification's single, growing-entanglement wavefunction or ED's exact
+sum over eigenstates, METTS samples a Markov chain of *unentangled*
+classical product states (CPS) $|i\rangle$: each is imaginary-time
+evolved by half the inverse temperature,
+$|\phi_i\rangle=e^{-\beta H/2}|i\rangle/\lVert e^{-\beta H/2}|i\rangle\rVert$
+(via imaginary-time TDVP — `tdvp_step` with a purely real, rather than
+imaginary, effective time step), then collapsed back down to a new CPS
+$|i'\rangle$ by sampling a definite outcome at each site in turn, with
+probability $|\langle i'|\phi_i\rangle|^2$, from a single left-to-right
+sweep (no need to ever form the full $2^N$ amplitude vector — a
+canonicalized MPS's marginal at one site, conditioned on those already
+sampled to its left, is already diagonal). A plain (unweighted) sample
+average of $\langle\phi_i|O|\phi_i\rangle$ over the resulting chain then
+converges to the true thermal average, because this specific Markov
+chain's stationary distribution already carries the correct Boltzmann
+weight — no importance reweighting needed. The collapse basis is
+alternated between two choices from one sample to the next
+(`basis_ops=("Sz","Sx")` by default) since collapsing repeatedly in the
+same basis can trap the chain in one symmetry sector for many steps,
+inflating autocorrelation (the paper's own finding):
+
+```python
+mean, stderr = sc.metts_vev(sc.Sz[0], T, nsamples=300, nwarmup=30,
+                             dbeta_half_step=0.05, basis_ops=("Sz","Sx"))
+```
+
+`nwarmup` discards that many initial Markov-chain steps before
+averaging (equilibration); `dbeta_half_step` sets the imaginary-time
+TDVP step size for the $e^{-\beta H/2}$ evolution (split into
+$\lceil(\beta/2)/\texttt{dbeta\_half\_step}\rceil$ equal steps). Being a
+Monte Carlo method, `metts_vev` returns `(mean, stderr)` rather than an
+exact value — `stderr` is a naive i.i.d. estimate and, since consecutive
+METTS samples are Markov-correlated, is likely optimistic unless
+`dbeta_half_step`/`nwarmup` are generous enough that samples actually
+decorrelate. Its main advantage over purification is that the sampled
+states stay unentangled classical product states between imaginary-time
+evolutions (no ancilla doubling, and bond dimension never has to carry
+the entanglement of a single ever-more-thermalized wavefunction) — see
+`examples/finite_temperature/metts_VS_exact` for a cross-check against
+the exact ED thermal average on a small Heisenberg chain.
+
 ## 10. Topological invariants
 
 **Many-body Berry phase.** For a ground state that depends on an

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -994,6 +994,63 @@ silently returning a wrong average if that state still carries
 non-negligible weight at the requested $T$ --- pass a larger \texttt{n=}
 in that case.
 
+\textbf{\texttt{metts\_vev(O, T, ...)}} is a third, independent
+finite-temperature method: METTS (Minimally Entangled Typical Thermal
+States, E.M. Stoudenmire and S.R. White, \emph{New J. Phys.} \textbf{12},
+055026 (2010), arXiv:1002.1305), implemented for
+\texttt{itensor\_version="python"} (\texttt{pyitensor/metts.py}) and
+\texttt{itensor\_version=3} (\texttt{mpscpp3/chain\_session.h}'s
+\texttt{Chain::metts\_vev}, a direct port of the same algorithm onto real
+ITensor v3, not an independent reimplementation) --- not for
+\texttt{itensor\_version=2} (mpscpp2 has no TDVP module at all, and METTS
+needs imaginary-time TDVP). On \texttt{itensor\_version=3}, a chain
+shorter than 3 sites raises \texttt{NotImplementedError} rather than
+crashing: ITensor v3's two-site TDVP hits the same ``LocalOp is default
+constructed'' abort as its two-site \texttt{dmrg()} for such short chains
+(see the Architecture section's note on that \texttt{mpscpp3} bug).
+Rather than purification's single, growing-entanglement wavefunction or
+ED's exact sum over eigenstates, METTS samples a Markov chain of
+\emph{unentangled} classical product states (CPS) $|i\rangle$: each is
+imaginary-time evolved by half the inverse temperature,
+$|\phi_i\rangle=e^{-\beta H/2}|i\rangle/\lVert e^{-\beta H/2}|i\rangle\rVert$
+(via imaginary-time TDVP --- \texttt{tdvp\_step} with a purely real,
+rather than imaginary, effective time step), then collapsed back down to
+a new CPS $|i'\rangle$ by sampling a definite outcome at each site in
+turn, with probability $|\langle i'|\phi_i\rangle|^2$, from a single
+left-to-right sweep (no need to ever form the full $2^N$ amplitude
+vector --- a canonicalized MPS's marginal at one site, conditioned on
+those already sampled to its left, is already diagonal). A plain
+(unweighted) sample average of $\langle\phi_i|O|\phi_i\rangle$ over the
+resulting chain then converges to the true thermal average, because this
+specific Markov chain's stationary distribution already carries the
+correct Boltzmann weight --- no importance reweighting needed. The
+collapse basis is alternated between two choices from one sample to the
+next (\texttt{basis\_ops=("Sz","Sx")} by default) since collapsing
+repeatedly in the same basis can trap the chain in one symmetry sector
+for many steps, inflating autocorrelation (the paper's own finding):
+
+\begin{lstlisting}
+mean, stderr = sc.metts_vev(sc.Sz[0], T, nsamples=300, nwarmup=30,
+                             dbeta_half_step=0.05, basis_ops=("Sz","Sx"))
+\end{lstlisting}
+
+\texttt{nwarmup} discards that many initial Markov-chain steps before
+averaging (equilibration); \texttt{dbeta\_half\_step} sets the
+imaginary-time TDVP step size for the $e^{-\beta H/2}$ evolution (split
+into $\lceil(\beta/2)/\texttt{dbeta\_half\_step}\rceil$ equal steps).
+Being a Monte Carlo method, \texttt{metts\_vev} returns
+\texttt{(mean, stderr)} rather than an exact value --- \texttt{stderr} is
+a naive i.i.d. estimate and, since consecutive METTS samples are
+Markov-correlated, is likely optimistic unless
+\texttt{dbeta\_half\_step}/\texttt{nwarmup} are generous enough that
+samples actually decorrelate. Its main advantage over purification is
+that the sampled states stay unentangled classical product states
+between imaginary-time evolutions (no ancilla doubling, and bond
+dimension never has to carry the entanglement of a single
+ever-more-thermalized wavefunction) --- see
+\texttt{examples/finite\_temperature/metts\_VS\_exact} for a cross-check
+against the exact ED thermal average on a small Heisenberg chain.
+
 \section{Topological invariants}
 
 \textbf{Many-body Berry phase.} For a ground state that depends on an

--- a/examples/finite_temperature/metts_VS_exact/main.py
+++ b/examples/finite_temperature/metts_VS_exact/main.py
@@ -1,0 +1,65 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+# METTS (Minimally Entangled Typical Thermal States) vs exact ED thermal
+# averages, following E.M. Stoudenmire and Steven R. White, "Minimally
+# entangled typical thermal state algorithms", New J. Phys. 12, 055026
+# (2010), arXiv:1002.1305. See src/dmrgpy/pyitensor/metts.py for the
+# algorithm itself: imaginary-time TDVP evolution of a classical product
+# state by e^{-beta H/2}, followed by a sequential ("perfect sampling")
+# collapse back down to a new product state, alternating the collapse
+# basis between Sz and Sx from one sample to the next for ergodicity.
+#
+# itensor_version="python" and 3 both implement METTS (see
+# vevtk/mettsvev.py's docstring; mpscpp3/chain_session.h's Chain::metts_vev
+# is a direct port of the same algorithm onto real ITensor v3) -- this
+# example cross-checks both against the exact ED Boltzmann average for a
+# small Heisenberg chain + field, where the full spectrum is cheap to
+# diagonalize directly.
+import numpy as np
+from dmrgpy import spinchain, cppext
+
+n = 4
+J, B = 1.0, 0.3
+
+versions = ["python"]
+if cppext.available(3):
+    versions.append(3)
+
+Ts = [0.5, 1.0, 3.0]
+for version in versions:
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    if version == "python":
+        sc.setup_python()
+    else:
+        sc.setup_cpp(version=version)
+    h = 0
+    for i in range(n - 1):
+        h = h + J*sc.Sx[i]*sc.Sx[i+1] + J*sc.Sy[i]*sc.Sy[i+1] + J*sc.Sz[i]*sc.Sz[i+1]
+    for i in range(n):
+        h = h + B*sc.Sz[i]
+    sc.set_hamiltonian(h)
+
+    print("\n=== itensor_version=%s ===" % (version,))
+    print("%6s  %12s  %20s  %12s  %20s" % ("T", "ED <Sz0>", "METTS <Sz0>", "ED <E>", "METTS <E>"))
+    for T in Ts:
+        ed_sz = sc.vev(sc.Sz[0], mode="ED", T=T).real
+        ed_e = sc.vev(h, mode="ED", T=T).real
+        metts_sz, err_sz = sc.metts_vev(sc.Sz[0], T, nsamples=300, nwarmup=30,
+                                         dbeta_half_step=0.08, seed=42)
+        metts_e, err_e = sc.metts_vev(h, T, nsamples=300, nwarmup=30,
+                                       dbeta_half_step=0.08, seed=42)
+        print("%6.2f  %12.5f  %8.5f +/- %8.5f  %12.5f  %8.5f +/- %8.5f"
+              % (T, ed_sz, metts_sz.real, err_sz, ed_e, metts_e.real, err_e))
+
+        # generous tolerance: METTS is a Monte Carlo method, so exact
+        # agreement isn't expected, only agreement within a comfortable
+        # multiple of its own (Markov-correlated, likely optimistic)
+        # reported standard error -- see tests/test_metts_vev.py for
+        # tighter, seed-pinned regression bounds.
+        assert abs(metts_sz.real - ed_sz) < 0.08, \
+            "METTS <Sz0> disagrees with ED at T=%g (itensor_version=%s)" % (T, version)
+        assert abs(metts_e.real - ed_e) < 0.08, \
+            "METTS <E> disagrees with ED at T=%g (itensor_version=%s)" % (T, version)
+
+print("\nTEST PASSED")

--- a/src/dmrgpy/manybodychain.py
+++ b/src/dmrgpy/manybodychain.py
@@ -304,10 +304,16 @@ class Many_Body_Chain():
               from .mpsjulialive.vev import vev as vevjl
               return vevjl(self,MO,**kwargs)
           else: raise
-      elif mode=="ED": 
+      elif mode=="ED":
           MOf = self.toMPO(MO,mode="ED") # fast operator
           return self.get_ED_obj().vev(MOf,**kwargs) # ED object
       else: raise
+  def metts_vev(self,MO,T,**kwargs):
+      """Finite-temperature <MO> via METTS sampling (White & Stoudenmire,
+      arXiv:1002.1305) -- see vevtk/mettsvev.py. Implemented for
+      itensor_version='python' and 3 (not 2, which has no TDVP)."""
+      from .vevtk.mettsvev import metts_vev as _metts_vev
+      return _metts_vev(self,MO,T,**kwargs)
   def test_ED(self):
       """Test the ED object"""
       self.get_ED_obj().test()

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -311,6 +311,7 @@ PYBIND11_MODULE(_dmrgcpp, m)
                "evolve_and_measure_tdvp(). Returns (correlator, final_wf)")
         .def("tdvp_step",&Chain::tdvp_step,
              py::arg("H"),py::arg("wf"),py::arg("dt"),py::arg("num_center")=2,
+             py::arg("niter")=50,
              "One TDVP step of size dt (may be complex -- see "
              "TDVP/README.md's own \"t\" convention) applied to an "
              "already-built MPO H and MPS wf, one-site (num_center=1) or "

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -322,6 +322,21 @@ PYBIND11_MODULE(_dmrgcpp, m)
              "correlator, see tdz.py, whose per-step contour increment "
              "varies with t). One-site TDVP doesn't grow bond dimension "
              "on its own -- pair with global_subspace_expand() below.")
+        .def("metts_vev",[](Chain& self, std::vector<PyTerm> const& terms_op,
+                             double T, int nsamples, int nwarmup,
+                             double dbeta_half_step,
+                             std::vector<std::string> const& basis_ops,
+                             unsigned long seed, int niter) {
+                return self.metts_vev(terms_from_python(terms_op),T,nsamples,
+                    nwarmup,dbeta_half_step,basis_ops,seed,niter);
+            }, py::arg("terms_op"),py::arg("T"),py::arg("nsamples")=200,
+               py::arg("nwarmup")=20,py::arg("dbeta_half_step")=0.05,
+               py::arg("basis_ops")=std::vector<std::string>{"Sz","Sx"},
+               py::arg("seed")=0,py::arg("niter")=30,
+               "Finite-temperature <A> via METTS sampling (White & "
+               "Stoudenmire, arXiv:1002.1305 -- see Chain::metts_vev's own "
+               "comment and pyitensor/metts.py for the full algorithm). "
+               "Returns (mean, stderr).")
         .def("global_subspace_expand",&Chain::global_subspace_expand,
              py::arg("H"),py::arg("phi"),py::arg("krylov_order"),
              py::arg("cutoff"),py::arg("maxdim")=0,

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -1,4 +1,5 @@
 #include <tuple>
+#include <map> // Chain::MettsEigCache (Chain::metts_vev)
 #include <algorithm> // std::next_permutation (four_correlation_tensor_sweep)
 #include <random> // std::mt19937_64/std::discrete_distribution (Chain::metts_vev)
 
@@ -774,14 +775,18 @@ class Chain
     // since one-site TDVP conserves bond dimension exactly and truncating
     // it would only ever shrink it, never grow it -- growth for one-site
     // comes from global_subspace_expand() below instead.
+    // niter=50 matches every pre-existing caller (none passed anything
+    // else); metts_vev() below is the first caller that needs a
+    // different value, hence the added (default-preserving) parameter
+    // rather than a second near-duplicate method.
     MPS
-    tdvp_step(MPO const& H, MPS psi, Cplx dt, int num_center=2) const
+    tdvp_step(MPO const& H, MPS psi, Cplx dt, int num_center=2, int niter=50) const
         {
         Cplx t = Cplx(0.0,-1.0)*dt;
         auto sweeps = Sweeps(1);
         sweeps.maxdim() = maxm_;
         sweeps.cutoff() = cutoff_;
-        sweeps.niter() = 50;
+        sweeps.niter() = niter;
         tdvp(psi,H,t,sweeps,{"Quiet",!verbose_,"Silent",!verbose_,
                               "NumCenter",num_center,
                               "Truncate",num_center==2,
@@ -819,6 +824,9 @@ class Chain
               unsigned long seed, int niter=30) const
         {
         if (!have_H_) Error("Chain::metts_vev called before set_hamiltonian");
+        if (T<=0) Error("Chain::metts_vev: T must be > 0");
+        if (basis_ops.empty()) Error("Chain::metts_vev: basis_ops must be non-empty");
+        if (nsamples<1) Error("Chain::metts_vev: nsamples must be >= 1");
         auto A = build_mpo(sites_,terms_op,mpomaxm_);
         double beta_half = 1.0/(2.0*T);
         int nsteps = std::max(1,(int)std::ceil(beta_half/dbeta_half_step));
@@ -826,7 +834,8 @@ class Chain
 
         std::mt19937_64 rng(seed);
         int nbasis = (int)basis_ops.size();
-        MPS cps = random_cps(basis_ops[0],rng);
+        auto eigcache = metts_build_eigcache(basis_ops);
+        MPS cps = random_cps(basis_ops[0],rng,eigcache);
 
         std::vector<Cplx> samples;
         samples.reserve(nsamples);
@@ -836,13 +845,21 @@ class Chain
             MPS phi = cps;
             for (int s=0; s<nsteps; ++s)
                 {
-                phi = metts_tdvp_step(H_,phi,dt,niter);
+                phi = tdvp_step(H_,phi,dt,2,niter);
                 phi /= sqrt(innerC(phi,phi).real());
                 }
             if (it>=nwarmup) samples.push_back(innerC(phi,A,phi));
-            cps = collapse_to_cps(phi,basis_ops[it % nbasis],rng);
+            cps = collapse_to_cps(phi,basis_ops[it % nbasis],rng,eigcache);
             }
 
+        // nwarmup>=total_iters (e.g. nwarmup alone consuming every
+        // iteration) would otherwise leave samples empty and divide by
+        // zero below -- not reachable through the Python-facing default
+        // kwargs, but not guarded against a caller passing an oversized
+        // nwarmup either, so check explicitly rather than silently
+        // returning NaN.
+        if (samples.empty())
+            Error("Chain::metts_vev: no samples were retained (nwarmup >= nwarmup+nsamples?)");
         Cplx mean = 0;
         for (auto& v : samples) mean += v;
         mean /= double(samples.size());
@@ -1466,27 +1483,6 @@ class Chain
 
     // -- METTS helpers (Chain::metts_vev, public, above) --
 
-    // Same imaginary-time step as the public tdvp_step() above (dt=
-    // Cplx(0,-1)*dt already gives genuine decay for a purely real dt, see
-    // that method's own comment), but with a caller-chosen Lanczos
-    // iteration count instead of tdvp_step()'s hardcoded niter=50 --
-    // metts_vev()'s own niter parameter needs to actually reach the TDVP
-    // solver, unlike a plain delegation to tdvp_step() would allow.
-    MPS
-    metts_tdvp_step(MPO const& H, MPS psi, Cplx dt, int niter) const
-        {
-        Cplx t = Cplx(0.0,-1.0)*dt;
-        auto sweeps = Sweeps(1);
-        sweeps.maxdim() = maxm_;
-        sweeps.cutoff() = cutoff_;
-        sweeps.niter() = niter;
-        tdvp(psi,H,t,sweeps,{"Quiet",!verbose_,"Silent",!verbose_,
-                              "NumCenter",2,
-                              "Truncate",true,
-                              "DoNormalize",true});
-        return psi;
-        }
-
     // A CPS (classical product state: bond dimension 1 throughout) built
     // from per-site rank-1 ITensors over each site's bare physical index
     // (no Link legs yet). Fresh dim-1 Link indices are attached here via
@@ -1521,6 +1517,35 @@ class Chain
         return psi;
         }
 
+    // Per-(opname,site) diagHermitian() result, cached by
+    // metts_build_eigcache() below so random_cps()/collapse_to_cps()
+    // don't recompute the same site operator's eigendecomposition from
+    // scratch at every one of a METTS run's nwarmup+nsamples iterations
+    // -- a given (opname,i)'s eigenbasis never changes across the whole
+    // sampling run. D (the eigenvalue tensor diagHermitian also produces)
+    // is never read anywhere in this file, so only U and its eig index
+    // are kept.
+    struct MettsEigBasis { ITensor U; Index eig; };
+    using MettsEigCache = std::map<std::pair<std::string,int>,MettsEigBasis>;
+
+    MettsEigCache
+    metts_build_eigcache(std::vector<std::string> const& basis_ops) const
+        {
+        MettsEigCache cache;
+        int N = sites_.length();
+        for (auto const& opname : basis_ops)
+            for (int i=1; i<=N; ++i)
+                {
+                auto key = std::make_pair(opname,i);
+                if (cache.count(key)) continue;
+                auto opT = sites_.op(opname,i);
+                ITensor U,D;
+                diagHermitian(opT,U,D);
+                cache[key] = MettsEigBasis{U,uniqueIndex(U,opT)};
+                }
+        return cache;
+        }
+
     // A random CPS: at each site, uniformly picks one eigenstate of the
     // named single-site Hermitian operator opname (e.g. "Sz") -- a valid
     // seed for the METTS Markov chain regardless of choice (the chain's
@@ -1528,19 +1553,17 @@ class Chain
     // how many warmup steps are needed to reach it -- White & Stoudenmire,
     // arXiv:1002.1305, Sec. 2).
     MPS
-    random_cps(std::string const& opname, std::mt19937_64& rng) const
+    random_cps(std::string const& opname, std::mt19937_64& rng,
+               MettsEigCache const& eigcache) const
         {
         int N = sites_.length();
         std::vector<ITensor> vectors(N);
         for (int i=1; i<=N; ++i)
             {
-            auto opT = sites_.op(opname,i);
-            ITensor U,D;
-            diagHermitian(opT,U,D);
-            auto eig = uniqueIndex(U,opT);
-            std::uniform_int_distribution<int> dist(1,itensor::dim(eig));
+            auto const& eb = eigcache.at(std::make_pair(opname,i));
+            std::uniform_int_distribution<int> dist(1,itensor::dim(eb.eig));
             int k = dist(rng);
-            vectors[i-1] = U*setElt(eig(k));
+            vectors[i-1] = eb.U*setElt(eb.eig(k));
             }
         return build_product_state(vectors);
         }
@@ -1564,7 +1587,8 @@ class Chain
     // index contraction handles "no right link left" (i==N) the same way
     // as any other site.
     MPS
-    collapse_to_cps(MPS wf, std::string const& opname, std::mt19937_64& rng) const
+    collapse_to_cps(MPS wf, std::string const& opname, std::mt19937_64& rng,
+                     MettsEigCache const& eigcache) const
         {
         int N = sites_.length();
         wf.position(1);
@@ -1572,10 +1596,9 @@ class Chain
         ITensor L; // default-constructed/"null" (operator bool()==false) until i>1's first assignment
         for (int i=1; i<=N; ++i)
             {
-            auto opT = sites_.op(opname,i);
-            ITensor U,D;
-            diagHermitian(opT,U,D);
-            auto eig = uniqueIndex(U,opT);
+            auto const& eb = eigcache.at(std::make_pair(opname,i));
+            auto const& U = eb.U;
+            auto const& eig = eb.eig;
             int dim_i = itensor::dim(eig);
 
             ITensor T = wf.A(i);

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -1,5 +1,6 @@
 #include <tuple>
 #include <algorithm> // std::next_permutation (four_correlation_tensor_sweep)
+#include <random> // std::mt19937_64/std::discrete_distribution (Chain::metts_vev)
 
 // TDVP/tdvp.h and TDVP/basisextension.h are quoted includes, so they
 // resolve relative to this file's own directory (mpscpp3/) with no
@@ -788,6 +789,74 @@ class Chain
         return psi;
         }
 
+    // METTS (Minimally Entangled Typical Thermal States; E.M. Stoudenmire
+    // and S.R. White, arXiv:1002.1305) -- a direct port of
+    // pyitensor/metts.py's algorithm onto real ITensor v3 (see that
+    // module's own docstring for the full derivation this only summarizes
+    // here). Samples a Markov chain of classical product states (CPS):
+    // each is imaginary-time evolved by beta/2 via tdvp_step() above
+    // (dt=Cplx(0,-1)*step -- that method's own -i*dt convention already
+    // makes a purely real dt give genuine decay rather than rotation, so
+    // no new evolution primitive is needed here), then collapsed back
+    // down to a new CPS by collapse_to_cps() (private, below) using
+    // diagHermitian() for the per-site basis rotation, alternating the
+    // collapse basis through basis_ops from one sample to the next for
+    // ergodicity (paper, Sec. 3.3). A plain sample average of
+    // <phi|A|phi> over the resulting chain converges to the true thermal
+    // average, because this specific Markov chain's stationary
+    // distribution already carries the correct Boltzmann weight -- no
+    // importance reweighting needed (paper, Eq. (3)-(5)).
+    //
+    // Returns (mean, stderr): stderr is a naive i.i.d. estimate over the
+    // nsamples retained samples (after nwarmup discarded equilibration
+    // steps), so -- since consecutive METTS samples are Markov-correlated
+    // -- it's likely optimistic unless dbeta_half_step/nwarmup are
+    // generous enough that samples actually decorrelate.
+    std::pair<Cplx,double>
+    metts_vev(std::vector<MOTerm> const& terms_op, double T, int nsamples,
+              int nwarmup, double dbeta_half_step,
+              std::vector<std::string> const& basis_ops,
+              unsigned long seed, int niter=30) const
+        {
+        if (!have_H_) Error("Chain::metts_vev called before set_hamiltonian");
+        auto A = build_mpo(sites_,terms_op,mpomaxm_);
+        double beta_half = 1.0/(2.0*T);
+        int nsteps = std::max(1,(int)std::ceil(beta_half/dbeta_half_step));
+        Cplx dt = Cplx(0.0,-1.0)*(beta_half/double(nsteps));
+
+        std::mt19937_64 rng(seed);
+        int nbasis = (int)basis_ops.size();
+        MPS cps = random_cps(basis_ops[0],rng);
+
+        std::vector<Cplx> samples;
+        samples.reserve(nsamples);
+        int total_iters = nwarmup+nsamples;
+        for (int it=0; it<total_iters; ++it)
+            {
+            MPS phi = cps;
+            for (int s=0; s<nsteps; ++s)
+                {
+                phi = metts_tdvp_step(H_,phi,dt,niter);
+                phi /= sqrt(innerC(phi,phi).real());
+                }
+            if (it>=nwarmup) samples.push_back(innerC(phi,A,phi));
+            cps = collapse_to_cps(phi,basis_ops[it % nbasis],rng);
+            }
+
+        Cplx mean = 0;
+        for (auto& v : samples) mean += v;
+        mean /= double(samples.size());
+        double var = 0.0;
+        for (auto& v : samples)
+            {
+            double d = std::abs(v-mean);
+            var += d*d;
+            }
+        double stderr_ = samples.size()>1
+            ? std::sqrt(var/double(samples.size()-1)/double(samples.size())) : 0.0;
+        return {mean,stderr_};
+        }
+
     // Global subspace expansion (TDVP/basisextension.h's addBasis()):
     // enriches phi's local bases with a Krylov subspace {phi, H*phi,
     // H^2*phi, ...} of dimension krylov_order, then discards the least
@@ -1394,6 +1463,146 @@ class Chain
     // search that isn't trapped at a symmetric starting point.
     MPS
     default_mps() const { return randomMPS(sites_,maxm_); }
+
+    // -- METTS helpers (Chain::metts_vev, public, above) --
+
+    // Same imaginary-time step as the public tdvp_step() above (dt=
+    // Cplx(0,-1)*dt already gives genuine decay for a purely real dt, see
+    // that method's own comment), but with a caller-chosen Lanczos
+    // iteration count instead of tdvp_step()'s hardcoded niter=50 --
+    // metts_vev()'s own niter parameter needs to actually reach the TDVP
+    // solver, unlike a plain delegation to tdvp_step() would allow.
+    MPS
+    metts_tdvp_step(MPO const& H, MPS psi, Cplx dt, int niter) const
+        {
+        Cplx t = Cplx(0.0,-1.0)*dt;
+        auto sweeps = Sweeps(1);
+        sweeps.maxdim() = maxm_;
+        sweeps.cutoff() = cutoff_;
+        sweeps.niter() = niter;
+        tdvp(psi,H,t,sweeps,{"Quiet",!verbose_,"Silent",!verbose_,
+                              "NumCenter",2,
+                              "Truncate",true,
+                              "DoNormalize",true});
+        return psi;
+        }
+
+    // A CPS (classical product state: bond dimension 1 throughout) built
+    // from per-site rank-1 ITensors over each site's bare physical index
+    // (no Link legs yet). Fresh dim-1 Link indices are attached here via
+    // setElt() -- the same "outer product with a one-hot tensor" idiom
+    // MPS's own init_tensors() (mps.cc, backing the MPS(InitState)
+    // constructor) uses to build a product state from named basis
+    // states, generalized here to an arbitrary per-site vector (a
+    // METTS collapse outcome is a diagHermitian() eigenvector, not
+    // necessarily one of a site type's named states). leftLim/rightLim
+    // are set to match MPS(InitState)'s own convention (orthogonality
+    // center at site 1) since a bond-dimension-1 chain is trivially
+    // canonical everywhere once each site vector is unit-normalized (true
+    // here: every vector handed in is either a diagHermitian()
+    // eigenvector or built from one).
+    MPS
+    build_product_state(std::vector<ITensor> const& site_vectors) const
+        {
+        int N = sites_.length();
+        MPS psi(N);
+        std::vector<Index> links;
+        links.reserve(N-1);
+        for (int k=1; k<N; ++k) links.push_back(Index(1,TagSet("Link,l="+std::to_string(k))));
+        for (int i=1; i<=N; ++i)
+            {
+            ITensor T = site_vectors[i-1];
+            if (i>1) T *= setElt(links[i-2](1));
+            if (i<N) T *= setElt(links[i-1](1));
+            psi.set(i,T);
+            }
+        psi.leftLim(0);
+        psi.rightLim(2);
+        return psi;
+        }
+
+    // A random CPS: at each site, uniformly picks one eigenstate of the
+    // named single-site Hermitian operator opname (e.g. "Sz") -- a valid
+    // seed for the METTS Markov chain regardless of choice (the chain's
+    // stationary distribution doesn't depend on the starting CPS, only
+    // how many warmup steps are needed to reach it -- White & Stoudenmire,
+    // arXiv:1002.1305, Sec. 2).
+    MPS
+    random_cps(std::string const& opname, std::mt19937_64& rng) const
+        {
+        int N = sites_.length();
+        std::vector<ITensor> vectors(N);
+        for (int i=1; i<=N; ++i)
+            {
+            auto opT = sites_.op(opname,i);
+            ITensor U,D;
+            diagHermitian(opT,U,D);
+            auto eig = uniqueIndex(U,opT);
+            std::uniform_int_distribution<int> dist(1,itensor::dim(eig));
+            int k = dist(rng);
+            vectors[i-1] = U*setElt(eig(k));
+            }
+        return build_product_state(vectors);
+        }
+
+    // Sequential ("perfect sampling") collapse of MPS wf onto a new CPS
+    // built from eigenstates of the single-site Hermitian operator
+    // opname -- direct port of pyitensor/metts.py's collapse_to_cps(),
+    // see its own docstring for the full derivation; the paper's "quantum
+    // measurement" collapse step (Sec. 2.2) generalized from a single
+    // qubit measurement to the whole chain via one left-to-right sweep.
+    //
+    // Canonicalizing to site 1 first (wf.position(1)) makes every site
+    // i>1 right-orthonormal; contracting the running "collapsed-so-far"
+    // amplitude L into site i's tensor and rotating into the eigenbasis
+    // via dag(U) gives `rot`, whose diagonal marginal probabilities
+    // (summed over whatever's left of the chain to the right) fall out
+    // directly as the diagonal of rot*dag(prime(rot,eig)) -- no explicit
+    // partial trace needed, since right-orthonormality already performs
+    // it, and (unlike the manual-index-bookkeeping pyitensor port) no
+    // special-casing of the last site either: ITensor's own automatic
+    // index contraction handles "no right link left" (i==N) the same way
+    // as any other site.
+    MPS
+    collapse_to_cps(MPS wf, std::string const& opname, std::mt19937_64& rng) const
+        {
+        int N = sites_.length();
+        wf.position(1);
+        std::vector<ITensor> vectors(N);
+        ITensor L; // default-constructed/"null" (operator bool()==false) until i>1's first assignment
+        for (int i=1; i<=N; ++i)
+            {
+            auto opT = sites_.op(opname,i);
+            ITensor U,D;
+            diagHermitian(opT,U,D);
+            auto eig = uniqueIndex(U,opT);
+            int dim_i = itensor::dim(eig);
+
+            ITensor T = wf.A(i);
+            if (L) T *= L;
+            ITensor rot = dag(U)*T;
+            ITensor probs = rot*dag(prime(rot,eig));
+
+            std::vector<double> probs_raw(dim_i), p(dim_i);
+            double total = 0.0;
+            for (int k=1; k<=dim_i; ++k)
+                {
+                probs_raw[k-1] = probs.eltC(eig(k),prime(eig)(k)).real();
+                total += probs_raw[k-1];
+                }
+            for (int k=0; k<dim_i; ++k) p[k] = probs_raw[k]/total;
+            std::discrete_distribution<int> dist(p.begin(),p.end());
+            int k = dist(rng)+1; // 1-based
+
+            vectors[i-1] = U*setElt(eig(k));
+            if (i<N)
+                {
+                ITensor Lnew = rot*setElt(eig(k));
+                L = Lnew*(1.0/std::sqrt(probs_raw[k-1]));
+                }
+            }
+        return build_product_state(vectors);
+        }
 
     // Thin wrappers around v3's applyMPO() that always restore the result's
     // physical index to the standard, unprimed convention. Plain applyMPO()

--- a/src/dmrgpy/pyitensor/chain.py
+++ b/src/dmrgpy/pyitensor/chain.py
@@ -24,6 +24,7 @@ from .mpsalgebra import applyMPO, inner, nmultMPO
 from .mpsalgebra import sum as mps_sum
 from .mpsalgebra import randomMPS, traceC
 from .mpsalgebra import _fresh_link_copy
+from .metts import metts_thermal_average as _metts_thermal_average
 from .sites import SiteX
 from .svd import svd
 from .sweeps import Sweeps
@@ -643,6 +644,32 @@ class Chain:
     def general_kpm(self, terms_x, wfa, wfb, kpmmaxm, kpm_accelerate, num_polynomials, kpm_cutoff):
         m = to_mpo(AutoMPO.from_terms(self.sites, terms_x), cutoff=_BUILD_CUTOFF, maxdim=self.mpomaxm)
         return self._kpm_moments(m, wfa, wfb, num_polynomials, kpmmaxm, kpm_cutoff, kpm_accelerate)
+
+    def metts_vev(self, terms_op, T, nsamples=200, nwarmup=20,
+                  dbeta_half_step=0.05, basis_ops=("Sz", "Sx"), seed=None, niter=30):
+        """Finite-temperature <A> via METTS sampling (White & Stoudenmire,
+        arXiv:1002.1305 -- see metts.py for the full algorithm). Reuses
+        self.H (already built by set_hamiltonian) and this chain's own
+        cutoff/maxm as the TDVP truncation controls, same convention as
+        every other method here. Single-operator signature (terms_op is
+        one MultiOperator.to_terms() output), matching every other vev-
+        like method's surface here (vev, overlap_aMb, ...) -- this keeps
+        the same call signature mpscpp3's own Chain::metts_vev exposes.
+
+        Returns (mean, stderr) -- see metts_thermal_average()'s own
+        docstring for what these mean and their (Markov-correlated, so
+        optimistic) error bars.
+        """
+        if not self.have_H:
+            raise RuntimeError("Chain.metts_vev called before set_hamiltonian")
+        op = to_mpo(AutoMPO.from_terms(self.sites, terms_op), cutoff=_BUILD_CUTOFF,
+                    maxdim=self.mpomaxm)
+        beta = 1.0 / T
+        means, stderrs = _metts_thermal_average(
+            self.H, self.sites, [op], beta, nsamples, nwarmup=nwarmup,
+            dbeta_half_step=dbeta_half_step, cutoff=self.cutoff, maxdim=self.maxm,
+            basis_ops=basis_ops, seed=seed, niter=niter)
+        return means[0], stderrs[0]
 
     def nhkpm_moments(self, terms_hs, terms_hs_dag, wfa, wfb, n, kpmmaxm, kpmcutoff):
         """Non-Hermitian KPM (port of NHKPM.jl, see

--- a/src/dmrgpy/pyitensor/metts.py
+++ b/src/dmrgpy/pyitensor/metts.py
@@ -1,0 +1,250 @@
+"""METTS: Minimally Entangled Typical Thermal States.
+
+Reference: E.M. Stoudenmire and Steven R. White, "Minimally entangled
+typical thermal state algorithms", New J. Phys. 12, 055026 (2010),
+arXiv:1002.1305.
+
+Algorithm (paper's Sec. 2):
+
+  1. Start from a classical product state (CPS) |i>: an unentangled
+     product of single-site basis states (not necessarily the
+     computational/Sz basis -- any product of single-site vectors
+     counts, e.g. |+x> at some sites).
+  2. Imaginary-time evolve it by half the inverse temperature:
+         |phi_i> = e^{-beta H/2} |i> / || e^{-beta H/2} |i> ||.
+     Every operator expectation value <A> is estimated as the average of
+     <phi_i|A|phi_i> over many samples i, because
+         Tr[A e^{-beta H}] / Tr[e^{-beta H}]
+           = sum_i <i|e^{-beta H/2} A e^{-beta H/2}|i>
+             / sum_i <i|e^{-beta H}|i>
+     for *any* complete CPS basis {|i>} (Eq. (1)-(2) of the paper), and
+     the specific Markov chain built by repeatedly collapsing |phi_i>
+     back down to a new CPS |i'> with probability |<i'|phi_i>|^2 has
+     exactly this Boltzmann-weighted ensemble as its stationary
+     distribution (Eq. (3)-(5)): each |phi_i> sampled from that chain is
+     already properly weighted, so a plain (unweighted) sample average
+     of <phi_i|A|phi_i> converges to the thermal average -- no importance
+     reweighting needed, unlike generic Monte Carlo.
+  3. Collapse |phi_i> to a new CPS by sequential ("perfect") sampling: a
+     single left-to-right sweep samples one site at a time from its exact
+     conditional marginal (given the sites already sampled to its left),
+     using only the local MPS tensor -- never the full 2^N amplitude
+     vector -- because canonicalizing to site 1 makes every site to the
+     right already right-orthonormal, i.e. the partial trace over "the
+     rest of the chain" needed for that marginal is already built into
+     the tensor's own gauge (see collapse_to_cps() below; this is the
+     same "perfect sampling from an MPS" trick as Ferris & Vidal, PRB 85,
+     165146 (2012), and ITensor's own MPS::sample()).
+  4. Alternate the collapse basis between two mutually unbiased choices
+     (e.g. Sz and Sx for spin-1/2) from one sample to the next: collapsing
+     repeatedly in the *same* basis lets the Markov chain get trapped for
+     many steps in that basis's symmetry sector (the paper's Sec. 3.3),
+     inflating the autocorrelation time; alternating fixes this in
+     practice for the models the paper tests.
+
+This module works with plain pyitensor MPS/MPO objects (mpscontainer.py)
+and tdvp.py's TDVP stepper -- imaginary time is just tdvp_step()'s own
+complex-dt generalization with dt=-1j*dtau (dt purely imaginary <->
+tdvp_step's usual real-time exp(-i*dt*H); dt purely real <-> the decaying
+exp(-dtau*H) imaginary-time propagator wanted here, since forward/backward
+half-sweep coefficients -1j*(dt/2) and +1j*(dt/2) become -dtau/2 and
++dtau/2 respectively for dt=-1j*dtau -- a real, negative forward exponent,
+i.e. genuine decay, not rotation). See chain.py's Chain.metts_vev() for how
+this is wired into the rest of the engine (H and the observables' MPOs are
+each built once from MultiOperator terms and reused across every sample).
+"""
+
+import numpy as np
+
+from .index import Index
+from .mpscontainer import MPS
+from .mpsalgebra import inner
+from .tdvp import tdvp_step
+from .tensor import ITensor, noPrime
+
+
+def _site_operator_matrix(sites, opname, i):
+    """The (dim,dim) matrix of single-site operator `opname` at (1-based)
+    site i, in the convention that plain matrix-vector multiplication
+    reproduces exactly what sites.op(opname,i) does when contracted into
+    an MPS tensor -- obtained by actually invoking that same contraction
+    on each basis vector, rather than re-deriving sites/base.py's
+    unprimed-in/primed-out convention algebraically here."""
+    s = sites.si(i)
+    d = s.dim
+    op = sites.op(opname, i)
+    out = np.zeros((d, d), dtype=complex)
+    for a in range(d):
+        vec = np.zeros(d, dtype=complex)
+        vec[a] = 1.0
+        ket = ITensor((s,), vec)
+        res = noPrime(op * ket, "Site")
+        out[:, a] = res.array
+    return out
+
+
+def _eigenbasis(sites, opname, i):
+    """(eigvals, eigvecs) of the named single-site Hermitian operator at
+    site i, eigvecs as columns expressed in the site's native
+    (computational) basis -- np.linalg.eigh, since every physical
+    operator dmrgpy's site tables define (Sz, Sx, N, ...) is Hermitian."""
+    M = _site_operator_matrix(sites, opname, i)
+    return np.linalg.eigh(M)
+
+
+def product_state(sites, vectors):
+    """An MPS product state (bond dimension 1 throughout) from a list of
+    per-site complex vectors (vectors[i-1], length sites.dim(i)). Trivial
+    dim-1 Link indices are still built between neighboring sites so this
+    looks, to every downstream routine (mpsalgebra.inner, MPS.position,
+    tdvp_step, ...), like any other MPS in this engine -- see
+    mpscontainer.py's own module docstring on why interior sites always
+    carry a Link-tagged index here."""
+    n = sites.length()
+    links = [Index(1, tags="Link,l={}".format(k + 1)) for k in range(n - 1)]
+    tensors = []
+    for i in range(1, n + 1):
+        s = sites.si(i)
+        vec = np.asarray(vectors[i - 1], dtype=complex).reshape(-1)
+        inds = []
+        if i > 1:
+            inds.append(links[i - 2])
+        inds.append(s)
+        if i < n:
+            inds.append(links[i - 1])
+        shape = tuple(ind.dim for ind in inds)
+        tensors.append(ITensor(tuple(inds), vec.reshape(shape)))
+    mps = MPS(tensors)
+    mps.center = 1
+    return mps
+
+
+def random_cps(sites, opname, rng):
+    """A random classical product state: at each site, uniformly pick one
+    eigenstate of the named single-site operator (e.g. "Sz"). Valid seed
+    for the METTS Markov chain regardless of choice -- the chain's
+    stationary distribution doesn't depend on the starting CPS (paper,
+    Sec. 2), only how many warmup steps are needed to reach it."""
+    n = sites.length()
+    vectors = []
+    for i in range(1, n + 1):
+        _, evecs = _eigenbasis(sites, opname, i)
+        k = rng.integers(0, sites.dim(i))
+        vectors.append(evecs[:, k].copy())
+    return product_state(sites, vectors)
+
+
+def collapse_to_cps(psi, sites, opname, rng):
+    """Sequential ("perfect") sampling collapse of MPS `psi` onto a new
+    classical product state built from eigenstates of the single-site
+    Hermitian operator `opname` (e.g. "Sz" or "Sx") -- the paper's
+    "quantum measurement" collapse step (Sec. 2.2), generalized from a
+    single qubit measurement to the whole chain via one left-to-right
+    sweep.
+
+    Canonicalizing to site 1 first (work.position(1)) makes every site
+    i>1 right-orthonormal; contracting the running "collapsed-so-far"
+    vector L into site i's tensor and reading off
+    sum_{right link} |<eigenstate k|tensor>|^2 then gives exactly the
+    marginal probability of outcome k at site i *conditioned on* the
+    outcomes already sampled to its left -- no explicit partial trace is
+    needed because right-orthonormality already performs it. This means
+    the full N-site joint distribution is sampled exactly (up to the
+    original MPS's own truncation), never requiring the full
+    exponentially-sized amplitude vector.
+
+    Returns (new_cps_mps, outcomes): outcomes[i-1] is the sampled
+    eigenvalue (float) at site i, for diagnostics only.
+    """
+    n = sites.length()
+    work = psi.copy()
+    work.position(1)
+    vectors = []
+    outcomes = []
+    L = None  # running collapsed-prefix amplitude, an ITensor over the current left link, or None at site 1
+    for i in range(1, n + 1):
+        evals, evecs = _eigenbasis(sites, opname, i)
+        T = work.A(i)
+        if L is not None:
+            T = L * T
+        s = sites.si(i)
+        right_link = next((ind for ind in T.inds if ind != s), None)
+        if right_link is not None:
+            mat = T.transpose_to((s, right_link))
+        else:
+            mat = T.transpose_to((s,)).reshape(s.dim, 1)
+        rot = evecs.conj().T @ mat  # amplitude of each eigenbasis outcome, per remaining right-link value
+        probs_raw = np.sum(np.abs(rot) ** 2, axis=1)
+        total = probs_raw.sum()
+        p = probs_raw / total
+        p = p / p.sum()  # re-normalize away roundoff so rng.choice never complains
+        k = int(rng.choice(s.dim, p=p))
+        vectors.append(evecs[:, k].copy())
+        outcomes.append(float(evals[k]))
+        if right_link is not None:
+            L = ITensor((right_link,), rot[k, :] / np.sqrt(probs_raw[k]))
+    new_cps = product_state(sites, vectors)
+    return new_cps, outcomes
+
+
+def imaginary_time_evolve(psi, H, dbeta_half, nsteps, cutoff, maxdim, niter=30):
+    """Evolve psi by e^{-dbeta_half*H}, via nsteps of imaginary-time TDVP
+    (dt=-1j*(dbeta_half/nsteps) passed to tdvp_step's own -i*dt real-time
+    convention -- see this module's docstring for why that gives genuine
+    decay rather than rotation), renormalizing after every step since
+    imaginary-time evolution isn't norm-preserving (unlike the real-time
+    case tdvp_step was originally written for)."""
+    dt = -1j * (dbeta_half / nsteps)
+    for _ in range(nsteps):
+        psi = tdvp_step(psi, H, dt, cutoff=cutoff, maxdim=maxdim, niter=niter)
+        psi.normalize()
+    return psi
+
+
+def metts_thermal_average(H, sites, ops, beta, nsamples, nwarmup=20,
+                           dbeta_half_step=0.05, cutoff=1e-10, maxdim=200,
+                           basis_ops=("Sz",), initial_cps=None, seed=None,
+                           niter=30):
+    """Estimate Tr[A e^{-beta H}]/Tr[e^{-beta H}] for each MPO A in `ops`
+    via METTS sampling (arXiv:1002.1305).
+
+    beta: inverse temperature (1/T).
+    nsamples: number of retained METTS samples, after nwarmup discarded
+        equilibration steps of the Markov chain.
+    dbeta_half_step: TDVP imaginary-time step size for the e^{-beta H/2}
+        evolution, split into ceil((beta/2)/dbeta_half_step) equal steps.
+    basis_ops: sequence of single-site operator names to cycle the
+        collapse basis over, one per sample (e.g. ("Sz","Sx") for
+        spin-1/2 -- see module docstring on why alternation matters).
+    initial_cps: an MPS product state seeding the chain; a random CPS in
+        basis_ops[0] if not given.
+
+    Returns (means, stderrs): means[j] is the sample mean of ops[j],
+    stderrs[j] its naive iid standard error over the nsamples retained
+    samples. METTS samples are Markov-correlated, so this underestimates
+    the true error unless dbeta_half_step/nwarmup are generous enough
+    that consecutive samples actually decorrelate (paper, Sec. 3.3).
+    """
+    rng = np.random.default_rng(seed)
+    beta_half = beta / 2.0
+    nsteps = max(1, int(np.ceil(beta_half / dbeta_half_step)))
+
+    cps = initial_cps if initial_cps is not None else random_cps(sites, basis_ops[0], rng)
+
+    nbasis = len(basis_ops)
+    samples = [[] for _ in ops]
+    total_iters = nwarmup + nsamples
+    for it in range(total_iters):
+        phi = imaginary_time_evolve(cps, H, beta_half, nsteps, cutoff, maxdim, niter=niter)
+        if it >= nwarmup:
+            for j, A in enumerate(ops):
+                samples[j].append(inner(phi, A, phi))
+        basis = basis_ops[it % nbasis]
+        cps, _ = collapse_to_cps(phi, sites, basis, rng)
+
+    means, stderrs = [], []
+    for vals in samples:
+        arr = np.array(vals)
+        means.append(arr.mean())
+        stderrs.append(arr.std(ddof=1) / np.sqrt(len(arr)) if len(arr) > 1 else 0.0)
+    return means, stderrs

--- a/src/dmrgpy/pyitensor/metts.py
+++ b/src/dmrgpy/pyitensor/metts.py
@@ -92,6 +92,20 @@ def _eigenbasis(sites, opname, i):
     return np.linalg.eigh(M)
 
 
+def _build_eigcache(sites, basis_ops):
+    """{(opname, i): (evals, evecs)} for every (opname, site) pair the
+    sampling run will ever need, computed once up front. Without this,
+    random_cps()/collapse_to_cps() would recompute the same operator's
+    eigendecomposition from scratch at every site on every one of the
+    nwarmup+nsamples Markov-chain iterations, even though a given
+    (opname, i)'s eigenbasis never changes across the whole run -- with
+    n sites and O(200-300) iterations that's tens of thousands of
+    redundant eigh() calls for no reason."""
+    n = sites.length()
+    return {(opname, i): _eigenbasis(sites, opname, i)
+            for opname in set(basis_ops) for i in range(1, n + 1)}
+
+
 def product_state(sites, vectors):
     """An MPS product state (bond dimension 1 throughout) from a list of
     per-site complex vectors (vectors[i-1], length sites.dim(i)). Trivial
@@ -119,22 +133,25 @@ def product_state(sites, vectors):
     return mps
 
 
-def random_cps(sites, opname, rng):
+def random_cps(sites, opname, rng, eigcache=None):
     """A random classical product state: at each site, uniformly pick one
     eigenstate of the named single-site operator (e.g. "Sz"). Valid seed
     for the METTS Markov chain regardless of choice -- the chain's
     stationary distribution doesn't depend on the starting CPS (paper,
-    Sec. 2), only how many warmup steps are needed to reach it."""
+    Sec. 2), only how many warmup steps are needed to reach it.
+
+    eigcache: optional {(opname, i): (evals, evecs)} from
+    _build_eigcache(), used instead of recomputing on every call."""
     n = sites.length()
     vectors = []
     for i in range(1, n + 1):
-        _, evecs = _eigenbasis(sites, opname, i)
+        _, evecs = eigcache[(opname, i)] if eigcache is not None else _eigenbasis(sites, opname, i)
         k = rng.integers(0, sites.dim(i))
         vectors.append(evecs[:, k].copy())
     return product_state(sites, vectors)
 
 
-def collapse_to_cps(psi, sites, opname, rng):
+def collapse_to_cps(psi, sites, opname, rng, eigcache=None):
     """Sequential ("perfect") sampling collapse of MPS `psi` onto a new
     classical product state built from eigenstates of the single-site
     Hermitian operator `opname` (e.g. "Sz" or "Sx") -- the paper's
@@ -153,6 +170,9 @@ def collapse_to_cps(psi, sites, opname, rng):
     original MPS's own truncation), never requiring the full
     exponentially-sized amplitude vector.
 
+    eigcache: optional {(opname, i): (evals, evecs)} from
+    _build_eigcache(), used instead of recomputing on every call.
+
     Returns (new_cps_mps, outcomes): outcomes[i-1] is the sampled
     eigenvalue (float) at site i, for diagnostics only.
     """
@@ -163,7 +183,7 @@ def collapse_to_cps(psi, sites, opname, rng):
     outcomes = []
     L = None  # running collapsed-prefix amplitude, an ITensor over the current left link, or None at site 1
     for i in range(1, n + 1):
-        evals, evecs = _eigenbasis(sites, opname, i)
+        evals, evecs = eigcache[(opname, i)] if eigcache is not None else _eigenbasis(sites, opname, i)
         T = work.A(i)
         if L is not None:
             T = L * T
@@ -225,11 +245,19 @@ def metts_thermal_average(H, sites, ops, beta, nsamples, nwarmup=20,
     the true error unless dbeta_half_step/nwarmup are generous enough
     that consecutive samples actually decorrelate (paper, Sec. 3.3).
     """
+    if beta <= 0:
+        raise ValueError("metts_thermal_average: beta (1/T) must be > 0, got %r" % (beta,))
+    if not basis_ops:
+        raise ValueError("metts_thermal_average: basis_ops must be non-empty")
+    if nsamples < 1:
+        raise ValueError("metts_thermal_average: nsamples must be >= 1, got %r" % (nsamples,))
+
     rng = np.random.default_rng(seed)
     beta_half = beta / 2.0
     nsteps = max(1, int(np.ceil(beta_half / dbeta_half_step)))
+    eigcache = _build_eigcache(sites, basis_ops)
 
-    cps = initial_cps if initial_cps is not None else random_cps(sites, basis_ops[0], rng)
+    cps = initial_cps if initial_cps is not None else random_cps(sites, basis_ops[0], rng, eigcache)
 
     nbasis = len(basis_ops)
     samples = [[] for _ in ops]
@@ -240,7 +268,7 @@ def metts_thermal_average(H, sites, ops, beta, nsamples, nwarmup=20,
             for j, A in enumerate(ops):
                 samples[j].append(inner(phi, A, phi))
         basis = basis_ops[it % nbasis]
-        cps, _ = collapse_to_cps(phi, sites, basis, rng)
+        cps, _ = collapse_to_cps(phi, sites, basis, rng, eigcache)
 
     means, stderrs = [], []
     for vals in samples:

--- a/src/dmrgpy/vevtk/mettsvev.py
+++ b/src/dmrgpy/vevtk/mettsvev.py
@@ -1,0 +1,70 @@
+"""METTS-based finite-temperature vev -- a Many_Body_Chain-facing wrapper
+around Chain.metts_vev() (pyitensor.chain.Chain for itensor_version=
+"python", mpscpp3's Chain::metts_vev in-process pybind11 method for
+itensor_version=3). See pyitensor/metts.py for the algorithm itself
+(White & Stoudenmire, "Minimally entangled typical thermal state
+algorithms", New J. Phys. 12, 055026 (2010), arXiv:1002.1305) --
+mpscpp3/chain_session.h's own Chain::metts_vev is a direct port of that
+same algorithm onto real ITensor v3 (imaginary-time TDVP + a sequential-
+sampling MPS collapse using diagHermitian() for the per-site basis
+rotation), not an independent implementation.
+
+Only itensor_version in ("python", 3) are wired up -- itensor_version=2
+(mpscpp2, no TDVP module at all) doesn't have a route to imaginary-time
+evolution, so isn't supported. This is a genuinely different finite-
+temperature method from the two already in this codebase: thermal.py's
+Thermal_Spin_Chain (ancilla purification + imaginary-time annealing of a
+single, growing-entanglement wavefunction) and vevtk/thermalvev.py's
+thermal_vev_ex (exact Boltzmann sum over ED excited states) -- METTS
+instead samples many *unentangled* typical states and averages, trading
+exactness for a bond dimension that stays small even at low temperature
+(no ancilla doubling).
+"""
+
+import random
+
+
+def metts_vev(MB, Op, T, nsamples=200, nwarmup=20, dbeta_half_step=0.05,
+              basis_ops=("Sz", "Sx"), seed=None, niter=30):
+    """Thermal <Op> at temperature T via METTS sampling.
+
+    MB: a Many_Body_Chain with itensor_version in ("python", 3) and a
+        Hamiltonian already set via MB.set_hamiltonian(...).
+    Op: a MultiOperator (the observable to measure).
+    Returns (mean, stderr) -- see
+    pyitensor.metts.metts_thermal_average's own docstring for the
+    stderr's (Markov-correlated, so optimistic) meaning.
+    """
+    if MB.itensor_version not in ("python", 3):
+        raise NotImplementedError(
+            "metts_vev is only implemented for itensor_version='python' or "
+            "3 so far (got itensor_version=%r)" % (MB.itensor_version,))
+    if MB.itensor_version == 3 and MB.ns < 3:
+        # Same underlying vendored-ITensor limitation CLAUDE.md documents
+        # for v3's two-site dmrg() (mode.py's get_mode() falls back to ED
+        # for it there): two-site TDVP hits the identical "LocalOp is
+        # default constructed" SIGABRT for chains this short, confirmed
+        # directly. metts_vev() doesn't go through get_mode() (it isn't a
+        # DMRG-vs-ED choice), so it needs its own guard here rather than
+        # silently inheriting that fallback -- and unlike gs_energy/vev,
+        # there's no ED-based METTS to fall back to, so this raises
+        # instead of substituting a different method.
+        raise NotImplementedError(
+            "metts_vev with itensor_version=3 can't handle a chain this "
+            "short (n=%d < 3 sites): ITensor v3's two-site TDVP aborts the "
+            "whole process for chains below 3 sites (the same vendored-"
+            "ITensor limitation as its two-site dmrg(), see CLAUDE.md). "
+            "Use itensor_version='python' instead for small chains." % (MB.ns,))
+    MB._session.set_sweep_params(MB.maxm, MB.nsweeps, MB.cutoff, MB.noise)
+    MB._session.set_verbose(MB.verbose)
+    MB._session.set_mpomaxm(max(MB.maxm, MB.mpomaxm))
+    MB._session.set_hamiltonian(MB.hamiltonian.to_terms())
+    # Both backends' metts_vev want a concrete integer seed (the C++ side
+    # has no equivalent of Python's seed=None "fresh entropy" convention),
+    # so draw one here when the caller didn't pin one -- keeps the
+    # non-reproducible-by-default behavior every other seed= kwarg in
+    # this codebase has, rather than silently becoming deterministic.
+    seed_arg = seed if seed is not None else random.getrandbits(63)
+    return MB._session.metts_vev(
+        Op.to_terms(), T, nsamples, nwarmup,
+        dbeta_half_step, list(basis_ops), seed_arg, niter)

--- a/src/dmrgpy/vevtk/mettsvev.py
+++ b/src/dmrgpy/vevtk/mettsvev.py
@@ -55,6 +55,21 @@ def metts_vev(MB, Op, T, nsamples=200, nwarmup=20, dbeta_half_step=0.05,
             "whole process for chains below 3 sites (the same vendored-"
             "ITensor limitation as its two-site dmrg(), see CLAUDE.md). "
             "Use itensor_version='python' instead for small chains." % (MB.ns,))
+    # Validate here rather than relying on either backend's own checks:
+    # mpscpp3/chain_session.h's Chain::metts_vev does validate T/basis_ops/
+    # nsamples too, but via ITensor's Error(), which -- unlike a normal C++
+    # exception -- calls abort() directly (see itensor/util/error.h) and so
+    # can never be caught from Python; it's only a last-resort safety net
+    # against direct _session.metts_vev() misuse, not a substitute for a
+    # real, catchable check here (confirmed directly: a T<=0 call used to
+    # SIGABRT the whole interpreter instead of raising before this check
+    # was added).
+    if T <= 0:
+        raise ValueError("metts_vev: T must be > 0, got %r" % (T,))
+    if not basis_ops:
+        raise ValueError("metts_vev: basis_ops must be non-empty")
+    if nsamples < 1:
+        raise ValueError("metts_vev: nsamples must be >= 1, got %r" % (nsamples,))
     MB._session.set_sweep_params(MB.maxm, MB.nsweeps, MB.cutoff, MB.noise)
     MB._session.set_verbose(MB.verbose)
     MB._session.set_mpomaxm(max(MB.maxm, MB.mpomaxm))

--- a/tests/test_metts_vev.py
+++ b/tests/test_metts_vev.py
@@ -1,0 +1,121 @@
+"""Regression coverage for Many_Body_Chain.metts_vev() (finite-temperature
+expectation values via the METTS -- Minimally Entangled Typical Thermal
+States -- sampling algorithm, White & Stoudenmire, New Journal of Physics
+12, 055026 (2010), arXiv:1002.1305).
+
+METTS is implemented for itensor_version="python" (pyitensor/metts.py) and
+itensor_version=3 (mpscpp3/chain_session.h's Chain::metts_vev, a direct
+port of the same algorithm onto real ITensor v3 -- see its own comment)::
+imaginary-time TDVP evolution of a classical product state by
+e^{-beta H/2}, then a sequential/"perfect sampling" collapse back down to
+a new product state, alternating the collapse basis between Sz and Sx for
+ergodicity. This is a genuinely different, independent finite-temperature
+method from the two already covered elsewhere (thermal.py's ancilla-
+purification anneal(), tested in test_thermal_purification_VS_exact's
+underlying example, and vevtk/thermalvev.py's exact ED Boltzmann sum over
+excited states, tested in test_thermal_vev.py) -- so this is validated
+directly against the same kind of full-spectrum ED reference those use,
+not against either of them.
+
+METTS is a Monte Carlo method: exact agreement isn't expected, only
+agreement within a generous multiple of the reported (Markov-correlated,
+so likely optimistic) standard error -- these seeds/sample counts were
+picked empirically (see the module-level comment on parameters below) to
+give several-sigma headroom without an unreasonably slow test.
+"""
+import pytest
+
+from dmrgpy import cppext, spinchain
+
+VERSIONS = [
+    "python",
+    pytest.param(3, marks=pytest.mark.skipif(
+        not cppext.available(3),
+        reason="requires the compiled mpscpp3 (ITensor v3) extension")),
+]
+
+
+def _heisenberg_field_chain(n, version, J=1.0, B=0.3):
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    if version == "python":
+        sc.setup_python()
+    else:
+        sc.setup_cpp(version=version)
+    h = 0
+    for i in range(n - 1):
+        h = h + J * sc.Sx[i] * sc.Sx[i + 1] + J * sc.Sy[i] * sc.Sy[i + 1] + J * sc.Sz[i] * sc.Sz[i + 1]
+    for i in range(n):
+        h = h + B * sc.Sz[i]
+    sc.set_hamiltonian(h)
+    return sc, h
+
+
+def test_metts_matches_ed_two_site_magnetization():
+    """2-site Heisenberg chain + field: METTS's own reported standard
+    error at these sample counts is ~0.013 (measured empirically); the
+    actual deviation from the exact ED thermal average is ~0.002, so
+    tol=0.05 (~4x that error) is generous headroom against an unlucky
+    seed while still catching a real algorithmic regression (e.g. a sign
+    error in the collapse or the imaginary-time step, which previously
+    produced ~10x larger discrepancies during development). python-only:
+    ITensor v3's two-site TDVP aborts the whole process for chains below
+    3 sites (same vendored-ITensor limitation as its two-site dmrg(), see
+    CLAUDE.md and test_metts_vev_v3_rejects_short_chain below)."""
+    sc, h = _heisenberg_field_chain(2, "python")
+    T = 1.0
+
+    ed_sz = sc.vev(sc.Sz[0], mode="ED", T=T)
+    metts_sz, err_sz = sc.metts_vev(sc.Sz[0], T, nsamples=600, nwarmup=50,
+                                     dbeta_half_step=0.05, seed=2024)
+
+    assert metts_sz.real == pytest.approx(ed_sz.real, abs=0.05)
+    assert err_sz < 0.03  # sanity check the stochastic error itself is small
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_matches_ed_three_site_energy_and_magnetization(version):
+    """3-site chain: cross-checks both the thermal energy (a stringent
+    check -- a bug in the imaginary-time TDVP propagator would show up as
+    a systematic energy bias, not just sampling noise) and a local <Sz>,
+    each against the exact ED Boltzmann average. Parametrized over the
+    pure-Python and ITensor v3 backends -- both implement the identical
+    algorithm (see module docstring), so both must agree with ED."""
+    sc, h = _heisenberg_field_chain(3, version, B=0.4)
+    T = 0.8
+
+    ed_e = sc.vev(h, mode="ED", T=T)
+    ed_sz = sc.vev(sc.Sz[1], mode="ED", T=T)
+
+    metts_e, err_e = sc.metts_vev(h, T, nsamples=300, nwarmup=30,
+                                   dbeta_half_step=0.08, seed=77)
+    metts_sz, err_sz = sc.metts_vev(sc.Sz[1], T, nsamples=300, nwarmup=30,
+                                     dbeta_half_step=0.08, seed=77)
+
+    assert metts_e.real == pytest.approx(ed_e.real, abs=0.05)
+    assert metts_sz.real == pytest.approx(ed_sz.real, abs=0.05)
+
+
+def test_metts_vev_requires_supported_backend():
+    """METTS needs imaginary-time TDVP + sequential-sampling MPS collapse;
+    mpscpp2 (ITensor v2) has no TDVP module at all -- metts_vev must raise
+    a clear error rather than silently dispatching to the wrong backend or
+    crashing deep inside cppext."""
+    sc, h = _heisenberg_field_chain(2, "python")
+    sc.itensor_version = 2  # simulate a non-python/non-v3 backend without touching cppext
+    with pytest.raises(NotImplementedError):
+        sc.metts_vev(sc.Sz[0], 1.0, nsamples=2, nwarmup=1)
+
+
+def test_metts_vev_v3_rejects_short_chain():
+    """ITensor v3's two-site TDVP hits the same 'LocalOp is default
+    constructed' SIGABRT as its two-site dmrg() for chains below 3 sites
+    (see CLAUDE.md's documented mpscpp3 bug) -- confirmed directly during
+    development (a 2-site metts_vev call crashed the whole process before
+    this guard was added). metts_vev must raise a catchable Python
+    exception instead, same as the itensor_version dispatch guard above.
+    This only exercises the Python-side guard (fires before ever touching
+    self._session), so it needs no compiled extension to run."""
+    sc, h = _heisenberg_field_chain(2, "python")
+    sc.itensor_version = 3
+    with pytest.raises(NotImplementedError):
+        sc.metts_vev(sc.Sz[0], 1.0, nsamples=2, nwarmup=1)

--- a/tests/test_metts_vev.py
+++ b/tests/test_metts_vev.py
@@ -27,6 +27,8 @@ import pytest
 
 from dmrgpy import cppext, spinchain
 
+from _helpers import setup_backend
+
 VERSIONS = [
     "python",
     pytest.param(3, marks=pytest.mark.skipif(
@@ -37,10 +39,7 @@ VERSIONS = [
 
 def _heisenberg_field_chain(n, version, J=1.0, B=0.3):
     sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
-    if version == "python":
-        sc.setup_python()
-    else:
-        sc.setup_cpp(version=version)
+    setup_backend(sc, version)
     h = 0
     for i in range(n - 1):
         h = h + J * sc.Sx[i] * sc.Sx[i + 1] + J * sc.Sy[i] * sc.Sy[i + 1] + J * sc.Sz[i] * sc.Sz[i + 1]
@@ -119,3 +118,51 @@ def test_metts_vev_v3_rejects_short_chain():
     sc.itensor_version = 3
     with pytest.raises(NotImplementedError):
         sc.metts_vev(sc.Sz[0], 1.0, nsamples=2, nwarmup=1)
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_vev_rejects_non_positive_temperature(version):
+    """T<=0 must raise rather than silently flip the imaginary-time step's
+    sign (beta=1/T negative would make the 'decay' amplify high-energy
+    components instead of suppressing them, a silently wrong thermal
+    average with no error). Checked in vevtk/mettsvev.py *before*
+    dispatching to either backend's own session: mpscpp3/chain_session.h's
+    Chain::metts_vev does validate this too, but via ITensor's Error(),
+    which calls abort() directly (see itensor/util/error.h) rather than
+    throwing a catchable exception -- confirmed directly, a T<=0 call used
+    to SIGABRT the whole interpreter instead of raising. That C++-side
+    check is only a last-resort safety net against direct
+    _session.metts_vev() misuse, not something a Python test can exercise
+    without crashing the test process, so this test only ever reaches the
+    Python-level guard."""
+    sc, h = _heisenberg_field_chain(3, version)
+    with pytest.raises(ValueError):
+        sc.metts_vev(sc.Sz[0], -1.0, nsamples=2, nwarmup=1)
+    with pytest.raises(ValueError):
+        sc.metts_vev(sc.Sz[0], 0.0, nsamples=2, nwarmup=1)
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_vev_rejects_empty_basis_ops(version):
+    """An empty basis_ops would otherwise index basis_ops[0] out of bounds
+    (undefined behavior in the C++ port) or KeyError deep inside the
+    Python one -- caught by vevtk/mettsvev.py's own check before either
+    backend's session ever sees it (see
+    test_metts_vev_rejects_non_positive_temperature's docstring on why
+    the C++-side check alone isn't something a Python test can rely on)."""
+    sc, h = _heisenberg_field_chain(3, version)
+    with pytest.raises(ValueError):
+        sc.metts_vev(sc.Sz[0], 1.0, nsamples=2, nwarmup=1, basis_ops=())
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_vev_rejects_non_positive_nsamples(version):
+    """nsamples<1 would otherwise leave the retained-samples list empty
+    and divide by zero when averaging (silently producing NaN in the C++
+    port before this guard was added) -- caught by vevtk/mettsvev.py's own
+    check before either backend's session ever sees it (see
+    test_metts_vev_rejects_non_positive_temperature's docstring on why the
+    C++-side check alone isn't something a Python test can rely on)."""
+    sc, h = _heisenberg_field_chain(3, version)
+    with pytest.raises(ValueError):
+        sc.metts_vev(sc.Sz[0], 1.0, nsamples=0, nwarmup=1)


### PR DESCRIPTION
## Summary
- Implements METTS (Minimally Entangled Typical Thermal States, White & Stoudenmire, arXiv:1002.1305) as a third, independent finite-temperature method alongside the existing purification (`thermal.py`) and ED-Boltzmann-sum (`vevtk/thermalvev.py`) approaches: imaginary-time TDVP evolution of a classical product state by `e^{-beta H/2}`, then a sequential ("perfect sampling") collapse back to a new product state, alternating the collapse basis between Sz and Sx for ergodicity.
- `pyitensor/metts.py` has the reference algorithm, wired up as `Chain.metts_vev()` in `pyitensor/chain.py`.
- `mpscpp3/chain_session.h` + `bindings.cc` port the same algorithm onto real ITensor v3 (`diagHermitian()` for the per-site eigenbasis rotation, `setElt()`-built product states), reusing the existing `tdvp_step()`'s `-i*dt` convention for imaginary time — no new evolution primitive needed.
- `Many_Body_Chain.metts_vev()` / `vevtk/mettsvev.py` dispatch to `itensor_version` `"python"` or `3` (not `2`, which has no TDVP), including a guard against v3's known `<3`-site TDVP abort (same underlying vendored-ITensor bug as its two-site `dmrg()`, documented in CLAUDE.md).
- `docs/user_guide.md`/`.tex` updated (§9 Finite temperature).

## Test plan
- [x] `tests/test_metts_vev.py` (both `itensor_version="python"` and `3`) — METTS thermal energy/magnetization agree with exact ED Boltzmann averages on 2-3 site Heisenberg chains within a few times the reported (Markov-correlated) standard error.
- [x] `examples/finite_temperature/metts_VS_exact` — same cross-check across a small temperature scan, both backends.
- [x] Full `pytest tests` suite run with the newly-compiled ITensor v3 extension: no regressions (the one remaining failure, `test_tdz_dynamical_correlator_peak_matches_exact_gap[2]`, is pre-existing/environment-only — mpscpp2 isn't compiled in this sandbox — and touches no file this PR changes).
- [x] `docs/user_guide.tex` recompiles cleanly with `pdflatex` (no errors).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t