### PR TITLE
Add parallel METTS sampling (njobs) for the pyitensor backend

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -896,6 +896,32 @@ the entanglement of a single ever-more-thermalized wavefunction) — see
 `examples/finite_temperature/metts_VS_exact` for a cross-check against
 the exact ED thermal average on a small Heisenberg chain.
 
+For `itensor_version="python"`, an `njobs` keyword (default 1) runs
+`njobs` independent METTS Markov chains in parallel worker processes and
+pools their statistics, instead of one longer sequential chain —
+`nsamples` is split as evenly as possible across them, each chain gets
+its own `nwarmup` equilibration and an independently-seeded RNG, and
+their per-chain `(mean, stderr, count)` triples are combined into the
+same `(mean, stderr)` a single pooled run over all the raw samples would
+give (no raw samples need to cross the process boundary, so this is
+exact, not an approximation). Measured directly on a 6-site chain
+(`nsamples=200`, `nwarmup=20`): wall time went from 34s at `njobs=1`
+down to 14s at `njobs=8` — real but sub-linear speedup, since every
+extra chain repeats the full `nwarmup` rather than sharing it. This is
+the effective optimization for this backend: its per-sample cost is
+dominated by `pyitensor`'s own generic-tensor-engine Python overhead
+(confirmed by profiling), not shared BLAS work, so splitting across OS
+processes helps where the `kernels.py` JAX/numba contraction-kernel
+route does not (see that module's docstring, and
+`pyitensor/metts.py`'s own comment, on why numba is measurably *slower*
+for METTS specifically — each sample restarts from a fresh
+bond-dimension-1 product state, so a run exercises many distinct
+contraction shapes rather than reusing one, and the fixed per-shape
+compile tax never amortizes). `njobs` is not available for
+`itensor_version=3`: its session is a single live in-process C++ object
+with no per-worker copy a process pool could hand out; requesting
+`njobs>1` there raises rather than silently falling back to `njobs=1`.
+
 ## 10. Topological invariants
 
 **Many-body Berry phase.** For a ground state that depends on an

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1051,6 +1051,34 @@ ever-more-thermalized wavefunction) --- see
 \texttt{examples/finite\_temperature/metts\_VS\_exact} for a cross-check
 against the exact ED thermal average on a small Heisenberg chain.
 
+For \texttt{itensor\_version="python"}, an \texttt{njobs} keyword
+(default 1) runs \texttt{njobs} independent METTS Markov chains in
+parallel worker processes and pools their statistics, instead of one
+longer sequential chain --- \texttt{nsamples} is split as evenly as
+possible across them, each chain gets its own \texttt{nwarmup}
+equilibration and an independently-seeded RNG, and their per-chain
+\texttt{(mean, stderr, count)} triples are combined into the same
+\texttt{(mean, stderr)} a single pooled run over all the raw samples
+would give (no raw samples need to cross the process boundary, so this
+is exact, not an approximation). Measured directly on a 6-site chain
+(\texttt{nsamples=200}, \texttt{nwarmup=20}): wall time went from 34s at
+\texttt{njobs=1} down to 14s at \texttt{njobs=8} --- real but sub-linear
+speedup, since every extra chain repeats the full \texttt{nwarmup}
+rather than sharing it. This is the effective optimization for this
+backend: its per-sample cost is dominated by \texttt{pyitensor}'s own
+generic-tensor-engine Python overhead (confirmed by profiling), not
+shared BLAS work, so splitting across OS processes helps where the
+\texttt{kernels.py} JAX/numba contraction-kernel route does not (see
+that module's docstring, and \texttt{pyitensor/metts.py}'s own comment,
+on why numba is measurably \emph{slower} for METTS specifically --- each
+sample restarts from a fresh bond-dimension-1 product state, so a run
+exercises many distinct contraction shapes rather than reusing one, and
+the fixed per-shape compile tax never amortizes). \texttt{njobs} is not
+available for \texttt{itensor\_version=3}: its session is a single live
+in-process C++ object with no per-worker copy a process pool could hand
+out; requesting \texttt{njobs>1} there raises rather than silently
+falling back to \texttt{njobs=1}.
+
 \section{Topological invariants}
 
 \textbf{Many-body Berry phase.} For a ground state that depends on an

--- a/src/dmrgpy/pyitensor/chain.py
+++ b/src/dmrgpy/pyitensor/chain.py
@@ -646,7 +646,8 @@ class Chain:
         return self._kpm_moments(m, wfa, wfb, num_polynomials, kpmmaxm, kpm_cutoff, kpm_accelerate)
 
     def metts_vev(self, terms_op, T, nsamples=200, nwarmup=20,
-                  dbeta_half_step=0.05, basis_ops=("Sz", "Sx"), seed=None, niter=30):
+                  dbeta_half_step=0.05, basis_ops=("Sz", "Sx"), seed=None, niter=30,
+                  njobs=1):
         """Finite-temperature <A> via METTS sampling (White & Stoudenmire,
         arXiv:1002.1305 -- see metts.py for the full algorithm). Reuses
         self.H (already built by set_hamiltonian) and this chain's own
@@ -654,7 +655,10 @@ class Chain:
         every other method here. Single-operator signature (terms_op is
         one MultiOperator.to_terms() output), matching every other vev-
         like method's surface here (vev, overlap_aMb, ...) -- this keeps
-        the same call signature mpscpp3's own Chain::metts_vev exposes.
+        the same call signature mpscpp3's own Chain::metts_vev exposes
+        (njobs is therefore a keyword-only *addition*, python-only --
+        vevtk/mettsvev.py never forwards it to the compiled v3 session,
+        see that module's own njobs guard).
 
         Returns (mean, stderr) -- see metts_thermal_average()'s own
         docstring for what these mean and their (Markov-correlated, so
@@ -668,7 +672,7 @@ class Chain:
         means, stderrs = _metts_thermal_average(
             self.H, self.sites, [op], beta, nsamples, nwarmup=nwarmup,
             dbeta_half_step=dbeta_half_step, cutoff=self.cutoff, maxdim=self.maxm,
-            basis_ops=basis_ops, seed=seed, niter=niter)
+            basis_ops=basis_ops, seed=seed, niter=niter, njobs=njobs)
         return means[0], stderrs[0]
 
     def nhkpm_moments(self, terms_hs, terms_hs_dag, wfa, wfb, n, kpmmaxm, kpmcutoff):

--- a/src/dmrgpy/pyitensor/metts.py
+++ b/src/dmrgpy/pyitensor/metts.py
@@ -54,6 +54,8 @@ this is wired into the rest of the engine (H and the observables' MPOs are
 each built once from MultiOperator terms and reused across every sample).
 """
 
+import multiprocessing
+
 import numpy as np
 
 from .index import Index
@@ -221,37 +223,14 @@ def imaginary_time_evolve(psi, H, dbeta_half, nsteps, cutoff, maxdim, niter=30):
     return psi
 
 
-def metts_thermal_average(H, sites, ops, beta, nsamples, nwarmup=20,
-                           dbeta_half_step=0.05, cutoff=1e-10, maxdim=200,
-                           basis_ops=("Sz",), initial_cps=None, seed=None,
-                           niter=30):
-    """Estimate Tr[A e^{-beta H}]/Tr[e^{-beta H}] for each MPO A in `ops`
-    via METTS sampling (arXiv:1002.1305).
-
-    beta: inverse temperature (1/T).
-    nsamples: number of retained METTS samples, after nwarmup discarded
-        equilibration steps of the Markov chain.
-    dbeta_half_step: TDVP imaginary-time step size for the e^{-beta H/2}
-        evolution, split into ceil((beta/2)/dbeta_half_step) equal steps.
-    basis_ops: sequence of single-site operator names to cycle the
-        collapse basis over, one per sample (e.g. ("Sz","Sx") for
-        spin-1/2 -- see module docstring on why alternation matters).
-    initial_cps: an MPS product state seeding the chain; a random CPS in
-        basis_ops[0] if not given.
-
-    Returns (means, stderrs): means[j] is the sample mean of ops[j],
-    stderrs[j] its naive iid standard error over the nsamples retained
-    samples. METTS samples are Markov-correlated, so this underestimates
-    the true error unless dbeta_half_step/nwarmup are generous enough
-    that consecutive samples actually decorrelate (paper, Sec. 3.3).
-    """
-    if beta <= 0:
-        raise ValueError("metts_thermal_average: beta (1/T) must be > 0, got %r" % (beta,))
-    if not basis_ops:
-        raise ValueError("metts_thermal_average: basis_ops must be non-empty")
-    if nsamples < 1:
-        raise ValueError("metts_thermal_average: nsamples must be >= 1, got %r" % (nsamples,))
-
+def _metts_single_chain(H, sites, ops, beta, nsamples, nwarmup,
+                         dbeta_half_step, cutoff, maxdim, basis_ops,
+                         initial_cps, seed, niter):
+    """One full METTS Markov chain (nwarmup discarded + nsamples retained
+    iterations), sequential -- the body metts_thermal_average() always ran
+    before njobs= was added. Returns (means, stderrs, nsamples) -- the
+    trailing nsamples is only needed by _pool_chain_results() below, to
+    weight/combine several independent chains' statistics correctly."""
     rng = np.random.default_rng(seed)
     beta_half = beta / 2.0
     nsteps = max(1, int(np.ceil(beta_half / dbeta_half_step)))
@@ -275,4 +254,137 @@ def metts_thermal_average(H, sites, ops, beta, nsamples, nwarmup=20,
         arr = np.array(vals)
         means.append(arr.mean())
         stderrs.append(arr.std(ddof=1) / np.sqrt(len(arr)) if len(arr) > 1 else 0.0)
-    return means, stderrs
+    return means, stderrs, nsamples
+
+
+def _run_chain_worker(args):
+    """Top-level (picklable) target for multiprocessing.Pool -- a bound
+    method or closure wouldn't survive pickling under the 'spawn' start
+    method, so this just unpacks a plain tuple and calls
+    _metts_single_chain() directly."""
+    return _metts_single_chain(*args)
+
+
+def _pool_chain_results(results, nops):
+    """Combine several independent chains' (means, stderrs, nsamples)
+    triples into the single (means, stderrs) pair metts_thermal_average()
+    would have returned had all chains' retained samples been pooled into
+    one flat array -- without ever needing the raw per-sample values
+    themselves (each chain only reports its own mean/stderr/count).
+
+    Exact, not approximate: writing v_k = stderr_k^2 * n_k for chain k's
+    own (ddof=1) sample variance and M for the pooled mean, the identity
+    sum_i |x_i - M|^2 = sum_k [ (n_k-1)*v_k + n_k*|m_k - M|^2 ]
+    holds for any partition of a dataset into groups (the cross term
+    sum_{i in k} (x_i - m_k) vanishes since m_k is group k's own mean) --
+    this holds equally for complex-valued samples (METTS <Op> can have a
+    small numerical-noise imaginary part) since |.|^2 is still the
+    relevant squared norm and the same orthogonality argument applies."""
+    means_out, stderrs_out = [], []
+    ns = np.array([n for _, _, n in results], dtype=float)
+    N = ns.sum()
+    for j in range(nops):
+        chain_means = np.array([means[j] for means, _, _ in results], dtype=complex)
+        chain_stderr = np.array([stderrs[j] for _, stderrs, _ in results], dtype=float)
+        chain_vars = chain_stderr ** 2 * ns
+        M = np.sum(ns * chain_means) / N
+        SS = np.sum((ns - 1) * chain_vars + ns * np.abs(chain_means - M) ** 2)
+        var_pooled = SS / (N - 1) if N > 1 else 0.0
+        means_out.append(M)
+        stderrs_out.append(np.sqrt(var_pooled / N) if N > 0 else 0.0)
+    return means_out, stderrs_out
+
+
+def metts_thermal_average(H, sites, ops, beta, nsamples, nwarmup=20,
+                           dbeta_half_step=0.05, cutoff=1e-10, maxdim=200,
+                           basis_ops=("Sz",), initial_cps=None, seed=None,
+                           niter=30, njobs=1):
+    """Estimate Tr[A e^{-beta H}]/Tr[e^{-beta H}] for each MPO A in `ops`
+    via METTS sampling (arXiv:1002.1305).
+
+    beta: inverse temperature (1/T).
+    nsamples: number of retained METTS samples, after nwarmup discarded
+        equilibration steps of the Markov chain.
+    dbeta_half_step: TDVP imaginary-time step size for the e^{-beta H/2}
+        evolution, split into ceil((beta/2)/dbeta_half_step) equal steps.
+    basis_ops: sequence of single-site operator names to cycle the
+        collapse basis over, one per sample (e.g. ("Sz","Sx") for
+        spin-1/2 -- see module docstring on why alternation matters).
+    initial_cps: an MPS product state seeding the chain; a random CPS in
+        basis_ops[0] if not given. Not supported together with njobs>1
+        (each parallel chain seeds its own independent random CPS -- a
+        single shared starting point wouldn't make sense split across
+        several otherwise-independent Markov chains).
+    njobs: run njobs independent METTS Markov chains in separate worker
+        processes (multiprocessing.Pool) instead of one -- nsamples is
+        split as evenly as possible across them, each with its own
+        nwarmup equilibration (a fresh chain has no warmup to share) and
+        an independently-seeded RNG derived from `seed` via
+        numpy.random.SeedSequence.spawn(), then their statistics are
+        combined exactly via _pool_chain_results() (no raw samples need
+        crossing the process boundary). This trades more total warmup
+        work (njobs*nwarmup steps instead of one chain's nwarmup) for
+        wall-clock time on a multi-core machine -- worth it whenever
+        nsamples/njobs is comfortably bigger than nwarmup, which is
+        exactly the profiled bottleneck: METTS's per-sample cost here is
+        dominated by this pure-Python tensor engine's own Python-level
+        bookkeeping overhead (see tdvp.py/tensor.py), not shared BLAS
+        work that would otherwise make multiprocessing redundant. njobs=1
+        (the default) is unchanged from before this parameter existed --
+        same single-process sequential chain, same seed reproducibility.
+
+    Returns (means, stderrs): means[j] is the sample mean of ops[j],
+    stderrs[j] its naive iid standard error over the nsamples retained
+    samples. METTS samples are Markov-correlated, so this underestimates
+    the true error unless dbeta_half_step/nwarmup are generous enough
+    that consecutive samples actually decorrelate (paper, Sec. 3.3).
+    """
+    if beta <= 0:
+        raise ValueError("metts_thermal_average: beta (1/T) must be > 0, got %r" % (beta,))
+    if not basis_ops:
+        raise ValueError("metts_thermal_average: basis_ops must be non-empty")
+    if nsamples < 1:
+        raise ValueError("metts_thermal_average: nsamples must be >= 1, got %r" % (nsamples,))
+    if njobs < 1:
+        raise ValueError("metts_thermal_average: njobs must be >= 1, got %r" % (njobs,))
+
+    if njobs == 1:
+        means, stderrs, _ = _metts_single_chain(
+            H, sites, ops, beta, nsamples, nwarmup, dbeta_half_step,
+            cutoff, maxdim, basis_ops, initial_cps, seed, niter)
+        return means, stderrs
+
+    if initial_cps is not None:
+        raise ValueError("metts_thermal_average: initial_cps is not supported together with njobs>1")
+
+    base, extra = divmod(nsamples, njobs)
+    chunk_sizes = [base + (1 if k < extra else 0) for k in range(njobs)]
+    chunk_sizes = [n for n in chunk_sizes if n > 0]
+    if len(chunk_sizes) == 1:
+        means, stderrs, _ = _metts_single_chain(
+            H, sites, ops, beta, chunk_sizes[0], nwarmup, dbeta_half_step,
+            cutoff, maxdim, basis_ops, None, seed, niter)
+        return means, stderrs
+
+    seeds = np.random.SeedSequence(seed).spawn(len(chunk_sizes))
+    tasks = [
+        (H, sites, ops, beta, n_local, nwarmup, dbeta_half_step, cutoff,
+         maxdim, basis_ops, None, seeds[k], niter)
+        for k, n_local in enumerate(chunk_sizes)
+    ]
+    # 'spawn', not the Linux default 'fork': confirmed directly this
+    # matters, not just a style preference. fork()ing a Pool worker from a
+    # parent process that has already run any numpy/scipy linear algebra
+    # (which every caller here has -- at minimum this module's own eigh()
+    # calls) duplicates whatever internal BLAS/OpenMP thread-pool state
+    # that parent has already spun up; the classic fork-after-threading
+    # hazard applies even though this process itself never touched the
+    # threading module. Measured directly on a 6-site chain, nsamples=200:
+    # the default fork-based Pool got monotonically *slower* as njobs grew
+    # (34s/62s/73s/100s for njobs=1/2/4/8 -- each extra worker added
+    # contention, not throughput), while 'spawn' (a fresh interpreter per
+    # worker, no inherited thread-pool state) gave the expected
+    # monotonic speedup on the same machine/workload (33s/21s/17s/14s).
+    with multiprocessing.get_context("spawn").Pool(len(chunk_sizes)) as pool:
+        results = pool.map(_run_chain_worker, tasks)
+    return _pool_chain_results(results, len(ops))

--- a/src/dmrgpy/vevtk/mettsvev.py
+++ b/src/dmrgpy/vevtk/mettsvev.py
@@ -25,12 +25,36 @@ import random
 
 
 def metts_vev(MB, Op, T, nsamples=200, nwarmup=20, dbeta_half_step=0.05,
-              basis_ops=("Sz", "Sx"), seed=None, niter=30):
+              basis_ops=("Sz", "Sx"), seed=None, niter=30, njobs=1):
     """Thermal <Op> at temperature T via METTS sampling.
 
     MB: a Many_Body_Chain with itensor_version in ("python", 3) and a
         Hamiltonian already set via MB.set_hamiltonian(...).
     Op: a MultiOperator (the observable to measure).
+    njobs: run njobs independent METTS Markov chains in parallel worker
+        processes and pool their statistics -- itensor_version="python"
+        only (see pyitensor.metts.metts_thermal_average's own docstring
+        for why, and for the exact pooling this uses). Measured directly
+        (6-site Heisenberg+field chain, nsamples=200, nwarmup=20): wall
+        time went 34s/21s/17s/14s for njobs=1/2/4/8 -- real but sublinear
+        speedup (diminishing returns, not a bug), since each additional
+        chain repeats the *full* nwarmup rather than sharing it, and each
+        spawned worker pays its own fresh-interpreter startup cost (see
+        below on why 'spawn' rather than fork). Worth it whenever
+        nsamples/njobs stays comfortably above nwarmup. Unlike
+        itensor_version=3, whose single, live in-process C++ session has
+        no multiprocessing story (no per-worker copy to hand out), and
+        unlike naively raising nsamples in a single chain, which buys no
+        parallelism at all. There is no equivalent knob for
+        itensor_version=3 here; see CLAUDE.md/kernels.py's own findings
+        on why the numba/JAX contraction-kernel route (the other lever
+        available for this pure-Python engine) makes METTS *slower*, not
+        faster: every sample restarts from a fresh bond-dimension-1
+        product state, so a run exercises many distinct contraction
+        shapes rather than the same one repeatedly, and the fixed
+        per-shape compile tax never gets amortized within a realistic
+        sample count -- confirmed directly, ~4x-24x slower with
+        kernels.USE_NUMBA=True depending on chain length, not faster.
     Returns (mean, stderr) -- see
     pyitensor.metts.metts_thermal_average's own docstring for the
     stderr's (Markov-correlated, so optimistic) meaning.
@@ -70,6 +94,21 @@ def metts_vev(MB, Op, T, nsamples=200, nwarmup=20, dbeta_half_step=0.05,
         raise ValueError("metts_vev: basis_ops must be non-empty")
     if nsamples < 1:
         raise ValueError("metts_vev: nsamples must be >= 1, got %r" % (nsamples,))
+    if njobs < 1:
+        raise ValueError("metts_vev: njobs must be >= 1, got %r" % (njobs,))
+    if njobs > 1 and MB.itensor_version != "python":
+        # mpscpp3's Chain is a single live in-process C++ session (see
+        # CLAUDE.md's cpp_handle section) -- there's no per-worker copy a
+        # multiprocessing pool could hand out the way pyitensor's Chain.H/
+        # sites (plain Python/numpy objects, confirmed picklable) allow.
+        # Rebuilding a whole separate v3 session per worker process is a
+        # bigger undertaking than this parameter is meant to cover, so
+        # this raises rather than silently ignoring njobs or silently
+        # falling back to a single sequential v3 chain.
+        raise NotImplementedError(
+            "metts_vev: njobs>1 (parallel independent Markov chains) is "
+            "only implemented for itensor_version='python' so far (got "
+            "itensor_version=%r)" % (MB.itensor_version,))
     MB._session.set_sweep_params(MB.maxm, MB.nsweeps, MB.cutoff, MB.noise)
     MB._session.set_verbose(MB.verbose)
     MB._session.set_mpomaxm(max(MB.maxm, MB.mpomaxm))
@@ -80,6 +119,10 @@ def metts_vev(MB, Op, T, nsamples=200, nwarmup=20, dbeta_half_step=0.05,
     # non-reproducible-by-default behavior every other seed= kwarg in
     # this codebase has, rather than silently becoming deterministic.
     seed_arg = seed if seed is not None else random.getrandbits(63)
+    if MB.itensor_version == "python":
+        return MB._session.metts_vev(
+            Op.to_terms(), T, nsamples, nwarmup,
+            dbeta_half_step, list(basis_ops), seed_arg, niter, njobs=njobs)
     return MB._session.metts_vev(
         Op.to_terms(), T, nsamples, nwarmup,
         dbeta_half_step, list(basis_ops), seed_arg, niter)

--- a/tests/test_metts_vev.py
+++ b/tests/test_metts_vev.py
@@ -155,6 +155,53 @@ def test_metts_vev_rejects_empty_basis_ops(version):
         sc.metts_vev(sc.Sz[0], 1.0, nsamples=2, nwarmup=1, basis_ops=())
 
 
+def test_metts_vev_njobs_parallel_chains_match_ed():
+    """njobs>1 (pyitensor/metts.py's parallel-independent-Markov-chains
+    path, python-only -- see that module's own docstring) must still
+    reproduce the same physics as the sequential njobs=1 path: nsamples
+    split across njobs independent chains, each with its own nwarmup and
+    an independently-seeded RNG, then combined via
+    _pool_chain_results()'s exact pooled-mean/pooled-variance formula.
+    Same generous tolerance as the other ED cross-checks above -- this
+    isn't re-testing METTS's own accuracy, only that splitting the work
+    across processes doesn't silently change the sampled distribution."""
+    sc, h = _heisenberg_field_chain(3, "python", B=0.4)
+    T = 0.8
+
+    ed_e = sc.vev(h, mode="ED", T=T)
+    ed_sz = sc.vev(sc.Sz[1], mode="ED", T=T)
+
+    metts_e, err_e = sc.metts_vev(h, T, nsamples=300, nwarmup=30,
+                                   dbeta_half_step=0.08, seed=77, njobs=3)
+    metts_sz, err_sz = sc.metts_vev(sc.Sz[1], T, nsamples=300, nwarmup=30,
+                                     dbeta_half_step=0.08, seed=77, njobs=3)
+
+    assert metts_e.real == pytest.approx(ed_e.real, abs=0.05)
+    assert metts_sz.real == pytest.approx(ed_sz.real, abs=0.05)
+
+
+def test_metts_vev_njobs_rejects_v3():
+    """itensor_version=3's Chain is a single live in-process C++ session
+    (see CLAUDE.md's cpp_handle section) with no per-worker copy a
+    multiprocessing pool could hand out, unlike pyitensor's picklable
+    plain-Python/numpy H/sites -- njobs>1 must raise rather than silently
+    ignoring the request or crashing deep inside a forked/pickled C++
+    handle."""
+    sc, h = _heisenberg_field_chain(3, 3)
+    with pytest.raises(NotImplementedError):
+        sc.metts_vev(sc.Sz[0], 1.0, nsamples=4, nwarmup=1, njobs=2)
+
+
+def test_metts_vev_rejects_non_positive_njobs():
+    """njobs<1 would otherwise silently fall through the njobs==1 fast
+    path's `if` check as false and hit divmod(nsamples, 0) -- caught by
+    metts_thermal_average's own guard before that, same convention as
+    every other parameter here."""
+    sc, h = _heisenberg_field_chain(3, "python")
+    with pytest.raises(ValueError):
+        sc.metts_vev(sc.Sz[0], 1.0, nsamples=4, nwarmup=1, njobs=0)
+
+
 @pytest.mark.parametrize("version", VERSIONS)
 def test_metts_vev_rejects_non_positive_nsamples(version):
     """nsamples<1 would otherwise leave the retained-samples list empty


### PR DESCRIPTION
## Summary
- Investigated whether METTS (`itensor_version="python"`) can be sped up and how it compares to ED timing. Profiling shows its cost is dominated by `pyitensor`'s generic tensor-engine Python overhead (index bookkeeping, small-tensor contractions), not shared BLAS work -- and METTS stays 2-3 orders of magnitude slower than ED at the small sizes ED can still diagonalize exactly (e.g. n=8: ED ~0.04s vs METTS[python] ~33s vs METTS[v3] ~4.7s for 120 iterations).
- Confirmed `kernels.py`'s existing JAX/numba contraction-kernel route is actually a **net loss** for METTS specifically (not just neutral): every sample restarts from a fresh bond-dimension-1 product state, so a run exercises many distinct contraction shapes rather than reusing one, and numba's fixed per-shape compile tax never amortizes -- measured 4x-24x *slower* with `USE_NUMBA=True` depending on chain length.
- Added a real, measured optimization instead: `njobs` runs several independent METTS Markov chains in parallel worker processes (embarrassingly parallel, as the METTS paper itself notes) and pools their statistics exactly via each chain's own `(mean, stderr, count)` -- no raw samples need to cross the process boundary. `itensor_version="python"` only; `itensor_version=3`'s live in-process C++ session has no per-worker copy to hand out, so `njobs>1` there raises rather than silently doing nothing.
- Found and worked around a real gotcha along the way: the default `fork`-based `multiprocessing.Pool` made runs monotonically *slower* as `njobs` grew (34s/62s/73s/100s for njobs=1/2/4/8) -- forking after the parent process had already run linear algebra inherited bad BLAS/OpenMP thread-pool state. Switching to the `spawn` start method fixed it cleanly (34s/21s/17s/14s).

## Test plan
- [x] `pytest tests/test_metts_vev.py` -- 14 passed (2 new tests: njobs matches ED, njobs rejected for v3, njobs<1 rejected)
- [x] `pytest tests` (full suite) -- 136 passed, 8 skipped, 1 pre-existing unrelated failure (confirmed present on `master` too: `test_dynamical_correlator.py::test_tdz_dynamical_correlator_peak_matches_exact_gap[2]`, an ED-fallback path issue unrelated to this change)
- [x] `examples/finite_temperature/metts_VS_exact` still passes end-to-end
- [x] `docs/user_guide.tex` recompiles cleanly with `pdflatex` (no errors, no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t