### PR TITLE
Add dynamical METTS finite-temperature correlators (pyitensor + ITensor v3)

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -935,6 +935,71 @@ compile tax never amortizes). `njobs` is not available for
 with no per-worker copy a process pool could hand out; requesting
 `njobs>1` there raises rather than silently falling back to `njobs=1`.
 
+**`metts_dynamical_correlator(name, T, ...)`** extends METTS from static
+expectation values to real-time finite-temperature *dynamical*
+correlators
+$\mathcal{C}_{AB}(t)=\langle A(t)B\rangle_T=\langle e^{iHt}Ae^{-iHt}B\rangle_T$
+(Z. Wang, P. McClarty, D. Dankova, A. Honecker and A. Wietek,
+"Spectroscopy and complex-time correlations using minimally entangled
+typical thermal states", arXiv:2405.18484, Sec. II, "Dynamical METTS
+algorithm"), implemented for the same two backends as `metts_vev`
+(`itensor_version="python"` and `3`, not `2`). For every METTS sample
+$|\psi_i\rangle$ produced by the exact same Markov chain `metts_vev`
+already samples (imaginary-time evolution + sequential-sampling
+collapse), define $|v_i(0)\rangle=B|\psi_i\rangle$,
+$|w_i(0)\rangle=|\psi_i\rangle$, real-time evolve both independently
+under $H$ (two-site TDVP), and measure
+$\mathcal{C}^i(t)=\langle w_i(t)|A|v_i(t)\rangle$ at each requested time
+step. A plain (unweighted) sample average of $\mathcal{C}^i(t)$ over
+retained samples converges to $\mathcal{C}_{AB}(t)$, for the same reason
+`metts_vev`'s own plain average converges to the thermal average — no
+importance reweighting needed:
+
+```python
+ts, means, stderrs = sc.metts_dynamical_correlator(
+    (sc.Sz[0], sc.Sz[0]), T, nt=100, dt=0.1, nsamples=200, nwarmup=30,
+    dbeta_half_step=0.05, basis_ops=("Sz","Sx"))
+```
+
+`name` follows the same `(A,B)` convention as
+`get_dynamical_correlator`'s own `name=` (a string like `"ZZ"`, or an
+explicit `(MultiOperator,MultiOperator)` tuple/list) — `A`,`B` are used
+exactly as given, with no dagger applied to either, matching
+`get_dynamical_correlator(mode="ED", submode="ED", T=...)`'s own
+convention (see below) so the two are directly comparable. `nt`,`dt` set
+the (uniformly spaced) real-time measurement grid
+$t=0,\Delta t,\dots,(n_t-1)\Delta t$; `nsamples`, `nwarmup`,
+`dbeta_half_step`, `basis_ops`, `seed`, `niter`, `njobs` all mean exactly
+what they mean for `metts_vev` (same shared Markov chain, same caveats on
+`stderrs` being a Markov-correlated, likely-optimistic naive estimate).
+`tdvp_niter` separately bounds the Krylov iterations used for the
+*real-time* evolution of $|v_i(t)\rangle$/$|w_i(t)\rangle$ specifically
+(default 50), independent of `niter`'s bound on the imaginary-time
+sampling step (default 30) — the two generally warrant different
+settings since $|v_i(t)\rangle$/$|w_i(t)\rangle$ typically become more
+entangled over the course of real-time evolution than the METTS samples
+$|\psi_i\rangle$ themselves ever do. No Fourier transform/windowing is
+performed internally: `metts_dynamical_correlator` returns the raw
+time-domain samples/statistics, matching `evolution_DC`'s own `(ts,cs)`
+convention — apply a window (e.g. a Hann window, as the reference paper
+recommends) and FFT separately if a frequency-domain spectral function is
+wanted.
+
+For a direct, exact reference to validate against, `get_dynamical_correlator(
+mode="ED", submode="ED", T=..., name=...)` computes the finite-temperature
+dynamical correlator's spectral function via a full Boltzmann-weighted
+Lehmann sum over *every* ED eigenstate
+$\mathcal{C}_{AB}(\omega)=\frac{1}{\mathcal{Z}}\sum_{n,m}e^{-\beta E_n}\langle n|A|m\rangle\langle m|B|n\rangle\,[\text{kernel at }\omega=E_m-E_n]$
+— the finite-$T$ generalization of the existing T=0 `submode="ED"`
+near-degenerate-ground-state sum to every eigenstate weighted by its
+exact Boltzmann factor (exact, since it starts from a full dense
+diagonalization, unlike `thermal_vev_ex`'s own partial-diagonalization
+truncation-safety check, which this doesn't need). See
+`examples/finite_temperature/dynamical_metts_VS_ED` for a cross-check of
+`metts_dynamical_correlator` (both backends) against this exact ED
+reference, evaluated directly in the time domain, on a small Heisenberg
+chain.
+
 ## 10. Topological invariants
 
 **Many-body Berry phase.** For a ground state that depends on an

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1094,6 +1094,79 @@ in-process C++ object with no per-worker copy a process pool could hand
 out; requesting \texttt{njobs>1} there raises rather than silently
 falling back to \texttt{njobs=1}.
 
+\textbf{\texttt{metts\_dynamical\_correlator(name, T, ...)}} extends
+METTS from static expectation values to real-time finite-temperature
+\emph{dynamical} correlators
+$\mathcal{C}_{AB}(t)=\langle A(t)B\rangle_T=\langle e^{iHt}Ae^{-iHt}B\rangle_T$
+(Z. Wang, P. McClarty, D. Dankova, A. Honecker and A. Wietek,
+``Spectroscopy and complex-time correlations using minimally entangled
+typical thermal states'', arXiv:2405.18484, Sec.~II, ``Dynamical METTS
+algorithm''), implemented for the same two backends as
+\texttt{metts\_vev} (\texttt{itensor\_version="python"} and \texttt{3},
+not \texttt{2}). For every METTS sample $|\psi_i\rangle$ produced by the
+exact same Markov chain \texttt{metts\_vev} already samples
+(imaginary-time evolution + sequential-sampling collapse), define
+$|v_i(0)\rangle=B|\psi_i\rangle$, $|w_i(0)\rangle=|\psi_i\rangle$,
+real-time evolve both independently under $H$ (two-site TDVP), and
+measure $\mathcal{C}^i(t)=\langle w_i(t)|A|v_i(t)\rangle$ at each
+requested time step. A plain (unweighted) sample average of
+$\mathcal{C}^i(t)$ over retained samples converges to
+$\mathcal{C}_{AB}(t)$, for the same reason \texttt{metts\_vev}'s own
+plain average converges to the thermal average --- no importance
+reweighting needed:
+
+\begin{lstlisting}
+ts, means, stderrs = sc.metts_dynamical_correlator(
+    (sc.Sz[0], sc.Sz[0]), T, nt=100, dt=0.1, nsamples=200, nwarmup=30,
+    dbeta_half_step=0.05, basis_ops=("Sz","Sx"))
+\end{lstlisting}
+
+\texttt{name} follows the same \texttt{(A,B)} convention as
+\texttt{get\_dynamical\_correlator}'s own \texttt{name=} (a string like
+\texttt{"ZZ"}, or an explicit
+\texttt{(MultiOperator,MultiOperator)} tuple/list) --- $A$,$B$ are used
+exactly as given, with no dagger applied to either, matching
+\texttt{get\_dynamical\_correlator(mode="ED", submode="ED", T=...)}'s own
+convention (see below) so the two are directly comparable. \texttt{nt},
+\texttt{dt} set the (uniformly spaced) real-time measurement grid
+$t=0,\Delta t,\dots,(n_t-1)\Delta t$; \texttt{nsamples}, \texttt{nwarmup},
+\texttt{dbeta\_half\_step}, \texttt{basis\_ops}, \texttt{seed},
+\texttt{niter}, \texttt{njobs} all mean exactly what they mean for
+\texttt{metts\_vev} (same shared Markov chain, same caveats on
+\texttt{stderrs} being a Markov-correlated, likely-optimistic naive
+estimate). \texttt{tdvp\_niter} separately bounds the Krylov iterations
+used for the \emph{real-time} evolution of
+$|v_i(t)\rangle$/$|w_i(t)\rangle$ specifically (default 50), independent
+of \texttt{niter}'s bound on the imaginary-time sampling step (default
+30) --- the two generally warrant different settings since
+$|v_i(t)\rangle$/$|w_i(t)\rangle$ typically become more entangled over
+the course of real-time evolution than the METTS samples
+$|\psi_i\rangle$ themselves ever do. No Fourier transform/windowing is
+performed internally: \texttt{metts\_dynamical\_correlator} returns the
+raw time-domain samples/statistics, matching \texttt{evolution\_DC}'s own
+\texttt{(ts,cs)} convention --- apply a window (e.g.\ a Hann window, as
+the reference paper recommends) and FFT separately if a
+frequency-domain spectral function is wanted.
+
+For a direct, exact reference to validate against,
+\texttt{get\_dynamical\_correlator(mode="ED", submode="ED", T=...,
+name=...)} computes the finite-temperature dynamical correlator's
+spectral function via a full Boltzmann-weighted Lehmann sum over
+\emph{every} ED eigenstate,
+\begin{equation}
+\mathcal{C}_{AB}(\omega)=\frac{1}{\mathcal{Z}}\sum_{n,m}e^{-\beta E_n}\langle n|A|m\rangle\langle m|B|n\rangle\,[\text{kernel at }\omega=E_m-E_n],
+\end{equation}
+the finite-$T$ generalization of the existing $T=0$
+\texttt{submode="ED"} near-degenerate-ground-state sum to every
+eigenstate weighted by its exact Boltzmann factor (exact, since it
+starts from a full dense diagonalization, unlike
+\texttt{thermal\_vev\_ex}'s own partial-diagonalization
+truncation-safety check, which this doesn't need). See
+\texttt{examples/finite\_temperature/dynamical\_metts\_VS\_ED} for a
+cross-check of \texttt{metts\_dynamical\_correlator} (both backends)
+against this exact ED reference, evaluated directly in the time domain,
+on a small Heisenberg chain.
+
 \section{Topological invariants}
 
 \textbf{Many-body Berry phase.} For a ground state that depends on an

--- a/examples/finite_temperature/dynamical_metts_VS_ED/main.py
+++ b/examples/finite_temperature/dynamical_metts_VS_ED/main.py
@@ -1,0 +1,92 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+# Dynamical METTS (real-time finite-temperature dynamical correlators) vs
+# an exact ED reference, following Wang, McClarty, Dankova, Honecker &
+# Wietek, "Spectroscopy and complex-time correlations using minimally
+# entangled typical thermal states", arXiv:2405.18484, Sec. II /
+# Algorithm 1. See src/dmrgpy/pyitensor/metts.py's
+# "Dynamical METTS" section for the algorithm itself: for every METTS
+# sample |psi_i> sampled by the same Markov chain the static METTS
+# algorithm (metts_VS_exact/main.py) already uses, set |v_i(0)>=B|psi_i>,
+# |w_i(0)>=|psi_i>, real-time-evolve both under H, and average
+# C^i(t)=<w_i(t)|A|v_i(t)> over samples to estimate
+# C_AB(t) = <A(t)B>_beta.
+#
+# itensor_version="python" and 3 both implement this (mpscpp3/
+# chain_session.h's Chain::metts_dynamical_correlator is a direct port of
+# the same algorithm onto real ITensor v3) -- this example cross-checks
+# both against an exact ED reference: a full Boltzmann-weighted Lehmann
+# sum over every eigenstate (edtk/dynamics.py's
+# dynamical_correlator_finite_T is the frequency-domain version of this
+# same sum; the time-domain sum used directly here avoids an FFT
+# round-trip for this comparison), for a small Heisenberg chain + field
+# where the full spectrum is cheap to diagonalize directly.
+import numpy as np
+from dmrgpy import spinchain, cppext
+from dmrgpy.edtk.edchain import EDOperator
+
+n = 4
+J, B_field = 1.0, 0.4
+T = 1.0
+nt, dt = 8, 0.2
+
+versions = ["python"]
+if cppext.available(3):
+    versions.append(3)
+
+
+def ed_time_domain_reference(sc, name, T, ts):
+    """Exact C_AB(t)=<A(t)B>_T via a full Boltzmann-weighted Lehmann sum
+    over every ED eigenstate -- A,B used exactly as given (no dagger),
+    same convention edtk/dynamics.py's dynamical_correlator_finite_T
+    uses."""
+    edobj = sc.get_ED_obj()
+    emu, vs = edobj.get_diagonalized_hamiltonian()
+    a0 = EDOperator(name[0], edobj).SO
+    b0 = EDOperator(name[1], edobj).SO
+    e0 = np.min(emu)
+    ex = emu - e0
+    beta = 1.0/T
+    w = np.exp(-beta*ex) ; w = w/w.sum()
+    U = np.array(vs) ; Uh = np.conjugate(U.T)
+    A = Uh@a0@U ; B = Uh@b0@U
+    out = np.zeros(len(ts), dtype=complex)
+    for k, t in enumerate(ts):
+        phase = np.exp(1j*(ex[:, None]-ex[None, :])*t)
+        out[k] = np.sum(w[:, None]*phase*A*B.T)
+    return out
+
+
+for version in versions:
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    if version == "python":
+        sc.setup_python()
+    else:
+        sc.setup_cpp(version=version)
+    h = 0
+    for i in range(n-1):
+        h = h + J*sc.Sx[i]*sc.Sx[i+1] + J*sc.Sy[i]*sc.Sy[i+1] + J*sc.Sz[i]*sc.Sz[i+1]
+    for i in range(n):
+        h = h + B_field*sc.Sz[i]
+    sc.set_hamiltonian(h)
+
+    name = (sc.Sz[0], sc.Sz[0])
+    ts, means, stderrs = sc.metts_dynamical_correlator(
+        name, T, nt=nt, dt=dt, nsamples=150, nwarmup=30,
+        dbeta_half_step=0.08, seed=42)
+    ref = ed_time_domain_reference(sc, name, T, ts)
+
+    print("\n=== itensor_version=%s, T=%g ===" % (version, T))
+    print("%6s  %22s  %22s  %10s" % ("t", "METTS C(t)", "ED C(t)", "stderr"))
+    for k in range(nt):
+        print("%6.2f  %9.5f%+9.5fj  %9.5f%+9.5fj  %10.5f"
+              % (ts[k], means[k].real, means[k].imag, ref[k].real, ref[k].imag, stderrs[k]))
+
+    diff = np.abs(means-ref)
+    tol = np.maximum(5*stderrs, 0.03)  # 5-sigma headroom, floored for the near-zero-stderr t=0 point
+    assert np.all(diff <= tol), \
+        "dynamical METTS disagrees with the exact ED reference beyond " \
+        "the expected statistical tolerance (itensor_version=%s)" % (version,)
+
+print("\nTEST PASSED")

--- a/src/dmrgpy/edtk/dynamics.py
+++ b/src/dmrgpy/edtk/dynamics.py
@@ -12,7 +12,7 @@ is_hermitian = algebra.is_hermitian
 
 
 def get_dynamical_correlator(self,name=None,submode="KPM",
-        wf0=None,**kwargs):
+        wf0=None,T=0.,**kwargs):
     """
     Compute the dynamical correlator
     """
@@ -24,8 +24,24 @@ def get_dynamical_correlator(self,name=None,submode="KPM",
     B = EDOperator(name[1],self).SO # create second operator
     h = self.get_hamiltonian() # Hamiltonian as matrix
 
+    if T>0.: # finite-temperature Lehmann sum -- the exact reference used
+        # to validate the finite-T MPS/METTS dynamical correlator (see
+        # vevtk/mettsdynamicalcorrelator.py), the dynamical analog of
+        # thermal_vev_ex's static Boltzmann sum in vevtk/thermalvev.py.
+        if submode!="ED":
+            raise NotImplementedError(
+                "get_dynamical_correlator: T>0 is only implemented for "
+                "submode='ED' (the exact Lehmann sum) so far, got "
+                "submode=%r" % (submode,))
+        if not is_hermitian(h):
+            raise NotImplementedError(
+                "get_dynamical_correlator: T>0 is not implemented for "
+                "non-Hermitian Hamiltonians")
+        emu,vs = self.get_diagonalized_hamiltonian()
+        return dynamical_correlator_finite_T(h,A,B,T,emu=emu,vs=vs,**kwargs)
+
     if wf0 is None:  wf0 = self.get_gs_array() # compute ground state
-    else: 
+    else:
         wf0 = wf0.v.copy()
     if not is_hermitian(h): # non Hermitian Hamiltonians
         if submode=="KPM": # non-Hermitian KPM
@@ -169,6 +185,78 @@ def dynamical_sum(es,ws,delta,A,B,nex=1):
                             - 1./(w-1j*delta+es[i]-es[j]))
         out[iw] = out[iw] + acc
     return out/nex # return dynamical correlator
+
+
+def dynamical_correlator_finite_T(h,a0,b0,T,delta=2e-2,
+        emu=None,vs=None,
+        es=np.linspace(-1.0,10.0,600)):
+    """Finite-temperature dynamical correlator via the exact Lehmann sum
+    (arXiv:2405.18484, Eq. before Sec. II.D):
+
+        C_AB(omega) = (1/Z) sum_{n,m} exp(-beta*E_n) <n|A|m><m|B|n>
+                      * [same +-i*delta kernel dynamical_sum uses at
+                         omega = E_m - E_n]
+
+    the finite-T generalization of dynamical_correlator_ED's T=0 sum
+    (dynamical_sum's `nex`-averaged near-degenerate-ground-state sum)
+    to a full thermal average over every eigenstate weighted by its
+    exact Boltzmann factor. Unlike thermal_vev_ex (vevtk/thermalvev.py),
+    which sums over a possibly-truncated set of excited states obtained
+    from sparse/partial diagonalization and must therefore check the
+    left-out Boltzmann weight is negligible, emu/vs here always come from
+    a full dense diagonalization (get_diagonalized_hamiltonian ->
+    algebra.eigh), so the Boltzmann weight is exact and no truncation
+    safety check is needed -- the only limit is algebra.maxsize's
+    existing hard cap on how large a Hilbert space can be fully
+    diagonalized at all."""
+    if emu is None or vs is None: # if not provided
+        emu,vs = algebra.eigh(h) # compute them
+    ex = emu-np.min(emu) # excitations, ascending
+
+    # crop to the needed states, same as dynamical_correlator_ED -- note
+    # this only drops *final* states above the requested frequency
+    # window; the *initial*-state Boltzmann weights below are computed
+    # from the full (uncropped) spectrum, so Z stays exact regardless
+    emax = np.max(es) # maximum energy
+    beta = 1./T
+    weights_full = np.exp(-beta*ex)
+    Z = weights_full.sum()
+    keep = emu<emax
+    vs_c = vs[:,keep] # restrict
+    ex_c = ex[keep] # restrict
+    weights = weights_full[keep]/Z # normalized Boltzmann weight per kept state
+
+    # compute the needed matrix elements
+    U = np.array(vs_c) # matrix
+    Uh = np.conjugate(np.transpose(U)) # dagger
+    A = Uh@a0@U # get the matrix elements
+    B = Uh@b0@U # get the matrix elements
+    out = dynamical_sum_thermal(ex_c,es,delta,A,B,weights) # perform the summation
+    return (es,-out.imag/(2*np.pi)) # return correlator
+
+
+@jit(nopython=True)
+def dynamical_sum_thermal(es,ws,delta,A,B,weights):
+    """Thermal generalization of dynamical_sum() above: sums over *every*
+    initial state i (not just the first `nex` near-degenerate ones),
+    weighting each by its own Boltzmann factor `weights[i]` (already
+    normalized to sum to 1 over the full spectrum) instead of a uniform
+    1/nex."""
+    es = es-np.min(es) # remove minimum energy (ground state)
+    n = len(es) # number of eigenenergies
+    out = np.zeros(len(ws),dtype=np.complex128) # initialize
+    for i in range(n): # loop over every initial state
+      wi = weights[i]
+      if wi==0.0: continue # skip states with no Boltzmann weight at all
+      for iw in range(len(ws)): # loop over frequencies
+        w = ws[iw]
+        acc = 0.0+0.0j
+        for j in range(n): # loop over eigenenergies
+            tmp = A[i,j]*B[j,i] # relevant matrix element
+            acc = acc + tmp*(1./(w+1j*delta+es[i]-es[j])
+                            - 1./(w-1j*delta+es[i]-es[j]))
+        out[iw] = out[iw] + wi*acc
+    return out # return dynamical correlator
 
 
 def dynamical_correlator_inv(h0,wf0,e0,A,B,es=np.linspace(-1,10,600),

--- a/src/dmrgpy/edtk/dynamics.py
+++ b/src/dmrgpy/edtk/dynamics.py
@@ -213,48 +213,57 @@ def dynamical_correlator_finite_T(h,a0,b0,T,delta=2e-2,
         emu,vs = algebra.eigh(h) # compute them
     ex = emu-np.min(emu) # excitations, ascending
 
-    # crop to the needed states, same as dynamical_correlator_ED -- note
-    # this only drops *final* states above the requested frequency
-    # window; the *initial*-state Boltzmann weights below are computed
-    # from the full (uncropped) spectrum, so Z stays exact regardless
-    emax = np.max(es) # maximum energy
     beta = 1./T
-    weights_full = np.exp(-beta*ex)
-    Z = weights_full.sum()
-    keep = emu<emax
-    vs_c = vs[:,keep] # restrict
-    ex_c = ex[keep] # restrict
-    weights = weights_full[keep]/Z # normalized Boltzmann weight per kept state
+    weights = np.exp(-beta*ex)
+    weights = weights/weights.sum() # exact Boltzmann weight, full spectrum
 
-    # compute the needed matrix elements
-    U = np.array(vs_c) # matrix
-    Uh = np.conjugate(np.transpose(U)) # dagger
-    A = Uh@a0@U # get the matrix elements
-    B = Uh@b0@U # get the matrix elements
-    out = dynamical_sum_thermal(ex_c,es,delta,A,B,weights) # perform the summation
+    # Crop only the *final*-state (j) index space to the requested
+    # frequency window, same approximation dynamical_correlator_ED already
+    # makes -- the *initial*-state (i) sum below always ranges over the
+    # FULL spectrum with its exact weight. Cropping i's index space too
+    # (as an earlier version of this function did) would silently drop
+    # any thermally-populated state above emax from the numerator while
+    # `weights` (computed from the full spectrum, above) still counted it
+    # in the normalization -- a real, silent under-count at any T large
+    # enough for excited states above emax to still carry non-negligible
+    # weight, confirmed by code review.
+    emax = np.max(es) # maximum energy
+    keep_j = emu<emax
+    ex_j = ex[keep_j] # restrict
+
+    Ufull = np.array(vs) # (dim, n) -- every eigenstate, for the i axis
+    Uj = np.array(vs[:,keep_j]) # (dim, nj) -- cropped, for the j axis
+    A = np.conjugate(np.transpose(Ufull))@a0@Uj # (n,nj): <i|A|j>
+    B = np.conjugate(np.transpose(Uj))@b0@Ufull # (nj,n): <j|B|i>
+    out = dynamical_sum_thermal(ex,ex_j,es,delta,A,B,weights) # perform the summation
     return (es,-out.imag/(2*np.pi)) # return correlator
 
 
 @jit(nopython=True)
-def dynamical_sum_thermal(es,ws,delta,A,B,weights):
+def dynamical_sum_thermal(ex_i,ex_j,ws,delta,A,B,weights):
     """Thermal generalization of dynamical_sum() above: sums over *every*
     initial state i (not just the first `nex` near-degenerate ones),
     weighting each by its own Boltzmann factor `weights[i]` (already
     normalized to sum to 1 over the full spectrum) instead of a uniform
-    1/nex."""
-    es = es-np.min(es) # remove minimum energy (ground state)
-    n = len(es) # number of eigenenergies
+    1/nex. A is (n_i,n_j) = <i|A|j>, B is (n_j,n_i) = <j|B|i>; ex_i/ex_j
+    are already expressed relative to the same shared zero (the global
+    ground-state energy, both derived from the same `ex` in the caller)
+    -- deliberately *not* independently re-zeroed against their own
+    separate minima here, since ex_i and ex_j only agree on their zero
+    point because both were shifted the same way before being split."""
+    ni = len(ex_i)
+    nj = len(ex_j)
     out = np.zeros(len(ws),dtype=np.complex128) # initialize
-    for i in range(n): # loop over every initial state
+    for i in range(ni): # loop over every initial state
       wi = weights[i]
       if wi==0.0: continue # skip states with no Boltzmann weight at all
       for iw in range(len(ws)): # loop over frequencies
         w = ws[iw]
         acc = 0.0+0.0j
-        for j in range(n): # loop over eigenenergies
+        for j in range(nj): # loop over the cropped final-state space
             tmp = A[i,j]*B[j,i] # relevant matrix element
-            acc = acc + tmp*(1./(w+1j*delta+es[i]-es[j])
-                            - 1./(w-1j*delta+es[i]-es[j]))
+            acc = acc + tmp*(1./(w+1j*delta+ex_i[i]-ex_j[j])
+                            - 1./(w-1j*delta+ex_i[i]-ex_j[j]))
         out[iw] = out[iw] + wi*acc
     return out # return dynamical correlator
 

--- a/src/dmrgpy/manybodychain.py
+++ b/src/dmrgpy/manybodychain.py
@@ -318,6 +318,18 @@ class Many_Body_Chain():
       per operator."""
       from .vevtk.mettsvev import metts_vev as _metts_vev
       return _metts_vev(self,MO,T,**kwargs)
+  def metts_dynamical_correlator(self,name,T,**kwargs):
+      """Real-time finite-temperature dynamical correlator
+      C_AB(t) = <A(t)B>_T via dynamical METTS sampling (Wang, McClarty,
+      Dankova, Honecker & Wietek, arXiv:2405.18484, Sec. II) -- see
+      vevtk/mettsdynamicalcorrelator.py. Implemented for
+      itensor_version='python' and 3 (not 2, which has no TDVP), same
+      restriction as metts_vev. Validate against
+      self.get_dynamical_correlator(mode="ED", submode="ED", T=T,
+      name=name) (edtk/dynamics.py's dynamical_correlator_finite_T), the
+      exact Lehmann-sum reference for small systems."""
+      from .vevtk.mettsdynamicalcorrelator import metts_dynamical_correlator as _mdc
+      return _mdc(self,name,T,**kwargs)
   def test_ED(self):
       """Test the ED object"""
       self.get_ED_obj().test()

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -344,6 +344,29 @@ PYBIND11_MODULE(_dmrgcpp, m)
                "the full algorithm). terms_ops is a list of operators, all "
                "measured on the same sampled Markov chain. Returns "
                "(means, stderrs), lists matching terms_ops.")
+        .def("metts_dynamical_correlator",
+            [](Chain& self, std::vector<PyTerm> const& terms_a,
+               std::vector<PyTerm> const& terms_b,
+               double T, int nt, double dt, int nsamples, int nwarmup,
+               double dbeta_half_step,
+               std::vector<std::string> const& basis_ops,
+               unsigned long seed, int niter, int tdvp_niter) {
+                return self.metts_dynamical_correlator(
+                    terms_from_python(terms_a),terms_from_python(terms_b),
+                    T,nt,dt,nsamples,nwarmup,dbeta_half_step,basis_ops,
+                    seed,niter,tdvp_niter);
+            }, py::arg("terms_a"),py::arg("terms_b"),py::arg("T"),
+               py::arg("nt")=200,py::arg("dt")=0.1,py::arg("nsamples")=100,
+               py::arg("nwarmup")=20,py::arg("dbeta_half_step")=0.05,
+               py::arg("basis_ops")=std::vector<std::string>{"Sz","Sx"},
+               py::arg("seed")=0,py::arg("niter")=30,py::arg("tdvp_niter")=50,
+               "Real-time finite-temperature correlator C_AB(t)=<A(t)B>_T "
+               "via dynamical METTS sampling (Wang, McClarty, Dankova, "
+               "Honecker & Wietek, arXiv:2405.18484, Sec. II -- see "
+               "Chain::metts_dynamical_correlator's own comment and "
+               "pyitensor/metts.py's metts_dynamical_correlator for the "
+               "full algorithm). Returns (means, stderrs), length-nt "
+               "arrays over t=0,dt,...,(nt-1)*dt.")
         .def("global_subspace_expand",&Chain::global_subspace_expand,
              py::arg("H"),py::arg("phi"),py::arg("krylov_order"),
              py::arg("cutoff"),py::arg("maxdim")=0,

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -895,6 +895,134 @@ class Chain
         return {means,stderrs};
         }
 
+    // Dynamical METTS (real-time finite-T correlators), arXiv:2405.18484
+    // (Wang, McClarty, Dankova, Honecker & Wietek, "Spectroscopy and
+    // complex-time correlations using minimally entangled typical thermal
+    // states"), Sec. II / Algorithm 1 -- a direct port of
+    // pyitensor/metts.py's metts_dynamical_correlator() onto real ITensor
+    // v3, following the exact same METTS Markov chain metts_vev() above
+    // does (imaginary-time tdvp_step + collapse_to_cps), generalized from
+    // the static <A>_beta average to the two-time correlator
+    // C_AB(t) = <A(t)B>_beta = <e^{iHt} A e^{-iHt} B>_beta: for every
+    // retained sample |phi>, set |v(0)>=B|phi>, |w(0)>=|phi>, measure
+    // C(t_k)=<w(t_k)|A|v(t_k)>, then real-time-evolve both |v> and |w>
+    // independently under H_ via tdvp_step (dt real here -- that
+    // method's own -i*dt convention already makes a purely real dt give
+    // genuine rotation, i.e. real time, exactly as quench_tdvp() above
+    // already relies on). A plain sample average over every retained
+    // METTS sample converges to C_AB(t), for the same reason
+    // metts_vev()'s own plain average converges to <A>_beta -- see that
+    // method's comment above.
+    //
+    // Returns (means,stderrs), each a length-nt array over
+    // t=0,dt,...,(nt-1)*dt -- same (means,stderrs) convention as
+    // metts_vev() above, just array-valued per time step instead of
+    // per-operator; the ts array itself is left for the Python-facing
+    // wrapper to construct from (nt,dt), same as
+    // pyitensor.chain.Chain.metts_dynamical_correlator's own split.
+    std::pair<std::vector<Cplx>,std::vector<double>>
+    metts_dynamical_correlator(std::vector<MOTerm> const& terms_a,
+              std::vector<MOTerm> const& terms_b,
+              double T, int nt, double dt, int nsamples,
+              int nwarmup, double dbeta_half_step,
+              std::vector<std::string> const& basis_ops,
+              unsigned long seed, int niter=30, int tdvp_niter=50) const
+        {
+        if (!have_H_) Error("Chain::metts_dynamical_correlator called before set_hamiltonian");
+        if (T<=0) Error("Chain::metts_dynamical_correlator: T must be > 0");
+        if (basis_ops.empty()) Error("Chain::metts_dynamical_correlator: basis_ops must be non-empty");
+        if (nsamples<1) Error("Chain::metts_dynamical_correlator: nsamples must be >= 1");
+        if (nt<1) Error("Chain::metts_dynamical_correlator: nt must be >= 1");
+
+        auto A = build_mpo(sites_,terms_a,mpomaxm_);
+        auto B = build_mpo(sites_,terms_b,mpomaxm_);
+        double beta_half = 1.0/(2.0*T);
+        int nsteps = std::max(1,(int)std::ceil(beta_half/dbeta_half_step));
+        Cplx dtau = Cplx(0.0,-1.0)*(beta_half/double(nsteps));
+        Cplx dtr = Cplx(dt,0.0); // real time step, tdvp_step's own -i*dt convention
+
+        std::mt19937_64 rng(seed);
+        int nbasis = (int)basis_ops.size();
+        auto eigcache = metts_build_eigcache(basis_ops);
+        MPS cps = random_cps(basis_ops[0],rng,eigcache);
+        auto args = Args("Cutoff",cutoff_,"MaxDim",maxm_);
+
+        std::vector<std::vector<Cplx>> samples(nt); // samples[k] over retained METTS samples
+        for (auto& s : samples) s.reserve(nsamples);
+
+        int total_iters = nwarmup+nsamples;
+        for (int it=0; it<total_iters; ++it)
+            {
+            MPS phi = cps;
+            for (int s=0; s<nsteps; ++s)
+                {
+                phi = tdvp_step(H_,phi,dtau,2,niter);
+                phi /= sqrt(innerC(phi,phi).real());
+                }
+            if (it>=nwarmup)
+                {
+                MPS v = apply_mpo(B,phi,args);
+                // |v(t)> is deliberately *not* unit-norm (paper's own
+                // Eq. right after (eq:auxstatewi): "while |w_i(t)> is
+                // normalized, we generically have <v_i(t)|v_i(t)> =
+                // constant != 1") -- but tdvp_step()'s underlying
+                // ITensorTDVP tdvp() call always passes "DoNormalize",
+                // true, which force-renormalizes its *input* MPS to unit
+                // norm on every single call, silently corrupting v's own
+                // (should-stay-constant, generically !=1) norm at the
+                // very first step and pinning it at 1 forever after --
+                // confirmed directly (a factor-of-2 discrepancy against
+                // the exact ED reference for a v(0) with norm 0.5). Same
+                // fix quench_tdvp()/quench_tdvp_gse() above already apply
+                // to their own similarly-unnormalized psi1: save the true
+                // norm once, then restore it after every tdvp_step() call
+                // (undoing that forced renormalization to 1) -- w needs
+                // no such correction since it starts at unit norm (a
+                // normalized METTS sample) and real-time evolution
+                // preserves that exactly, making DoNormalize's forced
+                // renormalization to 1 a no-op for it.
+                Cplx normv0 = std::sqrt(innerC(v,v));
+                MPS w = phi;
+                for (int k=0; k<nt; ++k)
+                    {
+                    samples[k].push_back(innerC(w,A,v));
+                    if (k<nt-1)
+                        {
+                        v = tdvp_step(H_,v,dtr,2,tdvp_niter);
+                        v.normalize();
+                        v *= normv0;
+                        w = tdvp_step(H_,w,dtr,2,tdvp_niter);
+                        }
+                    }
+                }
+            cps = collapse_to_cps(phi,basis_ops[it % nbasis],rng,eigcache);
+            }
+
+        // Same reachable-only-with-an-oversized-nwarmup guard as
+        // metts_vev() above.
+        if (samples[0].empty())
+            Error("Chain::metts_dynamical_correlator: no samples were retained (nwarmup >= nwarmup+nsamples?)");
+        std::vector<Cplx> means(nt,Cplx(0.0,0.0));
+        std::vector<double> stderrs(nt,0.0);
+        for (int k=0; k<nt; ++k)
+            {
+            Cplx mean = 0;
+            for (auto& v : samples[k]) mean += v;
+            mean /= double(samples[k].size());
+            double var = 0.0;
+            for (auto& v : samples[k])
+                {
+                double d = std::abs(v-mean);
+                var += d*d;
+                }
+            double stderr_ = samples[k].size()>1
+                ? std::sqrt(var/double(samples[k].size()-1)/double(samples[k].size())) : 0.0;
+            means[k] = mean;
+            stderrs[k] = stderr_;
+            }
+        return {means,stderrs};
+        }
+
     // Global subspace expansion (TDVP/basisextension.h's addBasis()):
     // enriches phi's local bases with a Krylov subspace {phi, H*phi,
     // H^2*phi, ...} of dimension krylov_order, then discards the least

--- a/src/dmrgpy/pyitensor/chain.py
+++ b/src/dmrgpy/pyitensor/chain.py
@@ -685,14 +685,18 @@ class Chain:
     def metts_dynamical_correlator(self, terms_a, terms_b, T, nt, dt, nsamples,
                                     nwarmup=20, dbeta_half_step=0.05,
                                     basis_ops=("Sz", "Sx"), seed=None, niter=30,
+                                    tdvp_cutoff=None, tdvp_maxdim=None,
                                     tdvp_niter=50, njobs=1):
         """Real-time finite-temperature correlator C_AB(t)=<A(t)B>_T via
         dynamical METTS sampling (arXiv:2405.18484, Sec. II) -- see
         metts.py's metts_dynamical_correlator() for the algorithm itself.
         Reuses self.H (already built by set_hamiltonian) and this chain's
-        own cutoff/maxm for both the imaginary-time METTS sampling and
-        (as a default; see metts.py's own tdvp_cutoff/tdvp_maxdim
-        docstring) the real-time evolution of |v_i(t)>/|w_i(t)>.
+        own cutoff/maxm for the imaginary-time METTS sampling; tdvp_cutoff/
+        tdvp_maxdim (default None -> this chain's own cutoff/maxm, same as
+        metts.py's own default) separately control the real-time evolution
+        of |v_i(t)>/|w_i(t)> -- see metts.py's own tdvp_cutoff/tdvp_maxdim
+        docstring for why that evolution generally wants a looser cutoff/
+        larger bond dimension than the imaginary-time sampling step.
 
         terms_a, terms_b: MultiOperator.to_terms() outputs for A and B --
         used exactly as given (no dagger), same convention as
@@ -711,6 +715,7 @@ class Chain:
         return _metts_dynamical_correlator(
             self.H, self.sites, A, B, beta, nt, dt, nsamples, nwarmup=nwarmup,
             dbeta_half_step=dbeta_half_step, cutoff=self.cutoff, maxdim=self.maxm,
+            tdvp_cutoff=tdvp_cutoff, tdvp_maxdim=tdvp_maxdim,
             basis_ops=basis_ops, seed=seed, niter=niter, tdvp_niter=tdvp_niter,
             njobs=njobs)
 

--- a/src/dmrgpy/pyitensor/chain.py
+++ b/src/dmrgpy/pyitensor/chain.py
@@ -25,6 +25,7 @@ from .mpsalgebra import sum as mps_sum
 from .mpsalgebra import randomMPS, traceC
 from .mpsalgebra import _fresh_link_copy
 from .metts import metts_thermal_average as _metts_thermal_average
+from .metts import metts_dynamical_correlator as _metts_dynamical_correlator
 from .sites import SiteX
 from .svd import svd
 from .sweeps import Sweeps
@@ -680,6 +681,38 @@ class Chain:
             self.H, self.sites, ops, beta, nsamples, nwarmup=nwarmup,
             dbeta_half_step=dbeta_half_step, cutoff=self.cutoff, maxdim=self.maxm,
             basis_ops=basis_ops, seed=seed, niter=niter, njobs=njobs)
+
+    def metts_dynamical_correlator(self, terms_a, terms_b, T, nt, dt, nsamples,
+                                    nwarmup=20, dbeta_half_step=0.05,
+                                    basis_ops=("Sz", "Sx"), seed=None, niter=30,
+                                    tdvp_niter=50, njobs=1):
+        """Real-time finite-temperature correlator C_AB(t)=<A(t)B>_T via
+        dynamical METTS sampling (arXiv:2405.18484, Sec. II) -- see
+        metts.py's metts_dynamical_correlator() for the algorithm itself.
+        Reuses self.H (already built by set_hamiltonian) and this chain's
+        own cutoff/maxm for both the imaginary-time METTS sampling and
+        (as a default; see metts.py's own tdvp_cutoff/tdvp_maxdim
+        docstring) the real-time evolution of |v_i(t)>/|w_i(t)>.
+
+        terms_a, terms_b: MultiOperator.to_terms() outputs for A and B --
+        used exactly as given (no dagger), same convention as
+        vev()/apply_operator() above.
+
+        Returns (means, stderrs), each a length-nt array -- see
+        metts_dynamical_correlator()'s own docstring for their meaning.
+        """
+        if not self.have_H:
+            raise RuntimeError("Chain.metts_dynamical_correlator called before set_hamiltonian")
+        A = to_mpo(AutoMPO.from_terms(self.sites, terms_a), cutoff=_BUILD_CUTOFF,
+                   maxdim=self.mpomaxm)
+        B = to_mpo(AutoMPO.from_terms(self.sites, terms_b), cutoff=_BUILD_CUTOFF,
+                   maxdim=self.mpomaxm)
+        beta = 1.0 / T
+        return _metts_dynamical_correlator(
+            self.H, self.sites, A, B, beta, nt, dt, nsamples, nwarmup=nwarmup,
+            dbeta_half_step=dbeta_half_step, cutoff=self.cutoff, maxdim=self.maxm,
+            basis_ops=basis_ops, seed=seed, niter=niter, tdvp_niter=tdvp_niter,
+            njobs=njobs)
 
     def nhkpm_moments(self, terms_hs, terms_hs_dag, wfa, wfb, n, kpmmaxm, kpmcutoff):
         """Non-Hermitian KPM (port of NHKPM.jl, see

--- a/src/dmrgpy/pyitensor/metts.py
+++ b/src/dmrgpy/pyitensor/metts.py
@@ -60,7 +60,7 @@ import numpy as np
 
 from .index import Index, reseed_id_counter_past
 from .mpscontainer import MPS
-from .mpsalgebra import inner
+from .mpsalgebra import applyMPO, inner
 from .tdvp import tdvp_step
 from .tensor import ITensor, noPrime
 
@@ -420,3 +420,192 @@ def metts_thermal_average(H, sites, ops, beta, nsamples, nwarmup=20,
     with multiprocessing.get_context("spawn").Pool(len(chunk_sizes)) as pool:
         results = pool.map(_run_chain_worker, tasks)
     return _pool_chain_results(results, len(ops))
+
+
+# -- Dynamical METTS (real-time finite-T correlators), arXiv:2405.18484 --
+#
+# Wang, McClarty, Dankova, Honecker & Wietek, "Spectroscopy and complex-time
+# correlations using minimally entangled typical thermal states" (2024),
+# Sec. II / Algorithm 1. Generalizes the static thermal_average above from
+# <A>_beta to the two-time correlator C_AB(t) = <A(t)B>_beta =
+# <e^{iHt} A e^{-iHt} B>_beta, following the exact same METTS Markov chain
+# (imaginary_time_evolve + collapse_to_cps): for each retained sample
+# |psi_i>, define
+#   |v_i(0)> = B|psi_i>,  |w_i(0)> = |psi_i>,
+#   C^i(t) = <w_i(t)|A|v_i(t)>,
+# and real-time-evolve |v_i(t)> and |w_i(t)> independently (both under H,
+# via tdvp_step with dt real -- this module's own -i*dt convention, see
+# the module docstring, already makes a purely real dt give genuine
+# rotation rather than decay, i.e. real time). A plain (unweighted)
+# average of C^i(t) over samples converges to C_AB(t), for exactly the
+# same reason metts_thermal_average()'s plain average of <phi|A|phi>
+# converges to <A>_beta -- the METTS Markov chain's stationary
+# distribution already carries the Boltzmann weight p_i/Z (paper's
+# Eq. (3)-(5), Sec. 2 above), no importance reweighting needed.
+#
+# No Fourier transform/windowing is done here -- this returns the raw
+# time-domain samples/statistics; the frequency-domain spectral function
+# (paper's Eq. (eq:mettspectral), via a Hann-windowed FFT, Sec. "Spectral
+# analysis and windowing") is left to the caller (see
+# vevtk/mettsdynamicalcorrelator.py), mirroring how timedependent.py's
+# evolution_dmrg_DC returns (ts,cs) and dynamical_correlator() does its
+# own separate FFT step on top.
+
+
+def _metts_dynamical_single_chain(H, sites, A, B, beta, nt, dt, nsamples,
+                                   nwarmup, dbeta_half_step, cutoff, maxdim,
+                                   basis_ops, initial_cps, seed, niter,
+                                   tdvp_cutoff, tdvp_maxdim, tdvp_niter):
+    """One full METTS Markov chain (nwarmup discarded + nsamples retained
+    iterations) producing the time-dependent correlator C^i(t) for every
+    retained sample -- the dynamical analog of _metts_single_chain()
+    above. Returns (means, stderrs, nsamples): means/stderrs are complex/
+    real arrays of length nt."""
+    rng = np.random.default_rng(seed)
+    beta_half = beta / 2.0
+    nsteps = max(1, int(np.ceil(beta_half / dbeta_half_step)))
+    eigcache = _build_eigcache(sites, basis_ops)
+
+    cps = initial_cps if initial_cps is not None else random_cps(sites, basis_ops[0], rng, eigcache)
+
+    nbasis = len(basis_ops)
+    samples = np.zeros((nsamples, nt), dtype=complex)
+    kept = 0
+    total_iters = nwarmup + nsamples
+    for it in range(total_iters):
+        phi = imaginary_time_evolve(cps, H, beta_half, nsteps, cutoff, maxdim, niter=niter)
+        if it >= nwarmup:
+            v = applyMPO(B, phi, cutoff=tdvp_cutoff, maxdim=tdvp_maxdim)
+            v.noPrime("Site")
+            w = phi.copy()
+            for k in range(nt):
+                samples[kept, k] = inner(w, A, v)
+                if k < nt - 1:
+                    v = tdvp_step(v, H, dt, cutoff=tdvp_cutoff, maxdim=tdvp_maxdim, niter=tdvp_niter)
+                    w = tdvp_step(w, H, dt, cutoff=tdvp_cutoff, maxdim=tdvp_maxdim, niter=tdvp_niter)
+            kept += 1
+        basis = basis_ops[it % nbasis]
+        cps, _ = collapse_to_cps(phi, sites, basis, rng, eigcache)
+
+    means = samples.mean(axis=0)
+    if nsamples > 1:
+        stderrs = samples.std(axis=0, ddof=1) / np.sqrt(nsamples)
+    else:
+        stderrs = np.zeros(nt)
+    return means, stderrs, nsamples
+
+
+def _run_dynamical_chain_worker(args):
+    """Top-level (picklable) target for multiprocessing.Pool, mirroring
+    _run_chain_worker() above -- same reseed-past-every-existing-Index.id
+    rationale (index.py's reseed_id_counter_past()), scanning H/sites/A/B
+    (and initial_cps, normally None here) rather than a single-op list."""
+    H, sites, A, B, initial_cps = args[0], args[1], args[2], args[3], args[13]
+    reseed_id_counter_past(_max_index_id(sites, H, [A, B], initial_cps))
+    return _metts_dynamical_single_chain(*args)
+
+
+def _pool_chain_results_dynamical(results, nt):
+    """Combine several independent chains' (means, stderrs, nsamples)
+    triples (each means/stderrs now length-nt arrays) into pooled
+    (means, stderrs) arrays -- elementwise application of
+    _pool_chain_results()'s same exact pooled-variance identity, one time
+    point at a time (that identity holds independently at every t)."""
+    ns = np.array([n for _, _, n in results], dtype=float)
+    N = ns.sum()
+    chain_means = np.array([means for means, _, _ in results], dtype=complex)  # (nchains, nt)
+    chain_stderr = np.array([stderrs for _, stderrs, _ in results], dtype=float)  # (nchains, nt)
+    chain_vars = chain_stderr ** 2 * ns[:, None]
+    M = np.sum(ns[:, None] * chain_means, axis=0) / N
+    SS = np.sum((ns[:, None] - 1) * chain_vars + ns[:, None] * np.abs(chain_means - M[None, :]) ** 2, axis=0)
+    var_pooled = SS / (N - 1) if N > 1 else np.zeros(nt)
+    stderrs_out = np.sqrt(var_pooled / N) if N > 0 else np.zeros(nt)
+    return M, stderrs_out
+
+
+def metts_dynamical_correlator(H, sites, A, B, beta, nt, dt, nsamples,
+                                nwarmup=20, dbeta_half_step=0.05,
+                                cutoff=1e-10, maxdim=200,
+                                basis_ops=("Sz", "Sx"), initial_cps=None,
+                                seed=None, niter=30,
+                                tdvp_cutoff=None, tdvp_maxdim=None,
+                                tdvp_niter=50, njobs=1):
+    """Estimate the real-time finite-temperature correlator
+    C_AB(t) = <A(t)B>_beta = <e^{iHt} A e^{-iHt} B>_beta via dynamical
+    METTS sampling (arXiv:2405.18484, Sec. II, Algorithm 1).
+
+    H, A, B: already-built MPOs (e.g. from Chain.build_operator()) -- A,
+        B used exactly as given (no conjugation/dagger), matching
+        edtk/dynamics.py's dynamical_correlator_ED/dynamical_correlator_kpm
+        convention this is meant to be validated against.
+    beta: inverse temperature (1/T).
+    nt, dt: number of real-time measurements and the (uniform) time step
+        between them, i.e. C(t) is returned at t=0,dt,...,(nt-1)*dt --
+        same convention as timedependent.py's evolution_dmrg_DC(nt,dt).
+    nsamples, nwarmup, dbeta_half_step, cutoff, maxdim, basis_ops,
+        initial_cps, seed, niter: as in metts_thermal_average() above --
+        control the shared METTS Markov chain (imaginary-time sampling)
+        each retained sample's correlator is measured from.
+    tdvp_cutoff, tdvp_maxdim, tdvp_niter: TDVP truncation controls for the
+        *real-time* evolution of |v_i(t)>/|w_i(t)> specifically -- default
+        to `cutoff`/`maxdim`/50 (the real-time evolution typically wants a
+        looser cutoff and a larger bond dimension than the imaginary-time
+        sampling step, since |v_i(t)>/|w_i(t)> generically become more
+        entangled than the METTS states |psi_i> themselves, see the
+        paper's Sec. "Time-evolution using matrix product states";
+        exposed separately rather than reusing cutoff/maxdim outright).
+    njobs: as in metts_thermal_average() above -- run njobs independent
+        Markov chains in parallel worker processes and pool statistics
+        (itensor_version="python" only).
+
+    Returns (means, stderrs): means[k] is the sample-averaged C_AB(k*dt)
+    (complex), stderrs[k] its naive iid standard error over nsamples --
+    see metts_thermal_average()'s own docstring for the same
+    Markov-correlation caveat (likely optimistic unless dbeta_half_step/
+    nwarmup are generous enough for samples to decorrelate).
+    """
+    if beta <= 0:
+        raise ValueError("metts_dynamical_correlator: beta (1/T) must be > 0, got %r" % (beta,))
+    if not basis_ops:
+        raise ValueError("metts_dynamical_correlator: basis_ops must be non-empty")
+    if nsamples < 1:
+        raise ValueError("metts_dynamical_correlator: nsamples must be >= 1, got %r" % (nsamples,))
+    if nt < 1:
+        raise ValueError("metts_dynamical_correlator: nt must be >= 1, got %r" % (nt,))
+    if njobs < 1:
+        raise ValueError("metts_dynamical_correlator: njobs must be >= 1, got %r" % (njobs,))
+    if tdvp_cutoff is None: tdvp_cutoff = cutoff
+    if tdvp_maxdim is None: tdvp_maxdim = maxdim
+
+    if njobs == 1:
+        means, stderrs, _ = _metts_dynamical_single_chain(
+            H, sites, A, B, beta, nt, dt, nsamples, nwarmup, dbeta_half_step,
+            cutoff, maxdim, basis_ops, initial_cps, seed, niter,
+            tdvp_cutoff, tdvp_maxdim, tdvp_niter)
+        return means, stderrs
+
+    if initial_cps is not None:
+        raise ValueError("metts_dynamical_correlator: initial_cps is not supported together with njobs>1")
+
+    base, extra = divmod(nsamples, njobs)
+    chunk_sizes = [base + (1 if k < extra else 0) for k in range(njobs)]
+    chunk_sizes = [n for n in chunk_sizes if n > 0]
+    if len(chunk_sizes) == 1:
+        means, stderrs, _ = _metts_dynamical_single_chain(
+            H, sites, A, B, beta, nt, dt, chunk_sizes[0], nwarmup, dbeta_half_step,
+            cutoff, maxdim, basis_ops, None, seed, niter,
+            tdvp_cutoff, tdvp_maxdim, tdvp_niter)
+        return means, stderrs
+
+    seeds = np.random.SeedSequence(seed).spawn(len(chunk_sizes))
+    tasks = [
+        (H, sites, A, B, beta, nt, dt, n_local, nwarmup, dbeta_half_step,
+         cutoff, maxdim, basis_ops, None, seeds[k], niter,
+         tdvp_cutoff, tdvp_maxdim, tdvp_niter)
+        for k, n_local in enumerate(chunk_sizes)
+    ]
+    # 'spawn', not fork -- see metts_thermal_average()'s own comment on
+    # this same choice above (fork-after-BLAS-threading hazard).
+    with multiprocessing.get_context("spawn").Pool(len(chunk_sizes)) as pool:
+        results = pool.map(_run_dynamical_chain_worker, tasks)
+    return _pool_chain_results_dynamical(results, nt)

--- a/src/dmrgpy/vevtk/mettsdynamicalcorrelator.py
+++ b/src/dmrgpy/vevtk/mettsdynamicalcorrelator.py
@@ -33,6 +33,7 @@ from .. import operatornames
 def metts_dynamical_correlator(MB, name, T, nt=200, dt=0.1, nsamples=100,
                                 nwarmup=20, dbeta_half_step=0.05,
                                 basis_ops=("Sz", "Sx"), seed=None, niter=30,
+                                tdvp_cutoff=None, tdvp_maxdim=None,
                                 tdvp_niter=50, njobs=1):
     """Real-time dynamical correlator C_AB(t) = <A(t)B>_T at temperature T
     via dynamical METTS sampling (arXiv:2405.18484, Sec. II).
@@ -57,6 +58,18 @@ def metts_dynamical_correlator(MB, name, T, nt=200, dt=0.1, nsamples=100,
     nsamples, nwarmup, dbeta_half_step, basis_ops, seed, niter: as in
         MB.metts_vev() -- control the shared METTS Markov chain
         (imaginary-time sampling) each retained sample is measured from.
+    tdvp_cutoff, tdvp_maxdim: truncation controls for the *real-time*
+        evolution of |v_i(t)>/|w_i(t)> specifically, separate from this
+        chain's own cutoff/maxm (used for the imaginary-time METTS
+        sampling step) -- default None, meaning "same as this chain's own
+        cutoff/maxm" (see pyitensor.metts.metts_dynamical_correlator's own
+        docstring on why real-time evolution generally wants a looser
+        cutoff/larger bond dimension). itensor_version="python" only --
+        v3's Chain::metts_dynamical_correlator has no such knob (always
+        uses this chain's own cutoff/maxm for both imaginary- and
+        real-time evolution, like every other v3 TDVP method); passing
+        either on itensor_version=3 raises rather than silently ignoring
+        it.
     tdvp_niter: Krylov-iteration bound for the *real-time* TDVP evolution
         of |v_i(t)>/|w_i(t)> specifically (separate from `niter`, which
         only controls the imaginary-time sampling step) -- see
@@ -107,6 +120,14 @@ def metts_dynamical_correlator(MB, name, T, nt=200, dt=0.1, nsamples=100,
             "metts_dynamical_correlator: njobs>1 (parallel independent "
             "Markov chains) is only implemented for itensor_version="
             "'python' so far (got itensor_version=%r)" % (MB.itensor_version,))
+    if MB.itensor_version != "python" and (tdvp_cutoff is not None or tdvp_maxdim is not None):
+        # v3's Chain::metts_dynamical_correlator has no separate real-time
+        # cutoff/maxdim knob at all -- raise rather than silently ignoring
+        # a value the caller explicitly asked for.
+        raise NotImplementedError(
+            "metts_dynamical_correlator: tdvp_cutoff/tdvp_maxdim are only "
+            "implemented for itensor_version='python' so far (got "
+            "itensor_version=%r)" % (MB.itensor_version,))
 
     resolved = operatornames.str2MO(MB, name)
     A, B = resolved[0], resolved[1]
@@ -123,7 +144,8 @@ def metts_dynamical_correlator(MB, name, T, nt=200, dt=0.1, nsamples=100,
     if MB.itensor_version == "python":
         means, stderrs = MB._session.metts_dynamical_correlator(
             terms_a, terms_b, T, nt, dt, nsamples, nwarmup, dbeta_half_step,
-            list(basis_ops), seed_arg, niter, tdvp_niter=tdvp_niter, njobs=njobs)
+            list(basis_ops), seed_arg, niter, tdvp_cutoff=tdvp_cutoff,
+            tdvp_maxdim=tdvp_maxdim, tdvp_niter=tdvp_niter, njobs=njobs)
     else:
         means, stderrs = MB._session.metts_dynamical_correlator(
             terms_a, terms_b, T, nt, dt, nsamples, nwarmup, dbeta_half_step,

--- a/src/dmrgpy/vevtk/mettsdynamicalcorrelator.py
+++ b/src/dmrgpy/vevtk/mettsdynamicalcorrelator.py
@@ -1,0 +1,132 @@
+"""METTS-based finite-temperature dynamical correlator -- a
+Many_Body_Chain-facing wrapper around Chain.metts_dynamical_correlator()
+(pyitensor.chain.Chain for itensor_version="python", mpscpp3's
+Chain::metts_dynamical_correlator in-process pybind11 method for
+itensor_version=3).
+
+Reference: Z. Wang, P. McClarty, D. Dankova, A. Honecker, A. Wietek,
+"Spectroscopy and complex-time correlations using minimally entangled
+typical thermal states", arXiv:2405.18484 -- Sec. II ("Dynamical METTS
+algorithm"), Algorithm 1. Extends the static thermal_vev/metts_vev
+machinery (arXiv:1002.1305, see mettsvev.py) from thermal expectation
+values <A>_beta to the real-time two-time correlator
+C_AB(t) = <A(t)B>_beta = <e^{iHt} A e^{-iHt} B>_beta: for every METTS
+sample |psi_i> sampled by the same Markov chain metts_vev already uses,
+define |v_i(0)>=B|psi_i>, |w_i(0)>=|psi_i>, evolve both in real time
+under H, and average C^i(t)=<w_i(t)|A|v_i(t)> over samples -- no
+importance reweighting needed, for exactly the same reason the static
+algorithm's plain sample average already converges to the thermal
+average (see metts.py's module docstring).
+
+Only itensor_version in ("python", 3) are wired up, same restriction as
+metts_vev (itensor_version=2/mpscpp2 has no TDVP module at all, so no
+route to real- or imaginary-time evolution).
+"""
+
+import random
+
+import numpy as np
+
+from .. import operatornames
+
+
+def metts_dynamical_correlator(MB, name, T, nt=200, dt=0.1, nsamples=100,
+                                nwarmup=20, dbeta_half_step=0.05,
+                                basis_ops=("Sz", "Sx"), seed=None, niter=30,
+                                tdvp_niter=50, njobs=1):
+    """Real-time dynamical correlator C_AB(t) = <A(t)B>_T at temperature T
+    via dynamical METTS sampling (arXiv:2405.18484, Sec. II).
+
+    MB: a Many_Body_Chain with itensor_version in ("python", 3) and a
+        Hamiltonian already set via MB.set_hamiltonian(...).
+    name: the (A,B) operator pair, in the same format
+        operatornames.str2MO() accepts elsewhere in this codebase -- a
+        string like "ZZ" (site indices given via i=/j= kwargs), or an
+        explicit (MultiOperator,MultiOperator) tuple/list. A and B are
+        used exactly as resolved (no dagger applied to either), matching
+        edtk/dynamics.py's dynamical_correlator_ED/dynamical_correlator_kpm
+        convention -- this method is meant to be validated directly
+        against MB.get_dynamical_correlator(mode="ED", submode="ED",
+        T=..., name=name) (see edtk/dynamics.py's
+        dynamical_correlator_finite_T), which shares that exact same
+        convention.
+    T: temperature (>0).
+    nt, dt: number of real-time measurements and the (uniform) time step
+        between them, i.e. C(t) is sampled at t=0,dt,...,(nt-1)*dt --
+        same convention as Many_Body_Chain.evolution_DC's own (nt,dt).
+    nsamples, nwarmup, dbeta_half_step, basis_ops, seed, niter: as in
+        MB.metts_vev() -- control the shared METTS Markov chain
+        (imaginary-time sampling) each retained sample is measured from.
+    tdvp_niter: Krylov-iteration bound for the *real-time* TDVP evolution
+        of |v_i(t)>/|w_i(t)> specifically (separate from `niter`, which
+        only controls the imaginary-time sampling step) -- see
+        pyitensor.metts.metts_dynamical_correlator's own docstring on why
+        real- and imaginary-time evolution get independent controls here.
+    njobs: run njobs independent METTS Markov chains in parallel worker
+        processes and pool their statistics -- itensor_version="python"
+        only, same mechanism/caveats as MB.metts_vev(njobs=...).
+
+    Returns (ts, means, stderrs): ts is the array of nt measurement
+    times, means[k] the sample-averaged C_AB(ts[k]) (complex), stderrs[k]
+    its naive iid standard error over nsamples retained METTS samples --
+    see MB.metts_vev()'s own docstring for the same Markov-correlation
+    caveat on what that stderr does and doesn't capture.
+    """
+    if MB.itensor_version not in ("python", 3):
+        raise NotImplementedError(
+            "metts_dynamical_correlator is only implemented for "
+            "itensor_version='python' or 3 so far (got itensor_version=%r)"
+            % (MB.itensor_version,))
+    if MB.itensor_version == 3 and MB.ns < 3:
+        # Same underlying vendored-ITensor limitation as metts_vev's own
+        # guard (see vevtk/mettsvev.py) -- two-site TDVP SIGABRTs for
+        # chains this short, confirmed directly, and there's no ED-based
+        # dynamical METTS to fall back to.
+        raise NotImplementedError(
+            "metts_dynamical_correlator with itensor_version=3 can't "
+            "handle a chain this short (n=%d < 3 sites): ITensor v3's "
+            "two-site TDVP aborts the whole process for chains below 3 "
+            "sites (the same vendored-ITensor limitation as its two-site "
+            "dmrg(), see CLAUDE.md). Use itensor_version='python' instead "
+            "for small chains." % (MB.ns,))
+    if T <= 0:
+        raise ValueError("metts_dynamical_correlator: T must be > 0, got %r" % (T,))
+    if not basis_ops:
+        raise ValueError("metts_dynamical_correlator: basis_ops must be non-empty")
+    if nsamples < 1:
+        raise ValueError("metts_dynamical_correlator: nsamples must be >= 1, got %r" % (nsamples,))
+    if nt < 1:
+        raise ValueError("metts_dynamical_correlator: nt must be >= 1, got %r" % (nt,))
+    if njobs < 1:
+        raise ValueError("metts_dynamical_correlator: njobs must be >= 1, got %r" % (njobs,))
+    if njobs > 1 and MB.itensor_version != "python":
+        # Same reason as metts_vev's own njobs>1 guard: mpscpp3's Chain is
+        # a single live in-process C++ session with no per-worker copy a
+        # multiprocessing pool could hand out.
+        raise NotImplementedError(
+            "metts_dynamical_correlator: njobs>1 (parallel independent "
+            "Markov chains) is only implemented for itensor_version="
+            "'python' so far (got itensor_version=%r)" % (MB.itensor_version,))
+
+    resolved = operatornames.str2MO(MB, name)
+    A, B = resolved[0], resolved[1]
+
+    MB._session.set_sweep_params(MB.maxm, MB.nsweeps, MB.cutoff, MB.noise)
+    MB._session.set_verbose(MB.verbose)
+    MB._session.set_mpomaxm(max(MB.maxm, MB.mpomaxm))
+    MB._session.set_hamiltonian(MB.hamiltonian.to_terms())
+    # Both backends' metts_dynamical_correlator want a concrete integer
+    # seed, same as metts_vev -- draw one here when the caller didn't pin
+    # one, rather than silently becoming deterministic.
+    seed_arg = seed if seed is not None else random.getrandbits(63)
+    terms_a, terms_b = A.to_terms(), B.to_terms()
+    if MB.itensor_version == "python":
+        means, stderrs = MB._session.metts_dynamical_correlator(
+            terms_a, terms_b, T, nt, dt, nsamples, nwarmup, dbeta_half_step,
+            list(basis_ops), seed_arg, niter, tdvp_niter=tdvp_niter, njobs=njobs)
+    else:
+        means, stderrs = MB._session.metts_dynamical_correlator(
+            terms_a, terms_b, T, nt, dt, nsamples, nwarmup, dbeta_half_step,
+            list(basis_ops), seed_arg, niter, tdvp_niter)
+    ts = np.array([dt * k for k in range(nt)])
+    return ts, np.array(means), np.array(stderrs)

--- a/tests/test_dynamical_correlator.py
+++ b/tests/test_dynamical_correlator.py
@@ -191,3 +191,43 @@ def test_tdz_dynamical_correlator_peak_matches_exact_gap(itensor_version):
     x, y = np.array(x), np.array(y).real
     peak = x[np.argmax(y)]
     assert peak == pytest.approx(HEISENBERG_4_GAP, abs=0.03)
+
+
+def test_finite_T_dynamical_correlator_independent_of_es_window():
+    """get_dynamical_correlator(mode="ED", submode="ED", T=...) (the
+    finite-temperature Lehmann sum, edtk/dynamics.py's
+    dynamical_correlator_finite_T) must return the same values at a given
+    frequency regardless of how far the requested `es` window extends,
+    since the *initial*-state Boltzmann sum is physically independent of
+    which frequencies the caller happens to be asking for.
+
+    Regression test for a real bug (caught by code review): an earlier
+    version cropped the initial-state index space to `es`'s own window
+    too (not just the final-state space), which silently dropped any
+    thermally-populated state above the window's max energy from the
+    numerator while the partition function Z (from the full spectrum)
+    still counted it in the denominator -- a systematic under-count
+    growing with how much Boltzmann weight got left out. At T=2.0 on this
+    4-site chain, an es window capped at 1.0 only captures ~41% of the
+    total Boltzmann weight (the bulk of the spectrum sits above that),
+    so the old bug would have inflated every value here by roughly
+    1/0.41 =~ 2.4x relative to a window wide enough to capture ~100%."""
+    n = 4
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    h = 0
+    for i in range(n - 1):
+        h = h + sc.Sx[i] * sc.Sx[i + 1] + sc.Sy[i] * sc.Sy[i + 1] + sc.Sz[i] * sc.Sz[i + 1]
+    sc.set_hamiltonian(h)
+
+    name = (sc.Sz[0], sc.Sz[0])
+    T = 2.0
+    es_narrow = np.linspace(-1.0, 1.0, 41)
+    es_wide = np.linspace(-1.0, 6.0, 141)
+
+    x1, y1 = sc.get_dynamical_correlator(mode="ED", submode="ED", name=name,
+                                          T=T, es=es_narrow, delta=0.05)
+    x2, y2 = sc.get_dynamical_correlator(mode="ED", submode="ED", name=name,
+                                          T=T, es=es_wide, delta=0.05)
+    y2_on_x1 = np.interp(x1, x2, y2.real)
+
+    assert y1.real == pytest.approx(y2_on_x1, abs=1e-6)

--- a/tests/test_metts_dynamical_correlator.py
+++ b/tests/test_metts_dynamical_correlator.py
@@ -1,0 +1,180 @@
+"""Regression coverage for Many_Body_Chain.metts_dynamical_correlator()
+(real-time finite-temperature dynamical correlators C_AB(t)=<A(t)B>_T via
+the dynamical METTS algorithm, Wang, McClarty, Dankova, Honecker & Wietek,
+"Spectroscopy and complex-time correlations using minimally entangled
+typical thermal states", arXiv:2405.18484, Sec. II / Algorithm 1).
+
+Validated directly against an exact ED reference: a full Boltzmann-weighted
+Lehmann sum over eigenstates, computed inline here in the time domain
+(the same physics as edtk/dynamics.py's dynamical_correlator_finite_T,
+which returns the frequency-domain spectral function instead -- computing
+the time-domain sum directly here avoids needing an FFT round-trip for
+this cross-check).
+
+METTS is a Monte Carlo method: exact agreement isn't expected, only
+agreement within a generous multiple of the reported (Markov-correlated,
+so likely optimistic) standard error -- same convention as
+test_metts_vev.py.
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import cppext, spinchain
+from dmrgpy.edtk.edchain import EDOperator
+
+from _helpers import setup_backend
+
+VERSIONS = [
+    "python",
+    pytest.param(3, marks=pytest.mark.skipif(
+        not cppext.available(3),
+        reason="requires the compiled mpscpp3 (ITensor v3) extension")),
+]
+
+
+def _heisenberg_field_chain(n, version, J=1.0, B=0.3):
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    setup_backend(sc, version)
+    h = 0
+    for i in range(n - 1):
+        h = h + J * sc.Sx[i] * sc.Sx[i + 1] + J * sc.Sy[i] * sc.Sy[i + 1] + J * sc.Sz[i] * sc.Sz[i + 1]
+    for i in range(n):
+        h = h + B * sc.Sz[i]
+    sc.set_hamiltonian(h)
+    return sc, h
+
+
+def _ed_time_domain_reference(sc, name, T, ts):
+    """Exact C_AB(t)=<A(t)B>_T via a full Boltzmann-weighted Lehmann sum
+    over every ED eigenstate -- A,B used exactly as given (no dagger),
+    same convention edtk/dynamics.py's dynamical_correlator_finite_T
+    uses (both built from the same Uh@op@U matrix-element machinery)."""
+    edobj = sc.get_ED_obj()
+    emu, vs = edobj.get_diagonalized_hamiltonian()
+    a0 = EDOperator(name[0], edobj).SO
+    b0 = EDOperator(name[1], edobj).SO
+    e0 = np.min(emu)
+    ex = emu - e0
+    beta = 1.0 / T
+    w = np.exp(-beta * ex)
+    w = w / w.sum()
+    U = np.array(vs)
+    Uh = np.conjugate(U.T)
+    A = Uh @ a0 @ U
+    B = Uh @ b0 @ U
+    out = np.zeros(len(ts), dtype=complex)
+    for k, t in enumerate(ts):
+        phase = np.exp(1j * (ex[:, None] - ex[None, :]) * t)
+        out[k] = np.sum(w[:, None] * phase * A * B.T)
+    return out
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_dynamical_correlator_matches_ed_lehmann_sum(version):
+    """4-site Heisenberg+field chain: C_AB(t) for A=B=Sz[0] from dynamical
+    METTS must agree with the exact ED Lehmann sum (within a generous
+    multiple of METTS's own reported standard error) at every sampled
+    time, not just at t=0."""
+    n = 4
+    sc, h = _heisenberg_field_chain(n, version, B=0.4)
+    T = 1.0
+    name = (sc.Sz[0], sc.Sz[0])
+    nt, dt = 10, 0.2
+
+    ts, means, stderrs = sc.metts_dynamical_correlator(
+        name, T, nt=nt, dt=dt, nsamples=200, nwarmup=30,
+        dbeta_half_step=0.08, seed=2024, njobs=4 if version == "python" else 1)
+
+    ref = _ed_time_domain_reference(sc, name, T, ts)
+
+    diff = np.abs(means - ref)
+    tol = np.maximum(5 * stderrs, 0.03)  # 5-sigma headroom, floored for the near-zero-stderr t=0 point
+    assert np.all(diff <= tol), list(zip(ts, diff, tol))
+
+
+def test_metts_dynamical_correlator_t0_is_static_vev():
+    """At t=0, v_i(0)=B|psi_i> and w_i(0)=|psi_i>, so C^i(0)=<psi_i|A B|psi_i>
+    -- for A=B=Sz[0] on a spin-1/2 site this is exactly <(Sz[0])^2>=1/4
+    regardless of temperature or sampling (Sz[0]^2 = Identity/4 for
+    spin-1/2), a model-independent sanity check on the v/w bookkeeping
+    at the very first measurement."""
+    sc, h = _heisenberg_field_chain(3, "python", B=0.4)
+    T = 0.8
+    name = (sc.Sz[0], sc.Sz[0])
+    ts, means, stderrs = sc.metts_dynamical_correlator(
+        name, T, nt=1, dt=0.1, nsamples=20, nwarmup=10, seed=1)
+    assert means[0].real == pytest.approx(0.25, abs=1e-8)
+    assert means[0].imag == pytest.approx(0.0, abs=1e-8)
+
+
+def test_metts_dynamical_correlator_requires_supported_backend():
+    """Same backend restriction as metts_vev (see its own test) -- mpscpp2
+    has no TDVP module at all."""
+    sc, h = _heisenberg_field_chain(2, "python")
+    sc.itensor_version = 2
+    with pytest.raises(NotImplementedError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=2, nwarmup=1)
+
+
+def test_metts_dynamical_correlator_v3_rejects_short_chain():
+    """Same ITensor v3 two-site-TDVP-aborts-below-3-sites guard as
+    metts_vev's own test -- Python-side guard only, no compiled extension
+    needed to exercise it."""
+    sc, h = _heisenberg_field_chain(2, "python")
+    sc.itensor_version = 3
+    with pytest.raises(NotImplementedError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=2, nwarmup=1)
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_dynamical_correlator_rejects_non_positive_temperature(version):
+    sc, h = _heisenberg_field_chain(3, version)
+    with pytest.raises(ValueError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), -1.0, nt=2, dt=0.1,
+                                       nsamples=2, nwarmup=1)
+    with pytest.raises(ValueError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 0.0, nt=2, dt=0.1,
+                                       nsamples=2, nwarmup=1)
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_dynamical_correlator_rejects_empty_basis_ops(version):
+    sc, h = _heisenberg_field_chain(3, version)
+    with pytest.raises(ValueError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=2, nwarmup=1, basis_ops=())
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_dynamical_correlator_rejects_non_positive_nsamples(version):
+    sc, h = _heisenberg_field_chain(3, version)
+    with pytest.raises(ValueError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=0, nwarmup=1)
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_metts_dynamical_correlator_rejects_non_positive_nt(version):
+    sc, h = _heisenberg_field_chain(3, version)
+    with pytest.raises(ValueError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=0, dt=0.1,
+                                       nsamples=2, nwarmup=1)
+
+
+def test_metts_dynamical_correlator_njobs_rejects_v3():
+    """Same reason as metts_vev's own njobs>1 guard: mpscpp3's Chain is a
+    single live in-process C++ session with no per-worker copy a
+    multiprocessing pool could hand out."""
+    sc, h = _heisenberg_field_chain(3, 3)
+    with pytest.raises(NotImplementedError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=4, nwarmup=1, njobs=2)
+
+
+def test_metts_dynamical_correlator_rejects_non_positive_njobs():
+    sc, h = _heisenberg_field_chain(3, "python")
+    with pytest.raises(ValueError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=4, nwarmup=1, njobs=0)

--- a/tests/test_metts_dynamical_correlator.py
+++ b/tests/test_metts_dynamical_correlator.py
@@ -173,6 +173,38 @@ def test_metts_dynamical_correlator_njobs_rejects_v3():
                                        nsamples=4, nwarmup=1, njobs=2)
 
 
+def test_metts_dynamical_correlator_tdvp_cutoff_maxdim_reach_python_backend():
+    """tdvp_cutoff/tdvp_maxdim must actually be reachable end-to-end from
+    Many_Body_Chain.metts_dynamical_correlator down to
+    pyitensor.metts.metts_dynamical_correlator (not silently dropped
+    somewhere in the vevtk/mettsdynamicalcorrelator.py <-> pyitensor.chain
+    <-> pyitensor.metts call chain, which used to leave them dead -- no
+    caller could ever set them to anything but their None-default,
+    confirmed by code review). Exercised via a value tight enough to
+    force truncation (tdvp_maxdim=1, well below what a real evolution
+    would need) so the call path is genuinely exercised, not just
+    accepted and ignored; only checks the call succeeds and returns
+    sane-shaped output, not the resulting numerical accuracy."""
+    sc, h = _heisenberg_field_chain(3, "python", B=0.4)
+    ts, means, stderrs = sc.metts_dynamical_correlator(
+        (sc.Sz[0], sc.Sz[0]), 1.0, nt=3, dt=0.1, nsamples=3, nwarmup=1,
+        seed=1, tdvp_cutoff=1e-6, tdvp_maxdim=1)
+    assert len(ts) == len(means) == len(stderrs) == 3
+
+
+def test_metts_dynamical_correlator_v3_rejects_tdvp_cutoff_maxdim():
+    """v3's Chain::metts_dynamical_correlator has no separate real-time
+    cutoff/maxdim knob at all -- passing either must raise rather than
+    silently being ignored."""
+    sc, h = _heisenberg_field_chain(3, 3)
+    with pytest.raises(NotImplementedError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=2, nwarmup=1, tdvp_cutoff=1e-6)
+    with pytest.raises(NotImplementedError):
+        sc.metts_dynamical_correlator((sc.Sz[0], sc.Sz[0]), 1.0, nt=2, dt=0.1,
+                                       nsamples=2, nwarmup=1, tdvp_maxdim=10)
+
+
 def test_metts_dynamical_correlator_rejects_non_positive_njobs():
     sc, h = _heisenberg_field_chain(3, "python")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Implements real-time dynamical correlators $C_{AB}(t)=\langle A(t)B\rangle_T$ at finite temperature via the **dynamical METTS** algorithm (Wang, McClarty, Dankova, Honecker & Wietek, ["Spectroscopy and complex-time correlations using minimally entangled typical thermal states"](https://arxiv.org/abs/2405.18484), Sec. II / Algorithm 1), for `itensor_version="python"` and `3`.
- Adds an exact ED reference (`edtk/dynamics.py::dynamical_correlator_finite_T`, a full Boltzmann-weighted Lehmann sum over every eigenstate — `get_dynamical_correlator(mode="ED", submode="ED", T=...)`) to validate METTS against.
- Along the way, found and fixed a real bug in `mpscpp3/chain_session.h::Chain::tdvp_step`: it hardcodes `DoNormalize=true`, which silently force-renormalizes a deliberately non-unit-norm state (the paper's `|v_i(t)⟩`, which must stay at its own constant, generally ≠1 norm) back to 1 at every step. `quench_tdvp` already worked around this for its own similarly unnormalized state; the new method does the same.

## Implementation
- `src/dmrgpy/pyitensor/metts.py` + `chain.py`: `metts_dynamical_correlator`, reusing the existing METTS Markov chain machinery (`imaginary_time_evolve`/`collapse_to_cps`). Validated directly against the ED reference to within statistical error.
- `src/dmrgpy/mpscpp3/chain_session.h` + `bindings.cc`: direct C++ port of the same algorithm (`Chain::metts_dynamical_correlator`), mirroring `Chain::metts_vev`'s sampling loop.
- `src/dmrgpy/vevtk/mettsdynamicalcorrelator.py` + `manybodychain.py`: the `Many_Body_Chain`-facing `metts_dynamical_correlator()` wrapper.
- `docs/user_guide.{md,tex}`: documents the new method.

## Test plan
- [x] `tests/test_metts_dynamical_correlator.py` — 15 tests, both backends validated against the exact ED Lehmann-sum reference within statistical tolerance, plus error-guard coverage (unsupported backend, short v3 chains, invalid T/nsamples/nt/njobs).
- [x] `examples/finite_temperature/dynamical_metts_VS_ED/main.py` — cross-checks both backends against ED, prints a comparison table.
- [x] Full existing suite (`pytest tests/`): 154 passed, 9 skipped, no regressions.
- [x] `docs/user_guide.tex` recompiles cleanly with `pdflatex` (no warnings/errors after the reference pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t