### PR TITLE
Speed up pyitensor TDVP/METTS: precomputed-plan matvec default, faster Lanczos-expm

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1258,16 +1258,24 @@ same windowing/FFT tail as `"TD"` (factored out into
 ## 5. Backend performance: v3 vs the pure-Python backend
 
 The pure-Python backend (`itensor_version="python"`) trades raw speed for
-zero build dependencies. Numbers below were measured directly on one
-machine, with `numba` installed *and* explicitly opted in
-(`pyitensor.kernels.USE_NUMBA = True`) for its accelerated
-matvec/effective-Hamiltonian kernel (see `pyitensor/kernels.py`). This
-kernel is **not** used automatically just by having `numba` installed --
-`USE_NUMBA` defaults to `False`, because the one-time JIT compile cost is
-a net regression for this library's typical one-shot-script usage
-pattern (see `kernels.py`'s own docstring for measured numbers). Set
-`kernels.USE_NUMBA = True` yourself before running DMRG if you want this
-path. Absolute times will vary by machine and load, but the qualitative
+zero build dependencies. The tables below were originally measured with
+`numba` explicitly opted in (`pyitensor.kernels.USE_NUMBA = True`); the
+*default* path (`USE_NUMBA = False`) has since been rewritten to
+precompute its own contraction plan once per bond/Lanczos-or-Krylov loop
+rather than re-deriving it on every matvec call (see `pyitensor/
+kernels.py`'s module docstring, "plain path" section), so it now performs
+comparably to these numba-opted-in numbers for ground-state DMRG (spot-
+checked directly: within ~10% of the §5.1 table below at n=8-20) without
+any opt-in at all. `USE_NUMBA` is not just unnecessary now but frequently
+counter-productive: re-measured directly, an independent-chain workload
+(each chain starting from its own random MPS, e.g. a parameter sweep)
+never reaches a stable steady state with numba on, because each chain's
+own random start produces a different bond-growth trajectory and hence
+different contraction shapes to compile every time -- see `kernels.py`'s
+own docstring for the full, current measurements and guidance (numba is
+now only ever worth opting into for a single long-running TDVP/METTS-like
+session, and even there the win is modest, ~10%, not a large one).
+Absolute times below will vary by machine and load, but the qualitative
 trends should hold.
 
 ### 5.1 Ground state energy (Heisenberg spin-1/2 chain)
@@ -1313,34 +1321,42 @@ on the pure-Python backend to take on the order of minutes or more.
 | Calculation | v3 | python | ratio |
 |---|---|---|---|
 | Excited-state gap (TFIM, n=8) | 0.41s | 2.35s | 5.7x |
-| TDVP quench evolution (n=6, 30 steps) | 0.11s | 0.97s | 8.9x |
 | Hubbard ground state (3 sites) | 0.04s | 0.11s | 3.1x |
 
-These single-run numbers include a one-time numba JIT compilation cost
-(~0.1–0.4s) for each distinct kernel the first time it runs in a process
-— a script that repeats the same calculation type many times (e.g. a
-parameter sweep) amortizes this and approaches the steady-state ratios
-shown in §5.1/§5.2, not these first-call numbers.
+TDVP-based workloads (real-time evolution, and METTS finite-temperature
+sampling in particular) are a materially different, larger gap than the
+ground-state/KPM numbers above, because they call the same effective-
+Hamiltonian matvec thousands of times more per run (many time steps x
+many Lanczos/Krylov iterations x many METTS samples, vs. a handful of
+DMRG sweeps) -- see `examples/finite_temperature/
+backend_timing_metts_dynamical_correlator/main.py`, which measures this
+directly (dynamical METTS, n=10: v3 ~9s vs. python ~51-59s for
+nsamples=10-40, a 5-6x gap after the matvec-planning and Lanczos-
+bookkeeping fixes referenced above -- it was ~13x before them).
 
 ### 5.4 Practical guidance
 
 - Use `itensor_version="python"` for quick prototyping, CI/environments
   without a C++ toolchain, or small systems (n ≲ 20) where the 1.3–2x
   overhead doesn't matter.
-- `numba` is already installed (it's a core dependency, see §2); also
-  install `jax` and set `pyitensor.kernels.USE_NUMBA = True` (off by
-  default, see §5's note above) if you want the accelerated matvec
-  kernel — without that opt-in, `pyitensor` falls back to plain NumPy
-  loops and is substantially slower than the numbers above (see
-  `pyitensor/__init__.py`'s own docstring).
-- For production-size chains, dynamical correlators, or anything
-  performance-sensitive, compile the C++ extension (`python install.py`)
-  and use `itensor_version=2` or `3`.
+- `USE_NUMBA`/`USE_JAX` (both off by default, see §5's note above) are
+  no longer needed to get the numbers above -- the default path already
+  precomputes its own contraction plan. Opting into `USE_NUMBA` is only
+  ever worth it for a single long-running TDVP/METTS-like session (same
+  matvec shapes recurring many times within one run), and even there the
+  win is modest (~10%); it's actively counter-productive for independent-
+  chain workloads like parameter sweeps (see `kernels.py`'s own
+  docstring for the measurements behind both claims).
+- For production-size chains, dynamical correlators, TDVP/METTS
+  workloads, or anything performance-sensitive, compile the C++
+  extension (`python install.py`) and use `itensor_version=2` or `3`.
 - `examples/groundstate/backend_timing_gs_energy/main.py` reproduces the n=8..20
   rows of the §5.1 table directly against the current codebase and
   current machine (n=24..32 aren't included, to keep the example fast to
-  run) — re-run it rather than trusting these numbers verbatim on a
-  different setup.
+  run); `examples/finite_temperature/
+  backend_timing_metts_dynamical_correlator/main.py` does the same for
+  the TDVP/METTS gap discussed in §5.3 — re-run both rather than trusting
+  these numbers verbatim on a different setup.
 
 ## 6. Directory reference
 

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -1512,18 +1512,26 @@ submodes share it).
 \label{sec:perf}
 
 The pure-Python backend (\texttt{itensor\_version="python"}) trades raw
-speed for zero build dependencies. Numbers below were measured directly
-on one machine, with \texttt{numba} installed \emph{and} explicitly
-opted in (\texttt{pyitensor.kernels.USE\_NUMBA = True}) for its
-accelerated matvec/effective-Hamiltonian kernel (see
-\texttt{pyitensor/kernels.py}). This kernel is \textbf{not} used
-automatically just by having \texttt{numba} installed --- \texttt{USE\_NUMBA}
-defaults to \texttt{False}, because the one-time JIT compile cost is a
-net regression for this library's typical one-shot-script usage pattern
-(see \texttt{kernels.py}'s own docstring for measured numbers). Set
-\texttt{kernels.USE\_NUMBA = True} yourself before running DMRG if you
-want this path. Absolute times will vary by machine and load, but the
-qualitative trends should hold.
+speed for zero build dependencies. The tables below were originally
+measured with \texttt{numba} explicitly opted in
+(\texttt{pyitensor.kernels.USE\_NUMBA = True}); the \emph{default} path
+(\texttt{USE\_NUMBA = False}) has since been rewritten to precompute its
+own contraction plan once per bond/Lanczos-or-Krylov loop rather than
+re-deriving it on every matvec call (see \texttt{pyitensor/kernels.py}'s
+module docstring, ``plain path'' section), so it now performs comparably
+to these numba-opted-in numbers for ground-state DMRG (spot-checked
+directly: within $\sim$10\% of the table below at $n=8$--$20$) without
+any opt-in at all. \texttt{USE\_NUMBA} is not just unnecessary now but
+frequently counter-productive: re-measured directly, an independent-chain
+workload (each chain starting from its own random MPS, e.g.\ a parameter
+sweep) never reaches a stable steady state with numba on, because each
+chain's own random start produces a different bond-growth trajectory and
+hence different contraction shapes to compile every time --- see
+\texttt{kernels.py}'s own docstring for the full, current measurements
+and guidance (numba is now only ever worth opting into for a single
+long-running TDVP/METTS-like session, and even there the win is modest,
+$\sim$10\%, not a large one). Absolute times below will vary by machine
+and load, but the qualitative trends should hold.
 
 \subsection{Ground state energy (Heisenberg spin-1/2 chain)}
 
@@ -1584,17 +1592,22 @@ backend to take on the order of minutes or more.
 Calculation & v3 & python & ratio \\
 \midrule
 Excited-state gap (TFIM, $n=8$) & 0.41s & 2.35s & 5.7$\times$ \\
-TDVP quench evolution ($n=6$, 30 steps) & 0.11s & 0.97s & 8.9$\times$ \\
 Hubbard ground state (3 sites) & 0.04s & 0.11s & 3.1$\times$ \\
 \bottomrule
 \end{tabular}
 \end{center}
 
-These single-run numbers include a one-time numba JIT compilation cost
-($\sim$0.1--0.4s) for each distinct kernel the first time it runs in a
-process --- a script that repeats the same calculation type many times
-(e.g.\ a parameter sweep) amortizes this and approaches the steady-state
-ratios shown above, not these first-call numbers.
+TDVP-based workloads (real-time evolution, and METTS finite-temperature
+sampling in particular) are a materially different, larger gap than the
+ground-state/KPM numbers above, because they call the same effective-
+Hamiltonian matvec thousands of times more per run (many time steps
+$\times$ many Lanczos/Krylov iterations $\times$ many METTS samples, vs.\
+a handful of DMRG sweeps) --- see
+\texttt{examples/finite\_temperature/backend\_timing\_metts\_dynamical\_correlator/main.py},
+which measures this directly (dynamical METTS, $n=10$: v3 $\sim$9s vs.\
+python $\sim$51--59s for \texttt{nsamples}=10--40, a 5--6$\times$ gap
+after the matvec-planning and Lanczos-bookkeeping fixes referenced above
+--- it was $\sim$13$\times$ before them).
 
 \subsection{Practical guidance}
 
@@ -1602,22 +1615,25 @@ ratios shown above, not these first-call numbers.
   \item Use \texttt{itensor\_version="python"} for quick prototyping,
     CI/environments without a C++ toolchain, or small systems ($n
     \lesssim 20$) where the 1.3--2$\times$ overhead doesn't matter.
-  \item \texttt{numba} is already installed (it's a core dependency, see
-    Section~\ref{sec:install}); also install \texttt{jax} and set
-    \texttt{pyitensor.kernels.USE\_NUMBA = True} (off by default, see the
-    note above) if you want the accelerated matvec kernel --- without
-    that opt-in, \texttt{pyitensor} falls back to plain NumPy loops and
-    is substantially slower than the numbers above (see
-    \texttt{pyitensor/\_\_init\_\_.py}'s own docstring).
-  \item For production-size chains, dynamical correlators, or anything
-    performance-sensitive, compile the C++ extension
-    (\texttt{python install.py}) and use \texttt{itensor\_version=2} or
-    \texttt{3}.
+  \item \texttt{USE\_NUMBA}/\texttt{USE\_JAX} (both off by default, see
+    the note above) are no longer needed to get the numbers above ---
+    the default path already precomputes its own contraction plan.
+    Opting into \texttt{USE\_NUMBA} is only ever worth it for a single
+    long-running TDVP/METTS-like session (same matvec shapes recurring
+    many times within one run), and even there the win is modest
+    ($\sim$10\%); it's actively counter-productive for independent-chain
+    workloads like parameter sweeps (see \texttt{kernels.py}'s own
+    docstring for the measurements behind both claims).
+  \item For production-size chains, dynamical correlators, TDVP/METTS
+    workloads, or anything performance-sensitive, compile the C++
+    extension (\texttt{python install.py}) and use
+    \texttt{itensor\_version=2} or \texttt{3}.
   \item \texttt{examples/groundstate/backend\_timing\_gs\_energy/main.py} reproduces
     the $n=8..20$ rows of the ground-state table directly against the
     current codebase and current machine ($n=24..32$ aren't included, to
-    keep the example fast to run) --- re-run it rather than trusting
-    these numbers verbatim on a different setup.
+    keep the example fast to run); \texttt{examples/finite\_temperature/backend\_timing\_metts\_dynamical\_correlator/main.py}
+    does the same for the TDVP/METTS gap discussed above --- re-run both
+    rather than trusting these numbers verbatim on a different setup.
 \end{itemize}
 
 \section{Directory reference}

--- a/examples/finite_temperature/backend_timing_metts_dynamical_correlator/main.py
+++ b/examples/finite_temperature/backend_timing_metts_dynamical_correlator/main.py
@@ -1,0 +1,76 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+# Compare wall-clock time for the dynamical METTS finite-temperature
+# correlator (Many_Body_Chain.metts_dynamical_correlator, see
+# vevtk/mettsdynamicalcorrelator.py and pyitensor/metts.py) between ITensor
+# v3 (mpscpp3) and the pure-Python backend (itensor_version="python").
+# Unlike examples/groundstate/backend_timing_gs_energy (a handful of DMRG
+# sweeps), this workload calls the same TDVP effective-Hamiltonian matvec
+# thousands of times more per run (many real-time steps x many Lanczos/
+# Krylov iterations x many METTS samples) -- the regime where pyitensor
+# used to be dramatically slower than v3, not just modestly slower, because
+# make_matvec()'s old default fallback re-derived its whole contraction
+# plan from scratch on every single matvec call (cheap enough per call to
+# be invisible for a DMRG sweep, but the dominant cost here). See
+# pyitensor/kernels.py's module docstring ("plain path" section) for the
+# fix and the profiling that found it.
+#
+# Confirmed directly on one machine (numbers will vary by machine/load --
+# this script is meant to be re-run, not read as a fixed benchmark table):
+# n=10, nsamples=40, nt=10 went from 152.0s (before the kernels.py/tdvp.py
+# fixes in this same change) to ~51s afterward -- v3 itself takes ~9s, so
+# the remaining gap (~5.7x) is the dense-tensor-vs-QN-block-sparse gap
+# real ITensor v3 still has here (unlike ground-state DMRG, TDVP evolves a
+# 2-site tensor through many real-time steps, so mpscpp3's ConserveQNs off
+# + random-MPS-start tradeoff -- see documentation.md -- costs it less
+# than it does for reaching a converged ground state from scratch).
+import time
+from dmrgpy import spinchain, cppext
+
+
+def metts_dynamical_correlator_timed(itensor_version, n, nsamples, nt):
+    spins = ["S=1/2" for i in range(n)]
+    sc = spinchain.Spin_Chain(spins, itensor_version=itensor_version)
+    h = 0
+    for i in range(n - 1):
+        h = h + sc.Sx[i]*sc.Sx[i+1] + sc.Sy[i]*sc.Sy[i+1] + sc.Sz[i]*sc.Sz[i+1]
+    sc.set_hamiltonian(h)
+    name = (sc.Sz[0], sc.Sz[0])
+    t0 = time.perf_counter()
+    sc.metts_dynamical_correlator(name, T=1.0, nt=nt, dt=0.1, nsamples=nsamples,
+                                   nwarmup=10, dbeta_half_step=0.08, seed=42)
+    return time.perf_counter() - t0
+
+
+# Warm up the python backend once, outside the timed loop, so one-time
+# import/first-call costs don't distort the smallest run.
+metts_dynamical_correlator_timed("python", 4, nsamples=1, nt=2)
+
+n, nt = 10, 10
+sizes_nsamples = [10, 40]
+
+have_v3 = cppext.available(3)
+header = f"{'nsamples':>10}"
+if have_v3:
+    header += f"{'v3 (s)':>10}"
+header += f"{'python (s)':>12}"
+if have_v3:
+    header += f"{'python/v3':>12}"
+print(header)
+
+for nsamples in sizes_nsamples:
+    tpy = metts_dynamical_correlator_timed("python", n, nsamples, nt)
+    row = f"{nsamples:10d}"
+    if have_v3:
+        t3 = metts_dynamical_correlator_timed(3, n, nsamples, nt)
+        row += f"{t3:10.2f}"
+    row += f"{tpy:12.2f}"
+    if have_v3:
+        row += f"{tpy/t3:12.2f}"
+    print(row)
+
+if not have_v3:
+    print("\n(ITensor v3 not compiled in this environment -- only the "
+          "python backend's own timing is shown; run `python install.py "
+          "--itensor-version=3` to compile it and see the v3 comparison.)")

--- a/examples/groundstate/backend_timing_gs_energy/main.py
+++ b/examples/groundstate/backend_timing_gs_energy/main.py
@@ -16,12 +16,17 @@ import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
 #
 # Confirmed directly on one machine (numbers will vary by machine/load --
 # this script is meant to be re-run, not read as a fixed benchmark table):
-# with numba installed (pyitensor's default accelerated kernel path, see
-# pyitensor/kernels.py), the python backend was only ~1.5-2.5x slower than
-# v3 for n=8-20, but the gap widened with n (~4-5x by n=28-32) -- v3
-# benefits from real ITensor's QN block-sparsity, which pyitensor's dense
-# NumPy tensors don't have even with numba JIT acceleration. Without numba,
-# expect a much larger gap (see pyitensor/__init__.py's own docstring).
+# at the default (small) bond dimension this script uses, the python
+# backend is ~1.5-2x slower than v3 for n=8-20 -- numba is NOT on by
+# default (pyitensor/kernels.py's USE_NUMBA defaults to False; see that
+# module's docstring for why, and examples/finite_temperature/
+# backend_timing_metts_dynamical_correlator for a workload where the gap
+# is much larger and numba's tradeoffs actually matter). At *larger* bond
+# dimension ground-state DMRG tells a different story entirely: pyitensor
+# is at parity with, or faster than, v3 (e.g. n=24/maxdim=300: v3 ~107s vs
+# python ~25-31s) because mpscpp3 in this repo runs with ConserveQNs=false
+# and a random-MPS start (see CLAUDE.md/documentation.md), sacrificing the
+# QN block-sparsity that would otherwise help it at scale.
 import time
 from dmrgpy import spinchain
 

--- a/src/dmrgpy/pyitensor/kernels.py
+++ b/src/dmrgpy/pyitensor/kernels.py
@@ -19,6 +19,10 @@ itself reports a non-CPU device (see _detect_default_use_jax() below) --
 UNTESTED on real GPU/TPU hardware (none was available while writing this),
 so treat that heuristic as a reasonable guess, not a verified claim; on a
 CPU-only install this now behaves exactly as if the module didn't exist.
+Re-confirmed after the plain-path fix below (see its own section): on a
+dynamical-METTS run JAX was still ~4x slower than the new plain default
+(210s vs. 52s at n=10, nsamples=40, nt=10) -- the conclusion above holds
+against the faster baseline too, not just the old one.
 
 If JAX *is* enabled, the mechanism is: express the whole contraction as
 one fused jax.numpy.einsum call (XLA fuses the operands itself, unlike
@@ -38,12 +42,32 @@ deterministically (first-occurrence order, operands always listed the
 same way) so structurally identical bonds produce byte-identical
 subscript strings and hit the same cache entry.
 
-Without JAX or numba (see below), dmrg.py's two_site_heff()/one_site_heff()
-get the exact pairwise ITensor.__mul__ chain (`t = t*L; t = t*H_i; ...`)
-that existed before this module did -- never routed through numpy.einsum,
-per the BLAS-dispatch gap above.
+== plain path (always on, the default when JAX/numba are unavailable or
+disabled) ==
 
-== numba path (default ON when importable) ==
+Without JAX or numba, dmrg.py's two_site_heff()/one_site_heff()/
+zero_site_heff() get _make_matvec_planned() (below): the same precomputed
+transpose+reshape+matmul plan the numba path uses (_plan_contraction_chain,
+shared by both), just executed directly in NumPy instead of through a
+compiled closure. This package originally used a bare pairwise
+ITensor.__mul__ chain here (`t = t*L; t = t*H_i; ...`), which re-derives
+that same plan (mul_plan()'s Index-matching, from tensor.py) from scratch
+on *every* matvec call -- cheap enough per call to be invisible for DMRG's
+ground-state sweep (a handful of calls per bond), but the dominant cost for
+TDVP/METTS, which call the same matvec build thousands of times more per
+run (many time steps x many Lanczos/Krylov iterations x many METTS
+samples): confirmed via cProfile on a dynamical-METTS run, 57% of
+cumulative time was in ITensor.__mul__ and its mul_plan()/Index-matching
+machinery before this fix. Precomputing the plan once per bond/loop instead
+of once per call closes most of that gap with no new dependency and no
+compile tax: confirmed directly, 1.4x-2x end-to-end wall-time win on real
+dynamical METTS runs (9.15s->6.68s at n=8; 152.0s->74.6s at n=10,
+nsamples=40, nt=10), bit-identical results (this reorders *when* the plan
+is computed, not *which* pairs get contracted first, so unlike tensor.py's
+contract_many() fix elsewhere in this package it does not perturb
+floating-point summation order).
+
+== numba path (opt-in; see below for why it isn't the default) ==
 
 Unlike JAX, a numba-compiled kernel operates directly on the same numpy
 arrays already in memory -- no host<->device array conversion, no
@@ -71,61 +95,59 @@ instead of a closure constant was consistently *slower* than tensordot,
 not faster, apparently because numba's optimizer can't treat a
 runtime-typed tuple argument's transpose as constant-foldable the way it
 does for a captured closure value known to be fixed at compile time. So
-_get_numba_contractor() below compiles and caches one specialized
+_get_numba_contractor() below compiles and caches (in-process only, see
+its own docstring for why not also on-disk via cache=True -- a real,
+confirmed crash risk, not just a theoretical one) one specialized
 function per distinct (permutation, reshape) pattern -- mirroring
 compile_contraction()/_einsum_jax's per-pattern JIT-cache-reuse strategy
 for the JAX path, for the same underlying reason (a bond's contraction
 *shape* recurs every sweep once maxdim saturates, so the compile cost is
-paid once and amortized over the whole run). Confirmed safe across
-process restarts that a numba cache=True disk cache correctly
-distinguishes different closures sharing the same source text by their
-different captured constants, rather than colliding on the first compiled
-variant seen (a real risk this pattern could otherwise hit silently).
+paid once and amortized over the whole run, within one process).
 
-USE_NUMBA nonetheless defaults to False. The per-contraction win above is
-real but so is numba's own compile-time cost, and it is NOT amortized
-away by cache=True the way the docstring above might suggest -- confirmed
-directly: a first-ever @njit call in a fresh process pays a large
-one-time LLVM/typing-system warm-up cost (~3s measured in isolation for
-one specific closure) *on top of* per-signature compilation; cache=True
-eliminates the *recompilation* of a previously-seen signature on a later
-process (~3s -> ~0.2s measured), but not that first process-wide warm-up
-tax, and DMRG naturally exercises several *distinct* contraction shapes
-within a single run (edge bonds have smaller bond dimension than
-saturated bulk bonds) each needing their own cache entry. Measured
-end-to-end on this package's own regression suite -- exactly the
-one-shot-script usage pattern CLAUDE.md describes as this library's real
-verification workflow (`cd examples/... && python <script>.py`), not a
-long-lived multi-calculation session -- selftest_dmrg.py (a handful of
-small DMRG runs) took 1.83s with USE_NUMBA defaulted on vs 1.15s with it
-off: a ~60% *regression*, not a win, because the fixed compile tax
-dominates a script this short. A sustained, multi-call session (repeated
-gs_energy() calls reusing the same shapes) does recover the steady-state
-win measured above -- confirmed directly, a 14-site/maxdim=60 Heisenberg
-chain's second and later gs_energy() calls in the same process ran at
-~0.78-0.80s, at or slightly below the compiled ITensor v3 backend's own
-~0.81s, after the first call's ~0.997s paid the compile tax -- so this is
-a genuine case where "on by default" is the wrong call despite the
-underlying kernel being a real, verified improvement, exactly the same
-shape of finding as the JAX CPU regression above. Opt in explicitly
-(`kernels.USE_NUMBA = True`, set once at the start of a script) for
-workloads that call gs_energy()/tevol_method()/etc. repeatedly in one
-process at small-to-moderate bond dimension -- parameter sweeps, or
-anything long-running enough to amortize the fixed compile cost.
+USE_NUMBA nonetheless defaults to False, and is worth even less now than
+when this section was first written, because the baseline it has to beat
+(the plain path above) is no longer the naive per-call ITensor.__mul__
+chain -- it's the same precomputed-plan technique numba itself uses,
+just without JIT. Re-measured directly against *that* baseline (not the
+old naive one):
 
-"Small-to-moderate bond dimension" matters: the ~1.7x-2x per-contraction
-win itself is specific to tensors small enough that numpy's own
-Python-level dispatch overhead is a meaningful fraction of the call cost.
-Measured directly at a genuinely large scale (n=24, maxdim=300 -- closer
-to where this library's real workloads live than the maxdim=60 benchmark
-above) numba showed *no* win even with compile cost fully excluded from
-the comparison: 105.7s without numba vs 108.1s with, a wash/slight loss,
-not an improvement -- at that size the actual BLAS matmul FLOPs dominate
-the per-call cost, leaving little Python-overhead fraction left for a
-compiled kernel to shave off. So opting in is only worth it for small-
-bond-dimension, sustained (many-call) sessions specifically -- it
-recovers rough parity with (not a clear win over) the compiled ITensor v3
-backend there, not a general-purpose speedup at any scale.
+- Ground-state DMRG, independent chains (e.g. a parameter sweep: a fresh
+  Spin_Chain per point, each starting from its own random MPS -- see
+  mpscpp3's own randomMPS()-based default_mps(), which pyitensor's DMRG
+  mirrors): the "steady state" this section used to describe *does not
+  reliably occur*. Confirmed directly at n=14/maxdim=60: the in-process
+  numba contractor cache kept growing across 4 independent gs_energy()
+  calls (106 -> 144 -> 194 -> 210 entries, never leveling off) because
+  each fresh random starting MPS produces its own bond-dimension growth
+  trajectory through the sweeps before saturating at maxdim, so the exact
+  edge-bond shapes hit differ call to call -- there is no fixed set of
+  shapes to amortize a compile over. All 4 calls took 6.5s-42.6s each,
+  vs. the plain path's steady ~0.7-0.8s; at n=24/maxdim=300 a single
+  fresh-chain call took 133.5s with numba vs. 25.2s plain (5.3x slower,
+  not the previously-reported "wash" -- that comparison was against the
+  slower naive baseline).
+- TDVP/METTS (a single long run that reuses the same matvec shapes many
+  times once bond dimension saturates -- the one scenario where numba's
+  in-process cache *does* stabilize): confirmed directly on a dynamical
+  METTS run (n=10, nsamples=40, nt=10), numba's own compile tax is now a
+  much larger fraction of a much smaller total: 328.8s cold vs. 51.8s
+  plain (6.3x worse) on the very first process, and even fully warmed up
+  (repeated in the same process after compilation) numba was still only
+  ~11% faster than plain (46.1s vs 51.8s) -- a real but marginal edge,
+  down from the 2x this section used to claim, because the plain path no
+  longer leaves that much of numba's old advantage on the table.
+
+So: still off by default, and now only worth opting into
+(`kernels.USE_NUMBA = True`, set once at the start of a script) for a
+narrower case than before -- a single long-running TDVP/METTS-like
+session at small-to-moderate bond dimension where the same shapes recur
+many times *within one run*, and even there the win is modest (~10%),
+not the roughly-2x this section previously reported (that number was
+real for numba-vs-naive-ITensor.__mul__, just no longer the comparison
+that matters after the plain-path fix above). Independent-chain workloads
+(parameter sweeps, or anything that builds a fresh random-start MPS each
+time) should not enable it at all -- the per-call compile tax is paid
+over and over with no steady state to amortize into.
 
 Never a hard dependency either way: everything in this package works with
 only NumPy/SciPy installed.
@@ -235,15 +257,35 @@ def _get_numba_contractor(perm_a, shape_a2, perm_b, shape_b2):
     (B transposed+reshaped to shape_b2)`, specialized (permutation/shape
     baked in as closure constants, not arguments -- see this module's
     docstring for why that distinction is what makes this faster than
-    tensordot rather than slower) and cached per distinct pattern so a
-    matvec chain that calls the same pairwise contraction shape on every
-    Lanczos iteration only pays the compile cost once."""
+    tensordot rather than slower) and cached (in-process, via
+    _numba_contractor_cache) per distinct pattern so a matvec chain that
+    calls the same pairwise contraction shape on every Lanczos/Krylov
+    iteration only pays the compile cost once per process.
+
+    Deliberately NOT `cache=True` (numba's own on-disk cache) -- confirmed
+    directly this is unsafe for this specific pattern: `_contract` is a
+    distinct closure (same source text, different perm/shape constants
+    baked in) every time this function compiles a new one, and numba's
+    per-source-location on-disk overload index has no eviction, so it
+    accumulates one entry per distinct closure *forever* across every
+    process that ever ran this code (908 stale `.nbc` files were found
+    for this one closure in a worktree used across several days of
+    sessions). Past some accumulation, loading the disk cache started
+    returning a corrupt overload and crashing with `RuntimeError: In
+    'NRT_adapt_ndarray_to_python', 'descr' is NULL` deep inside a real
+    dynamical-METTS TDVP run -- reproduced reliably in the affected
+    worktree, and confirmed fixed both by deleting the accumulated cache
+    files and by dropping `cache=True` entirely. The in-process dict cache
+    above is what actually matters for this module's own "sustained
+    multi-call session" use case (see the module docstring) -- cache=True
+    only ever aimed to avoid recompilation on a *later, separate* process,
+    a narrower benefit not worth this failure mode."""
     key = (perm_a, shape_a2, perm_b, shape_b2)
     f = _numba_contractor_cache.get(key)
     if f is not None:
         return f
 
-    @numba.njit(cache=True, fastmath=True)
+    @numba.njit(fastmath=True)
     def _contract(A, B):
         At = np.transpose(A, perm_a).copy().reshape(shape_a2)
         Bt = np.transpose(B, perm_b).copy().reshape(shape_b2)
@@ -253,13 +295,20 @@ def _get_numba_contractor(perm_a, shape_a2, perm_b, shape_b2):
     return _contract
 
 
-def _plan_numba_chain(pieces, order_in, order_out):
+def _plan_contraction_chain(pieces, order_in, order_out):
     """Precompute the fixed sequence of pairwise transpose+reshape+matmul
     steps for v(order_in) * pieces[0] * pieces[1] * ... , using mul_plan()
     (tensor.py) on index *structure* alone -- called once per matvec build
-    (once per bond), not once per Lanczos iteration. Returns (steps,
-    final_perm, out_shape) where steps is a list of (contractor,
-    out_shape_2factors, piece_array) and final_perm/out_shape reorder the
+    (once per bond/Lanczos-or-Krylov loop), not once per iteration, since
+    pieces/order_in/order_out are fixed for the lifetime of one such loop
+    and only the numeric contents of the vector being multiplied change
+    from call to call. Shared by both the numba path (_make_matvec_numba)
+    and the plain-NumPy path (_make_matvec_planned) below -- the only
+    difference between them is whether the per-step transpose+reshape+
+    matmul is executed via a numba-compiled closure or directly in NumPy.
+
+    Returns (steps, final_perm) where steps is a list of (perm_a, shape_a2,
+    perm_b, shape_b2, out_shape, piece_array) and final_perm reorders the
     chain's natural trailing free-index order into order_out."""
     from .tensor import mul_plan
 
@@ -275,10 +324,10 @@ def _plan_numba_chain(pieces, order_in, order_out):
         b_free_size = int(np.prod(b_free_dims)) if b_free_dims else 1
         perm_a = tuple(a_free + a_axes)
         perm_b = tuple(b_axes + b_free)
-        contractor = _get_numba_contractor(
-            perm_a, (a_free_size, a_axes_size), perm_b, (a_axes_size, b_free_size))
         out_shape = a_free_dims + b_free_dims
-        steps.append((contractor, out_shape, p.array))
+        steps.append((perm_a, (a_free_size, a_axes_size),
+                      perm_b, (a_axes_size, b_free_size),
+                      out_shape, p.array))
         cur_inds = tuple(cur_inds[i] for i in a_free) + tuple(p.inds[j] for j in b_free)
 
     final_perm = tuple(cur_inds.index(ind) for ind in order_out)
@@ -286,13 +335,54 @@ def _plan_numba_chain(pieces, order_in, order_out):
 
 
 def _make_matvec_numba(pieces, order_in, shape_in, order_out):
-    steps, final_perm = _plan_numba_chain(pieces, order_in, order_out)
+    steps, final_perm = _plan_contraction_chain(pieces, order_in, order_out)
+    out_shape = tuple(ind.dim for ind in order_out)
+    contractors = [
+        (_get_numba_contractor(perm_a, shape_a2, perm_b, shape_b2), step_shape, piece_arr)
+        for perm_a, shape_a2, perm_b, shape_b2, step_shape, piece_arr in steps]
+
+    def matvec(v_flat):
+        cur = v_flat.reshape(shape_in)
+        for contractor, step_shape, piece_arr in contractors:
+            cur = contractor(cur, piece_arr).reshape(step_shape)
+        return np.transpose(cur, final_perm).reshape(out_shape).reshape(-1)
+
+    return matvec
+
+
+def _make_matvec_planned(pieces, order_in, shape_in, order_out):
+    """Same precomputed transpose+reshape+matmul plan as _make_matvec_numba
+    (_plan_contraction_chain), executed directly in NumPy instead of through
+    a numba-compiled closure -- no JIT compile tax, no host<->device
+    transfer, always available. This is make_matvec()'s default fallback
+    (see its docstring): it replaces what used to be a bare ITensor.__mul__
+    chain that re-derived this same structural plan (mul_plan()'s Index
+    matching, from tensor.py) from scratch on *every* call. That cost is
+    negligible for DMRG's ground-state sweep (a handful of matvec calls per
+    bond) but dominates for TDVP/METTS, which call the same matvec build
+    thousands of times more per run (many time steps x many Lanczos/Krylov
+    iterations x many METTS samples) -- confirmed directly via cProfile on a
+    dynamical-METTS run: 57% of cumulative time was in ITensor.__mul__ and
+    its mul_plan()/Index-matching machinery before this change.
+
+    Confirmed directly: 1.4x-2x end-to-end wall-time win on real dynamical
+    METTS runs (9.15s->6.68s at n=8; 152.0s->74.6s at n=10, nsamples=40,
+    nt=10), bit-identical results against the ED cross-check in
+    examples/finite_temperature/dynamical_metts_VS_ED. Unlike tensor.py's
+    contract_many() fix elsewhere in this package, this does not change
+    floating-point summation order (same tensordot-equivalent transpose/
+    reshape/matmul per step, in the same left-to-right order as before) --
+    it only removes redundant replanning, so it carries none of that
+    change's excited-state-convergence-margin risk."""
+    steps, final_perm = _plan_contraction_chain(pieces, order_in, order_out)
     out_shape = tuple(ind.dim for ind in order_out)
 
     def matvec(v_flat):
         cur = v_flat.reshape(shape_in)
-        for contractor, step_shape, piece_arr in steps:
-            cur = contractor(cur, piece_arr).reshape(step_shape)
+        for perm_a, shape_a2, perm_b, shape_b2, step_shape, piece_arr in steps:
+            At = np.transpose(cur, perm_a).reshape(shape_a2)
+            Bt = np.transpose(piece_arr, perm_b).reshape(shape_b2)
+            cur = (At @ Bt).reshape(step_shape)
         return np.transpose(cur, final_perm).reshape(out_shape).reshape(-1)
 
     return matvec
@@ -311,9 +401,10 @@ def make_matvec(pieces, order_in, shape_in, order_out):
     chain (_make_matvec_numba) if numba is available (checked first --
     see this module's docstring, numba wins on CPU where JAX regresses
     since it has no array-transfer overhead), else a single fused, JIT-
-    compiled jax.numpy.einsum call if JAX is available and enabled,
-    else the same pairwise ITensor.__mul__ chain this package always
-    used."""
+    compiled jax.numpy.einsum call if JAX is available and enabled, else
+    the plain-NumPy precomputed-plan chain (_make_matvec_planned) -- always
+    available, no opt-in required, see its own docstring for why this is
+    make_matvec()'s default rather than a bare ITensor.__mul__ chain."""
     if available_numba():
         return _make_matvec_numba(pieces, order_in, shape_in, order_out)
 
@@ -329,12 +420,4 @@ def make_matvec(pieces, order_in, shape_in, order_out):
 
         return matvec
 
-    from .tensor import ITensor
-
-    def matvec(v_flat):
-        t = ITensor(tuple(order_in), v_flat.reshape(shape_in))
-        for p in pieces:
-            t = t * p
-        return t.transpose_to(order_out).reshape(-1)
-
-    return matvec
+    return _make_matvec_planned(pieces, order_in, shape_in, order_out)

--- a/src/dmrgpy/pyitensor/tdvp.py
+++ b/src/dmrgpy/pyitensor/tdvp.py
@@ -61,7 +61,7 @@ TDVP/tdvp.h+TDVP/basisextension.h's own NumCenter=1 + addBasis() pairing.
 """
 
 import numpy as np
-from scipy.linalg import expm as _dense_expm
+from scipy.linalg import eigh_tridiagonal
 
 from .dmrg import (_all_left_environments, _all_right_environments,
                     _extend_left, _extend_right, one_site_heff, two_site_heff,
@@ -76,48 +76,58 @@ def _lanczos_expm_multiply(matvec, v0, coeff, niter=30, tol=1e-12):
     matvec function) via a Krylov (Lanczos) subspace of dimension up to
     `niter`: build an orthonormal basis {v0, A v0, A^2 v0, ...} via the
     Lanczos recursion (with full reorthogonalization -- the subspace is
-    small enough, niter ~ tens, that this costs nothing and buys real
-    numerical stability), project A onto it as a small tridiagonal matrix
-    T, exponentiate T exactly (cheap, dense), and map back. Standard
+    small enough, niter ~ tens, that this costs nothing relative to the
+    matvec itself and buys real numerical stability), project A onto it as
+    a small tridiagonal matrix, exponentiate it, and map back. Standard
     Krylov-propagator technique for real-time quantum dynamics; this is
     what tdvp_step()'s "niter=50 bounds the Lanczos iterations" comment in
-    mpscpp3/chain_session.h refers to on the compiled-backend side."""
+    mpscpp3/chain_session.h refers to on the compiled-backend side.
+
+    Reorthogonalization is done as two BLAS matrix-vector products against
+    the (preallocated, incrementally filled) basis built so far, not a
+    per-vector Python loop -- confirmed via cProfile that this function's
+    *own* bookkeeping (independent of matvec cost) became the dominant
+    remaining cost of a dynamical-METTS run after kernels.py's matvec-
+    planning fix (see that module's docstring), and the O(niter) Python-
+    level np.vdot calls per Lanczos step (O(niter^2) total per call here)
+    were the biggest piece of it. The projected Krylov matrix is real
+    tridiagonal by construction (alpha=vdot(...).real, beta=norm(...) are
+    both always real), so it's exponentiated via eigh_tridiagonal's direct
+    eigendecomposition rather than a generic dense expm() Pade computation
+    -- cheaper, and only the first column of the exponentiated matrix is
+    ever used, so the full matrix is never assembled."""
     beta0 = np.linalg.norm(v0)
     if beta0 == 0:
         return v0.copy()
-    q = v0 / beta0
-    qs = [q]
+
+    m = min(niter, v0.size)
+    Q = np.empty((v0.size, m), dtype=complex)
+    Q[:, 0] = v0 / beta0
     alphas = []
     betas = []
-    w = matvec(q)
-    alpha = np.vdot(q, w).real
+
+    w = matvec(Q[:, 0])
+    alpha = np.vdot(Q[:, 0], w).real
     alphas.append(alpha)
-    w = w - alpha * q
-    m = min(niter, v0.size)
-    for _ in range(1, m):
+    w = w - alpha * Q[:, 0]
+    k = 1
+    while k < m:
         beta = np.linalg.norm(w)
         if beta < tol:
             break
         betas.append(beta)
-        q_new = w / beta
-        qs.append(q_new)
-        w = matvec(q_new)
-        alpha = np.vdot(q_new, w).real
+        Qprev = Q[:, :k]  # every vector built so far, *excluding* the new one
+        Q[:, k] = w / beta
+        w = matvec(Q[:, k])
+        alpha = np.vdot(Q[:, k], w).real
         alphas.append(alpha)
-        w = w - alpha * q_new - beta * qs[-2]
-        for qk in qs[:-1]:
-            w = w - np.vdot(qk, w) * qk
+        w = w - alpha * Q[:, k] - beta * Qprev[:, -1]
+        w = w - Qprev @ (Qprev.conj().T @ w)
+        k += 1
 
-    k = len(alphas)
-    T = np.zeros((k, k), dtype=complex)
-    for idx in range(k):
-        T[idx, idx] = alphas[idx]
-    for idx in range(k - 1):
-        T[idx, idx + 1] = betas[idx]
-        T[idx + 1, idx] = betas[idx]
-    Q = np.column_stack(qs[:k])
-    expT = _dense_expm(coeff * T)
-    return beta0 * (Q @ expT[:, 0])
+    evals, evecs = eigh_tridiagonal(np.array(alphas), np.array(betas))
+    exp_col0 = evecs @ (np.exp(coeff * evals) * evecs[0, :])
+    return beta0 * (Q[:, :k] @ exp_col0)
 
 
 def _evolve_two_site(L, Lbra, H, ket, i, R, Rbra, tau, niter):


### PR DESCRIPTION
## Summary

- Ground-state DMRG (`itensor_version="python"`) was already at parity with, or faster than, compiled ITensor v3 (a prior 2026-07-18 pass). TDVP-based workloads (real-time evolution, METTS finite-temperature sampling) were not: **dynamical METTS measured 13.3x slower than v3** (n=10, nsamples=40, nt=10: 152.0s vs 11.4s), because `kernels.make_matvec()`'s default fallback re-derived its whole contraction plan from scratch on *every* matvec call — invisible cost for DMRG's sweep-count call volume, dominant for TDVP/METTS's much higher one (cProfile: 57% of cumulative time in `ITensor.__mul__`/`mul_plan`).
- Extended the numba path's existing "precompute the contraction plan once per bond" technique to a new zero-dependency plain-NumPy default path, and optimized `tdvp.py`'s `_lanczos_expm_multiply` bookkeeping (vectorized reorthogonalization, `eigh_tridiagonal` instead of a generic dense `expm`). Combined: **152.0s → 51.4s**, cutting the v3 gap from **13.3x to 5.8x**.
- Found and fixed a real crash: `USE_NUMBA=True` through TDVP (never exercised before, only DMRG) hit `RuntimeError: In 'NRT_adapt_ndarray_to_python', 'descr' is NULL` — numba's `cache=True` on-disk cache for a dynamically-generated closure accumulates one entry per distinct closure forever (908 stale files found in one long-lived worktree); dropped `cache=True`.
- Re-measured numba/JAX against the new default and rewrote `kernels.py`'s docstring: numba no longer reaches a steady state for independent-chain ground-state workloads, and even where it does (a single long TDVP/METTS run) its edge shrank from ~2x to ~11%. JAX remains a clear CPU loss.
- Added `examples/finite_temperature/backend_timing_metts_dynamical_correlator` (mirrors the existing `backend_timing_gs_energy`) and corrected now-stale numba-related claims in `docs/documentation.{md,tex}` §5.

## Test plan

- [x] `pytest tests` — 157 passed, 9 skipped (pre-existing/unrelated)
- [x] `examples/finite_temperature/dynamical_metts_VS_ED` — TEST PASSED
- [x] `examples/finite_temperature/metts_VS_exact` — TEST PASSED
- [x] `examples/time_evolution/tdvp_VS_ED_time_evolution` — TEST PASSED
- [x] `examples/dynamical_correlator/dynamical_correlator_VS_ED` — TEST PASSED
- [x] `examples/spin_models/v2_VS_v3_heisenberg_spin_half`, `excited_states/v2_VS_v3_excited_states_gap`, `time_evolution/v2_VS_v3_time_evolution_quench`, `dynamical_correlator/v2_VS_v3_kpm_dynamical_correlator`, `backend_comparison/backend_switch_consistency` — all match to expected tolerances
- [x] `docs/documentation.tex` recompiles cleanly with `pdflatex` (pre-existing unrelated overfull-hbox warning only)
- [x] Numerically verified the new `_lanczos_expm_multiply` matches the old implementation to <1e-14 across several test cases including the k=1 edge case

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t