### PR TITLE
Fix confusing crash for unsupported ED dynamical-correlator submodes

### DIFF
--- a/src/dmrgpy/edtk/dynamics.py
+++ b/src/dmrgpy/edtk/dynamics.py
@@ -16,7 +16,9 @@ def get_dynamical_correlator(self,name=None,submode="KPM",
     """
     Compute the dynamical correlator
     """
-    if name is None: raise
+    if name is None:
+        raise ValueError("get_dynamical_correlator: name (the two-operator "
+                          "tuple) must be given")
 
     A = EDOperator(name[0],self).SO # create first operator
     B = EDOperator(name[1],self).SO # create second operator
@@ -52,7 +54,17 @@ def get_dynamical_correlator(self,name=None,submode="KPM",
       from .. import timedependent
       return timedependent.dynamical_correlator(self,mode="ED",
               name=name,**kwargs)
-    else: raise
+    else:
+        # A bare `raise` here (no active exception to re-raise) used to
+        # crash with a confusing "RuntimeError: No active exception to
+        # reraise" instead of naming the actual problem -- confirmed
+        # directly: reachable via mode.py's own silent DMRG->ED fallback
+        # whenever the requested submode (e.g. "TDZ", a DMRG/TDVP-only
+        # complex-time-evolution method with no ED counterpart at all)
+        # isn't one of the ones implemented above.
+        raise NotImplementedError(
+            "get_dynamical_correlator: submode=%r has no ED implementation"
+            % (submode,))
 
 
 def get_kpm_emax(chain,m,e0):

--- a/tests/test_dynamical_correlator.py
+++ b/tests/test_dynamical_correlator.py
@@ -7,9 +7,27 @@ systems -- no KPM polynomial-order tuning needed."""
 import numpy as np
 import pytest
 
-from dmrgpy import spinchain
+from dmrgpy import cppext, spinchain
 
 DELTA = 0.05
+
+# itensor_version=2 exercises TDZ's real MPO-Taylor-fallback path (see
+# test_tdz_dynamical_correlator_peak_matches_exact_gap's own docstring) --
+# when mpscpp2 isn't compiled, mode.py's own DMRG->ED fallback (see
+# CLAUDE.md) silently redirects here instead, and ED has no TDZ
+# implementation at all (a DMRG/TDVP-only complex-time-evolution method),
+# so this needs the same skip other multi-backend test files already use
+# for an optional/uncompiled extension (e.g. test_nh_dmrg.py,
+# test_four_point_correlator.py), not just for itensor_version=3.
+_TDZ_VERSIONS = [
+    pytest.param(2, marks=pytest.mark.skipif(
+        not cppext.available(2),
+        reason="requires the compiled mpscpp2 (ITensor v2) extension")),
+    pytest.param(3, marks=pytest.mark.skipif(
+        not cppext.available(3),
+        reason="requires the compiled mpscpp3 (ITensor v3) extension")),
+    pytest.param("python", id="python"),
+]
 
 # 4-site Heisenberg chain: ground state is a non-degenerate singlet, and
 # the first excited state is a 3-fold degenerate triplet at this exact
@@ -153,7 +171,7 @@ def test_ex_dynamical_correlator_peak_matches_kpm_and_cvm():
     assert peaks["EX"] == pytest.approx(peaks["CVM"], abs=1e-9)
 
 
-@pytest.mark.parametrize("itensor_version", [2, 3, "python"])
+@pytest.mark.parametrize("itensor_version", _TDZ_VERSIONS)
 def test_tdz_dynamical_correlator_peak_matches_exact_gap(itensor_version):
     """TDZ (tdz.py, complex-time evolution + perturbative real-axis
     reconstruction, arXiv:2311.10909) should locate its dominant peak at


### PR DESCRIPTION
## Summary
- `get_dynamical_correlator`'s ED path (`src/dmrgpy/edtk/dynamics.py`) used a bare `raise` (no active exception to re-raise) as its catch-all for an unrecognized `submode`, so hitting it crashed with an opaque `RuntimeError: No active exception to reraise` instead of naming the actual problem. Replaced with a `NotImplementedError` naming the unsupported submode (and fixed the sibling bare `raise` for a missing `name=` argument too, same file, same bug pattern).
- This was reachable for real, not just theoretical: `mode.py`'s documented DMRG->ED fallback silently redirects here whenever the compiled extension for a requested `itensor_version` isn't available, and `TDZ` (a DMRG/TDVP-only complex-time-evolution method, arXiv:2311.10909) has no ED implementation at all -- so `test_tdz_dynamical_correlator_peak_matches_exact_gap[2]` crashed with this whenever `mpscpp2` (ITensor v2) wasn't compiled in the environment running the tests.
- Added the missing `itensor_version=2`/`3` `skipif` guards to that test, matching the convention already used elsewhere in the suite (e.g. `test_nh_dmrg.py`, `test_four_point_correlator.py`) for optional/uncompiled extensions. This test specifically exercises TDZ's real MPO-Taylor-fallback path for `itensor_version=2` -- ED can't stand in for that, so it should skip cleanly rather than silently mis-testing the ED fallback instead.
- Scope note: a bare `raise`-as-catch-all is actually a pervasive idiom throughout this codebase (dozens of occurrences across many files) -- deliberately left alone here as out of scope; this PR only touches the one instance that was actually causing a real, reachable test failure.

## Test plan
- [x] `pytest tests/test_dynamical_correlator.py` -- 12 passed, 1 skipped (was 1 failure before)
- [x] `pytest tests` (full suite) -- 133 passed, 9 skipped, 0 failures
- [x] Manually confirmed the ED path now raises a clear, catchable `NotImplementedError` for an unsupported submode instead of the previous opaque `RuntimeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t