### PR TITLE
Add matrix-free IRAM (ARPACK-adapted) Arnoldi solver, benchmarked against arnolditk

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -351,8 +351,11 @@ Notable, deliberate implementation details (not bugs to "fix"):
   `dmrg.py`'s environment/matvec machinery; unlike `dmrg.py` it *does*
   implement the noise term, because for NH-DMRG it measurably matters).
   `groundstate.py`'s non-Hermitian `gs_energy` branch routes to it for
-  `itensor_version` 2, 3 and `"python"`; the MPS Arnoldi route
-  (`algebra/arnolditk.py`) remains as the fallback for other backends.
+  `itensor_version` 2, 3 and `"python"`; the MPS Arnoldi route (default
+  `algebra/arpacktk.py`, an Implicitly Restarted Arnoldi Method ported
+  from ARPACK; `algebra/arnolditk.py`'s explicit-restart Arnoldi remains
+  available for comparison, see `mpsalgebra.py`) remains as the fallback
+  for other backends.
   The adjoint MPO is built from `MultiOperator.get_dagger()`'s terms on
   the Python side, and since the non-Hermitian energy is not variational,
   `nhdmrg.py` certifies each run by the eigen-residual and redraws a
@@ -525,8 +528,10 @@ energies match the golden regression values in
 `tests/test_excited_states.py` to ~3e-15 on a 4-site chain, and
 `get_rdm` matches the existing backend-agnostic `reduced_dm_projective`
 to ~1e-15. `n==1` and non-Hermitian excited states already worked before
-this — they route through `gs_energy()`/the generic Arnoldi method
-(`mpsalgebra.mpsarnoldi`), neither of which is backend-specific.
+this — they route through `gs_energy()`/the generic MPS Arnoldi method
+(default `algebra/arpacktk.py`'s IRAM, via `mpsalgebra.mps_excited_states`;
+`algebra/arnolditk.py`'s `mpsarnoldi` remains available for comparison),
+neither of which is backend-specific.
 
 Bond entanglement entropy (`MPS.get_bond_entropy`, used e.g. by
 `entropy.py`'s `central_charge`) was missing entirely on the Julia

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -453,8 +453,11 @@ Notable, deliberate implementation details (not bugs to ``fix''):
     because for NH-DMRG it measurably matters). \texttt{groundstate.py}'s
     non-Hermitian \texttt{gs\_energy} branch routes to it for
     \texttt{itensor\_version} 2, 3 and \texttt{"python"}; the MPS Arnoldi
-    route (\texttt{algebra/arnolditk.py}) remains as the fallback for
-    other backends. The adjoint MPO is built from
+    route (default \texttt{algebra/arpacktk.py}, an Implicitly Restarted
+    Arnoldi Method ported from ARPACK; \texttt{algebra/arnolditk.py}'s
+    explicit-restart Arnoldi remains available for comparison, see
+    \texttt{mpsalgebra.py}) remains as the fallback for other backends.
+    The adjoint MPO is built from
     \texttt{MultiOperator.get\_dagger()}'s terms on the Python side, and
     since the non-Hermitian energy is not variational, \texttt{nhdmrg.py}
     certifies each run by the eigen-residual and redraws a fresh random
@@ -662,8 +665,10 @@ energies match the golden regression values in
 backend-agnostic \texttt{reduced\_dm\_projective} to
 $\sim 1 \times 10^{-15}$. $n=1$ and non-Hermitian excited states already
 worked before this --- they route through \texttt{gs\_energy()}/the
-generic Arnoldi method (\texttt{mpsalgebra.mpsarnoldi}), neither of
-which is backend-specific.
+generic MPS Arnoldi method (default \texttt{algebra/arpacktk.py}'s
+IRAM, via \texttt{mpsalgebra.mps\_excited\_states}; \texttt{algebra/
+arnolditk.py}'s \texttt{mpsarnoldi} remains available for comparison),
+neither of which is backend-specific.
 
 Bond entanglement entropy (\texttt{MPS.get\_bond\_entropy}, used e.g.\ by
 \texttt{entropy.py}'s \texttt{central\_charge}) was missing entirely on

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -303,6 +303,27 @@ imaginary potential. The biorthogonal pair $|\psi_R\rangle,|\psi_L\rangle$
 is also what feeds the non-Hermitian dynamical correlator,
 `get_dynamical_correlator(submode="KPM")` for $H\neq H^\dagger$ — see §6.
 
+Two independent MPS Arnoldi implementations are available, both
+matrix-free (they only ever apply $H$ to a wavefunction, never build a
+matrix) and both usable in ED mode or DMRG mode on any backend:
+`dmrgpy.mpsalgebra.lowest_energy_non_hermitian_arnoldi` (`algebra/
+arnolditk.py`) is a restarted Arnoldi method with explicit
+(Rayleigh-Ritz reseeded) restarts; `dmrgpy.mpsalgebra.
+lowest_energy_non_hermitian_iram` (`algebra/arpacktk.py`) is an
+Implicitly Restarted Arnoldi Method (IRAM), adapted from
+[ARPACK](https://bitbucket.org/chaoyang2013/arpack)'s
+`znaupd`/`znaup2`/`znaitr`/`znapps` — same exact-shift polynomial-filter
+restart ARPACK's own `eigs`-style solvers use, re-derived here for
+dmrgpy's own MPS/ED wavefunction objects instead of flat arrays (no
+BLAS/LAPACK Fortran dependency). Because IRAM compresses and reuses its
+existing Krylov subspace instead of rebuilding it from scratch on every
+restart, it typically needs noticeably fewer $H\,|\psi\rangle$
+applications to reach the same tolerance, though the two can trade
+places on hard (near-degenerate) spectra — see
+`examples/non_hermitian/arnoldi_vs_iram_benchmark`, which benchmarks
+both head to head (Op-count, wall time, accuracy) in both ED and DMRG
+mode.
+
 ## 5. Entanglement and quantum information
 
 **Entanglement entropy of a real-space bipartition.** Cutting the chain

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -305,24 +305,30 @@ is also what feeds the non-Hermitian dynamical correlator,
 
 Two independent MPS Arnoldi implementations are available, both
 matrix-free (they only ever apply $H$ to a wavefunction, never build a
-matrix) and both usable in ED mode or DMRG mode on any backend:
+matrix) and both usable in ED mode or DMRG mode on any backend.
+`dmrgpy.mpsalgebra.lowest_energy_non_hermitian_iram` (`algebra/
+arpacktk.py`) is an Implicitly Restarted Arnoldi Method (IRAM), adapted
+from [ARPACK](https://bitbucket.org/chaoyang2013/arpack)'s
+`znaupd`/`znaup2`/`znaitr`/`znapps` — the same exact-shift
+polynomial-filter restart ARPACK's own `eigs`-style solvers use,
+re-derived here for dmrgpy's own MPS/ED wavefunction objects instead of
+flat arrays (no BLAS/LAPACK Fortran dependency). It is the **default**
+MPS Arnoldi solver (`dmrgpy.mpsalgebra.lowest_energy_non_hermitian`, and
+the route `get_excited_states` uses for non-Hermitian $H$ with $n\ge2$,
+`excited_states_non_hermitian` in `excited.py`), since it compresses and
+reuses its existing Krylov subspace instead of rebuilding it from
+scratch on every restart, needing noticeably fewer $H\,|\psi\rangle$
+applications to reach the same tolerance on most spectra.
 `dmrgpy.mpsalgebra.lowest_energy_non_hermitian_arnoldi` (`algebra/
-arnolditk.py`) is a restarted Arnoldi method with explicit
-(Rayleigh-Ritz reseeded) restarts; `dmrgpy.mpsalgebra.
-lowest_energy_non_hermitian_iram` (`algebra/arpacktk.py`) is an
-Implicitly Restarted Arnoldi Method (IRAM), adapted from
-[ARPACK](https://bitbucket.org/chaoyang2013/arpack)'s
-`znaupd`/`znaup2`/`znaitr`/`znapps` — same exact-shift polynomial-filter
-restart ARPACK's own `eigs`-style solvers use, re-derived here for
-dmrgpy's own MPS/ED wavefunction objects instead of flat arrays (no
-BLAS/LAPACK Fortran dependency). Because IRAM compresses and reuses its
-existing Krylov subspace instead of rebuilding it from scratch on every
-restart, it typically needs noticeably fewer $H\,|\psi\rangle$
-applications to reach the same tolerance, though the two can trade
-places on hard (near-degenerate) spectra — see
+arnolditk.py`, a restarted Arnoldi method with explicit Rayleigh-Ritz
+reseeded restarts) remains available directly for comparison — the two
+can trade places on hard (near-degenerate) spectra, see
 `examples/non_hermitian/arnoldi_vs_iram_benchmark`, which benchmarks
 both head to head (Op-count, wall time, accuracy) in both ED and DMRG
-mode.
+mode — and is still used internally wherever IRAM's mode-1
+(standard-eigenproblem) formulation doesn't apply: shift-invert searches
+(`degeneracy.py`'s `eigenvalue_degeneracy`) and Krylov operators with a
+projector baked in (`fermionchain.py`'s `Spinon_Chain.get_gs`).
 
 ## 5. Entanglement and quantum information
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -347,6 +347,24 @@ every outer iteration from $H$'s own exact (still cheap, $O(\text{ncv}^2)$)
 representation on the Krylov basis $\mathrm{OP}$ builds — the same
 accommodation arnolditk's own `mode="ShiftInv"` path already made.
 
+`arpacktk.py` also implements ARPACK's mode 2 — the generalized
+eigenproblem $A|\psi\rangle=\lambda M|\psi\rangle$ for a Hermitian
+positive-definite $M$
+(`dmrgpy.mpsalgebra.mpsiram_generalized`/`generalized_excited_states`,
+$\mathrm{OP}=M^{-1}A$, $B=M$). Unlike mode 1/3, the Krylov basis must be
+orthonormal in the $M$-weighted inner product
+$\langle u,v\rangle_M=\langle u|M|v\rangle$ rather than the plain one, so
+building it uses a separate routine
+(`arnoldi_extend_generalized`) rather than adding a conditional $M$ to
+the mode-1/3 one. $\mathrm{OP}$ again goes through
+`self.applyinverse` (the same approximate-inverse caveat as mode 3, here
+with the trivial shift $\sigma=0$) — but unlike mode 3, $\mathrm{OP}$'s
+own Hessenberg-matrix eigenvalues stay directly meaningful (there is no
+shift to undo), so convergence/selection follow the same pattern as
+plain `mpsiram`, just built with the $M$-inner product. Verified against
+`scipy.linalg.eigh`'s generalized Hermitian-definite eigensolver in both
+ED and DMRG mode.
+
 ## 5. Entanglement and quantum information
 
 **Entanglement entropy of a real-space bipartition.** Cutting the chain

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -325,10 +325,27 @@ reseeded restarts) remains available directly for comparison — the two
 can trade places on hard (near-degenerate) spectra, see
 `examples/non_hermitian/arnoldi_vs_iram_benchmark`, which benchmarks
 both head to head (Op-count, wall time, accuracy) in both ED and DMRG
-mode — and is still used internally wherever IRAM's mode-1
-(standard-eigenproblem) formulation doesn't apply: shift-invert searches
-(`degeneracy.py`'s `eigenvalue_degeneracy`) and Krylov operators with a
-projector baked in (`fermionchain.py`'s `Spinon_Chain.get_gs`).
+mode — and is still used internally for Krylov operators with a
+projector baked in (`fermionchain.py`'s `Spinon_Chain.get_gs`, which
+IRAM's interface doesn't (yet) support).
+
+`arpacktk.py` also implements ARPACK's shift-invert mode
+(`dmrgpy.mpsalgebra.mpsiram_shift_invert`, ARPACK's mode 3,
+$\mathrm{OP}=(A-\sigma I)^{-1}$), used to find the eigenvalues closest to
+a target energy $e$ rather than an extremal one — `degeneracy.py`'s
+`eigenvalue_degeneracy` (used by `gs_degeneracy(mode="DMRG")` on
+non-Hermitian Hamiltonians) is built on it. Since dmrgpy has no exact
+MPO inverse — `self.applyinverse` is itself only an iterative
+correction-vector solve — this departs from ARPACK's own mode-3
+assumption that $\mathrm{OP}$'s eigenvalues are *exactly*
+$1/(\lambda-\sigma)$: only the IRAM restart *direction* (which Krylov
+directions the implicit shifts filter away) comes from
+$\mathrm{OP}$'s own cheap Hessenberg matrix (`which="LM"`, since the
+largest $|\mathrm{OP}\text{-eigenvalue}|$ is the $H$-eigenvalue closest
+to $e$); convergence and the reported eigenpairs are instead recomputed
+every outer iteration from $H$'s own exact (still cheap, $O(\text{ncv}^2)$)
+representation on the Krylov basis $\mathrm{OP}$ builds — the same
+accommodation arnolditk's own `mode="ShiftInv"` path already made.
 
 ## 5. Entanglement and quantum information
 

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -364,6 +364,29 @@ is also what feeds the non-Hermitian dynamical correlator,
 \lstinline|get_dynamical_correlator(submode="KPM")| for $H\neq H^\dagger$
 --- see Section~\ref{sec:dynamical}.
 
+Two independent MPS Arnoldi implementations are available, both
+matrix-free (they only ever apply $H$ to a wavefunction, never build a
+matrix) and both usable in ED mode or DMRG mode on any backend:
+\lstinline|dmrgpy.mpsalgebra.lowest_energy_non_hermitian_arnoldi|
+(\texttt{algebra/arnolditk.py}) is a restarted Arnoldi method with
+explicit (Rayleigh-Ritz reseeded) restarts;
+\lstinline|dmrgpy.mpsalgebra.lowest_energy_non_hermitian_iram|
+(\texttt{algebra/arpacktk.py}) is an Implicitly Restarted Arnoldi Method
+(IRAM), adapted from
+ARPACK\footnote{\url{https://bitbucket.org/chaoyang2013/arpack}}'s
+\lstinline|znaupd|/\lstinline|znaup2|/\lstinline|znaitr|/\lstinline|znapps|
+--- the same exact-shift polynomial-filter restart ARPACK's own
+\lstinline|eigs|-style solvers use, re-derived here for dmrgpy's own
+MPS/ED wavefunction objects instead of flat arrays (no BLAS/LAPACK
+Fortran dependency). Because IRAM compresses and reuses its existing
+Krylov subspace instead of rebuilding it from scratch on every restart,
+it typically needs noticeably fewer $H|\psi\rangle$ applications to
+reach the same tolerance, though the two can trade places on hard
+(near-degenerate) spectra --- see
+\texttt{examples/non\_hermitian/arnoldi\_vs\_iram\_benchmark}, which
+benchmarks both head to head (Op-count, wall time, accuracy) in both ED
+and DMRG mode.
+
 \section{Entanglement and quantum information}
 
 \textbf{Entanglement entropy of a real-space bipartition.} Cutting the

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -414,6 +414,24 @@ are instead recomputed every outer iteration from $H$'s own exact
 $\mathrm{OP}$ builds --- the same accommodation arnolditk's own
 \lstinline|mode="ShiftInv"| path already made.
 
+\texttt{algebra/arpacktk.py} also implements ARPACK's mode 2 --- the
+generalized eigenproblem $A|\psi\rangle=\lambda M|\psi\rangle$ for a
+Hermitian positive-definite $M$
+(\lstinline|dmrgpy.mpsalgebra.mpsiram_generalized|/
+\lstinline|generalized_excited_states|, $\mathrm{OP}=M^{-1}A$, $B=M$).
+Unlike mode 1/3, the Krylov basis must be orthonormal in the
+$M$-weighted inner product $\langle u,v\rangle_M=\langle u|M|v\rangle$
+rather than the plain one, so building it uses a separate routine
+(\lstinline|arnoldi_extend_generalized|) rather than adding a
+conditional $M$ to the mode-1/3 one. $\mathrm{OP}$ again goes through
+\lstinline|self.applyinverse| (the same approximate-inverse caveat as
+mode 3, here with the trivial shift $\sigma=0$) --- but unlike mode 3,
+$\mathrm{OP}$'s own Hessenberg-matrix eigenvalues stay directly
+meaningful (there is no shift to undo), so convergence/selection follow
+the same pattern as plain \lstinline|mpsiram|, just built with the
+$M$-inner product. Verified against \lstinline|scipy.linalg.eigh|'s
+generalized Hermitian-definite eigensolver in both ED and DMRG mode.
+
 \section{Entanglement and quantum information}
 
 \textbf{Entanglement entropy of a real-space bipartition.} Cutting the

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -389,11 +389,30 @@ Rayleigh-Ritz reseeded restarts) remains available directly for
 comparison --- the two can trade places on hard (near-degenerate)
 spectra, see \texttt{examples/non\_hermitian/arnoldi\_vs\_iram\_benchmark},
 which benchmarks both head to head (Op-count, wall time, accuracy) in
-both ED and DMRG mode --- and is still used internally wherever IRAM's
-mode-1 (standard-eigenproblem) formulation doesn't apply: shift-invert
-searches (\texttt{degeneracy.py}'s \lstinline|eigenvalue_degeneracy|)
-and Krylov operators with a projector baked in
-(\texttt{fermionchain.py}'s \lstinline|Spinon_Chain.get_gs|).
+both ED and DMRG mode --- and is still used internally for Krylov
+operators with a projector baked in (\texttt{fermionchain.py}'s
+\lstinline|Spinon_Chain.get_gs|, which IRAM's interface doesn't (yet)
+support).
+
+\texttt{algebra/arpacktk.py} also implements ARPACK's shift-invert mode
+(\lstinline|dmrgpy.mpsalgebra.mpsiram_shift_invert|, ARPACK's mode 3,
+$\mathrm{OP}=(A-\sigma I)^{-1}$), used to find the eigenvalues closest
+to a target energy $e$ rather than an extremal one ---
+\texttt{degeneracy.py}'s \lstinline|eigenvalue_degeneracy| (used by
+\lstinline|gs_degeneracy(mode="DMRG")| on non-Hermitian Hamiltonians) is
+built on it. Since dmrgpy has no exact MPO inverse ---
+\lstinline|self.applyinverse| is itself only an iterative
+correction-vector solve --- this departs from ARPACK's own mode-3
+assumption that $\mathrm{OP}$'s eigenvalues are \emph{exactly}
+$1/(\lambda-\sigma)$: only the IRAM restart \emph{direction} (which
+Krylov directions the implicit shifts filter away) comes from
+$\mathrm{OP}$'s own cheap Hessenberg matrix (\lstinline|which="LM"|,
+since the largest $|\mathrm{OP}\text{-eigenvalue}|$ is the
+$H$-eigenvalue closest to $e$); convergence and the reported eigenpairs
+are instead recomputed every outer iteration from $H$'s own exact
+(still cheap, $O(\mathrm{ncv}^2)$) representation on the Krylov basis
+$\mathrm{OP}$ builds --- the same accommodation arnolditk's own
+\lstinline|mode="ShiftInv"| path already made.
 
 \section{Entanglement and quantum information}
 

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -366,10 +366,7 @@ is also what feeds the non-Hermitian dynamical correlator,
 
 Two independent MPS Arnoldi implementations are available, both
 matrix-free (they only ever apply $H$ to a wavefunction, never build a
-matrix) and both usable in ED mode or DMRG mode on any backend:
-\lstinline|dmrgpy.mpsalgebra.lowest_energy_non_hermitian_arnoldi|
-(\texttt{algebra/arnolditk.py}) is a restarted Arnoldi method with
-explicit (Rayleigh-Ritz reseeded) restarts;
+matrix) and both usable in ED mode or DMRG mode on any backend.
 \lstinline|dmrgpy.mpsalgebra.lowest_energy_non_hermitian_iram|
 (\texttt{algebra/arpacktk.py}) is an Implicitly Restarted Arnoldi Method
 (IRAM), adapted from
@@ -378,14 +375,25 @@ ARPACK\footnote{\url{https://bitbucket.org/chaoyang2013/arpack}}'s
 --- the same exact-shift polynomial-filter restart ARPACK's own
 \lstinline|eigs|-style solvers use, re-derived here for dmrgpy's own
 MPS/ED wavefunction objects instead of flat arrays (no BLAS/LAPACK
-Fortran dependency). Because IRAM compresses and reuses its existing
-Krylov subspace instead of rebuilding it from scratch on every restart,
-it typically needs noticeably fewer $H|\psi\rangle$ applications to
-reach the same tolerance, though the two can trade places on hard
-(near-degenerate) spectra --- see
-\texttt{examples/non\_hermitian/arnoldi\_vs\_iram\_benchmark}, which
-benchmarks both head to head (Op-count, wall time, accuracy) in both ED
-and DMRG mode.
+Fortran dependency). It is the \textbf{default} MPS Arnoldi solver
+(\lstinline|dmrgpy.mpsalgebra.lowest_energy_non_hermitian|, and the
+route \lstinline|get_excited_states| uses for non-Hermitian $H$ with
+$n\ge2$, \lstinline|excited_states_non_hermitian| in
+\texttt{excited.py}), since it compresses and reuses its existing Krylov
+subspace instead of rebuilding it from scratch on every restart, needing
+noticeably fewer $H|\psi\rangle$ applications to reach the same
+tolerance on most spectra.
+\lstinline|dmrgpy.mpsalgebra.lowest_energy_non_hermitian_arnoldi|
+(\texttt{algebra/arnolditk.py}, a restarted Arnoldi method with explicit
+Rayleigh-Ritz reseeded restarts) remains available directly for
+comparison --- the two can trade places on hard (near-degenerate)
+spectra, see \texttt{examples/non\_hermitian/arnoldi\_vs\_iram\_benchmark},
+which benchmarks both head to head (Op-count, wall time, accuracy) in
+both ED and DMRG mode --- and is still used internally wherever IRAM's
+mode-1 (standard-eigenproblem) formulation doesn't apply: shift-invert
+searches (\texttt{degeneracy.py}'s \lstinline|eigenvalue_degeneracy|)
+and Krylov operators with a projector baked in
+(\texttt{fermionchain.py}'s \lstinline|Spinon_Chain.get_gs|).
 
 \section{Entanglement and quantum information}
 

--- a/examples/non_hermitian/arnoldi_vs_iram_benchmark/main.py
+++ b/examples/non_hermitian/arnoldi_vs_iram_benchmark/main.py
@@ -1,0 +1,219 @@
+# Head-to-head benchmark: arnolditk's thick-restart Arnoldi (the
+# pre-existing MPS Arnoldi route, see dmrgpy.algebra.arnolditk) vs the new
+# matrix-free Implicitly Restarted Arnoldi Method (IRAM) ported from
+# ARPACK's znaupd/znaup2 (see dmrgpy.algebra.arpacktk), focusing on
+# non-Hermitian ground states first (mode="GS" / which="SR" -- smallest
+# real part) since that is the case arnolditk's own docs call out as
+# "typically several orders of magnitude less accurate than NH-DMRG at
+# comparable cost" (see examples/non_hermitian/nhdmrg_VS_ED_VS_arnoldi).
+#
+# Instruments the number of expensive Op(x) calls (MPO*MPS application in
+# DMRG mode / sparse matvec in ED mode) alongside wall time and accuracy
+# against an ED ground truth -- the same instrumentation approach as
+# examples/groundstate/arnoldi_benchmark, extended to cover both
+# algorithms so they can be compared directly on identical test cases.
+#
+# Usage: python main.py [--json out.json] [--modes ED,DMRG]
+import sys, os, time, json, argparse
+
+sys.path.append(os.getcwd()+'/../../../src')
+
+import numpy as np
+
+from dmrgpy.multioperatortk.staticoperator import StaticOperator
+from dmrgpy.edtk.edchain import EDOperator, State
+from dmrgpy.mps import MPS
+from dmrgpy.algebra import arnolditk
+from dmrgpy.algebra import arpacktk
+
+# ---------------------------------------------------------------------
+# Instrumentation: count Op(x) = M*x calls, the expensive primitive.
+# ---------------------------------------------------------------------
+_counts = {"dmrg": 0, "ed": 0}
+
+_orig_static_mul = StaticOperator.__mul__
+def _counted_static_mul(self, v):
+    if type(v) == MPS:
+        _counts["dmrg"] += 1
+    return _orig_static_mul(self, v)
+StaticOperator.__mul__ = _counted_static_mul
+
+_orig_ed_mul = EDOperator.__mul__
+def _counted_ed_mul(self, v):
+    if isinstance(v, State):
+        _counts["ed"] += 1
+    return _orig_ed_mul(self, v)
+EDOperator.__mul__ = _counted_ed_mul
+
+def reset_counts():
+    _counts["dmrg"] = 0
+    _counts["ed"] = 0
+
+def get_count(mode):
+    return _counts["dmrg"] if mode == "DMRG" else _counts["ed"]
+
+
+# ---------------------------------------------------------------------
+# Test cases: non-Hermitian first (the focus of this comparison), then a
+# couple of Hermitian ones since IRAM/arnolditk should agree there too.
+# ---------------------------------------------------------------------
+
+def make_fermion_chain(n, seed):
+    from dmrgpy import fermionchain
+    rng = np.random.RandomState(seed)
+    fc = fermionchain.Fermionic_Chain(n)
+    mh = np.zeros((n, n), dtype=complex)
+    for i in range(n - 1):
+        mh[i, i + 1] = 1.0
+        mh[i + 1, i] = 1.0
+    for i in range(n):
+        mh[i, i] = 1j * (-1) ** i
+    h = 0
+    for i in range(n):
+        for j in range(n):
+            h = h + mh[i, j] * fc.Cdag[i] * fc.C[j]
+    for i in range(n - 1):
+        h = h + (fc.N[i] - 0.5) * (fc.N[i + 1] - 0.5)
+    fc.set_hamiltonian(h)
+    return fc, h
+
+
+def make_spin_chain(n, seed):
+    from dmrgpy import spinchain
+    rng = np.random.RandomState(seed)
+    spins = ["S=1/2" for i in range(n)]
+    sc = spinchain.Spin_Chain(spins)
+    h = 0
+    for i in range(n - 1):
+        h = h + rng.random() * sc.Sx[i] * sc.Sx[i + 1]
+        h = h + rng.random() * sc.Sy[i] * sc.Sy[i + 1]
+        h = h + rng.random() * sc.Sz[i] * sc.Sz[i + 1]
+    sc.set_hamiltonian(h)
+    return sc, h
+
+
+def run_case_arnolditk(build, n, mode, seed=1, tol=1e-6, **kwargs):
+    chain, h = build(n, seed)
+    chain.mode = None
+    if mode == "DMRG": chain.setup_python()  # no compiled extension needed
+    arnolditk.arnoldimode = mode
+    reset_counts()
+    t0 = time.time()
+    try:
+        es, wfs = arnolditk.mpsarnoldi(chain, h, mode="GS", delta=tol, **kwargs)
+        ok, err = True, None
+    except Exception as e:
+        es, wfs = None, None
+        ok, err = False, repr(e)
+    dt = time.time() - t0
+    return dict(ok=ok, err=err,
+                energies=(np.atleast_1d(es).tolist() if ok else None),
+                time=dt, nops=get_count(mode))
+
+
+def run_case_iram(build, n, mode, seed=1, tol=1e-6, **kwargs):
+    chain, h = build(n, seed)
+    chain.mode = None
+    if mode == "DMRG": chain.setup_python()  # no compiled extension needed
+    arnolditk.arnoldimode = mode  # arpacktk reuses arnolditk's random_state,
+                                   # which reads this same module flag
+    reset_counts()
+    t0 = time.time()
+    try:
+        es, wfs = arpacktk.mpsiram(chain, h, which="SR", tol=tol, **kwargs)
+        ok, err = True, None
+    except Exception as e:
+        es, wfs = None, None
+        ok, err = False, repr(e)
+    dt = time.time() - t0
+    return dict(ok=ok, err=err,
+                energies=(np.atleast_1d(es).tolist() if ok else None),
+                time=dt, nops=get_count(mode))
+
+
+def ground_truth(build, n, seed, nwf=1, n_gt=None):
+    chain, h = build(n, seed)
+    if n_gt is None:
+        n_gt = max(nwf, 6)
+    es = chain.get_excited(mode="ED", n=n_gt)
+    es = np.array(es)
+    order = np.argsort(es.real)
+    return es[order].tolist()
+
+
+CASES = []
+
+def add_case(name, build, n, nwf=1, seed=1, **kwargs):
+    CASES.append(dict(name=name, build=build, n=n, nwf=nwf, seed=seed, kwargs=kwargs))
+
+add_case("nonhermitian_fermion_n4", make_fermion_chain, 4, nwf=1, seed=3)
+add_case("nonhermitian_fermion_n6", make_fermion_chain, 6, nwf=1, seed=4)
+add_case("nonhermitian_fermion_n8", make_fermion_chain, 8, nwf=1, seed=7)
+add_case("hermitian_spin_n6", make_spin_chain, 6, nwf=1, seed=1)
+add_case("hermitian_spin_n10", make_spin_chain, 10, nwf=1, seed=2)
+
+# Smaller variants for DMRG mode (itensor_version="python"/pyitensor):
+# each Op(x) there is a real MPO*MPS application, much slower than an ED
+# sparse matvec, so keep chain lengths modest to keep this runnable
+# without a compiled C++ extension.
+SMALL_CASES = []
+def add_small_case(name, build, n, nwf=1, seed=1, **kwargs):
+    SMALL_CASES.append(dict(name=name, build=build, n=n, nwf=nwf, seed=seed, kwargs=kwargs))
+
+add_small_case("nonhermitian_fermion_n4", make_fermion_chain, 4, nwf=1, seed=3)
+add_small_case("hermitian_spin_n4", make_spin_chain, 4, nwf=1, seed=1)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", default=None)
+    ap.add_argument("--modes", default="ED,DMRG")
+    ap.add_argument("--tol", type=float, default=1e-6)
+    args = ap.parse_args()
+
+    modes = args.modes.split(",")
+    results = []
+    all_cases = {"ED": CASES, "DMRG": SMALL_CASES}
+    for mode in modes:
+        for case in all_cases.get(mode, CASES):
+            gt = ground_truth(case["build"], case["n"], case["seed"], nwf=case["nwf"])
+            print(f"=== {case['name']} (n={case['n']}, mode={mode}) === ground truth: {np.round(gt[0],6)}")
+            for algo, runner in [("arnolditk", run_case_arnolditk),
+                                  ("iram", run_case_iram)]:
+                res = runner(case["build"], case["n"], mode, tol=args.tol,
+                              seed=case["seed"], **case["kwargs"])
+                res.update(name=case["name"], mode=mode, algo=algo, n=case["n"])
+                if res["ok"]:
+                    es = np.array(res["energies"], dtype=complex)
+                    gts = np.array(gt, dtype=complex)
+                    err = float(np.min(np.abs(es[0] - gts)))
+                    res["energies"] = [[e.real, e.imag] for e in es]
+                else:
+                    err = None
+                res["max_energy_error"] = err
+                results.append(res)
+                print(f"  algo={algo:9s} mode={mode:5s} ok={res['ok']!s:5s} "
+                      f"nops={res['nops']:4d} time={res['time']:7.3f}s "
+                      f"err={err} "
+                      f"energy={res['energies'][0] if res['ok'] else res['err']}")
+
+    print("\n=== Summary: Op(x) call count, arnolditk vs iram ===")
+    for mode in modes:
+        for case in all_cases.get(mode, CASES):
+            a = [r for r in results if r["name"] == case["name"]
+                 and r["mode"] == mode and r["algo"] == "arnolditk"][0]
+            b = [r for r in results if r["name"] == case["name"]
+                 and r["mode"] == mode and r["algo"] == "iram"][0]
+            if a["ok"] and b["ok"] and a["nops"] > 0:
+                ratio = b["nops"] / a["nops"]
+                print(f"  {mode:5s} {case['name']:28s} "
+                      f"arnolditk={a['nops']:4d}  iram={b['nops']:4d}  "
+                      f"(iram/arnolditk={ratio:.2f}x)")
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nWrote {args.json}")
+
+if __name__ == "__main__":
+    main()

--- a/src/dmrgpy/algebra/arpacktk.py
+++ b/src/dmrgpy/algebra/arpacktk.py
@@ -51,16 +51,25 @@ Ported pieces, and their ARPACK sources:
                       convergence, adjust kev to avoid stagnation exactly
                       as znaup2 does, restart, repeat)
 
-This is deliberately the *matrix-free, mode-1* subset of ARPACK (OP=A,
-B=I; no shift-invert modes 2-4, no reverse communication, no B-inner
-product) -- everything dmrgpy's own MPS/ED objects need
-(``self.random_mps()``/``EDchain``, ``.dot()``, ``.normalize()``,
-``.copy()``, ``+``/``-``/scalar ``*``) and nothing more.
+This is the *matrix-free, mode-1* subset of ARPACK (OP=A, B=I; no
+reverse communication, no B-inner product) -- everything dmrgpy's own
+MPS/ED objects need (``self.random_mps()``/``EDchain``, ``.dot()``,
+``.normalize()``, ``.copy()``, ``+``/``-``/scalar ``*``) and nothing
+more -- plus ``mpsiram_shift_invert``, a shift-invert mode (ARPACK's
+mode 3, OP=inv(A-sigma*I), B=I) adapted to dmrgpy's only *approximate*
+matrix inverse (``self.applyinverse``, an iterative correction-vector
+solve, not an exact linear solve) -- see its own docstring for how that
+changes the convergence/selection machinery relative to ARPACK's own
+mode-3 assumption of an exact inverse.
 """
 import numpy as np
 
 from .arnolditk import random_state
 from . import arnolditk
+from .krylov import krylov_matrix_representation
+from .krylov import diagonalize as krylov_diagonalize
+from .krylov import select_states as krylov_select_states
+from .krylov import unitary_transformation as krylov_unitary_transformation
 
 
 def _goodness(which, ritz):
@@ -270,6 +279,105 @@ def mpsiram(self, H, which="SR", nev=1, ncv=None, tol=1e-8, maxiter=200,
     es = np.array([wf.aMb(H, wf) for wf in wfs])
     # most-wanted first (Y_sel's last column was the most wanted)
     return es[::-1], wfs[::-1]
+
+
+def mpsiram_shift_invert(self, H, e=0.0, nev=1, ncv=None, delta=1e-3,
+        maxn=20, maxiter=50, verbose=0, wfskip=None):
+    """Shift-invert IRAM (ARPACK mode 3: OP=inv(A-sigma*I), B=I),
+    adapted for dmrgpy's own ``self.applyinverse``, which is only an
+    *approximate* inverse (an iterative correction-vector solve, not an
+    exact linear solve) -- the same accommodation arnolditk's own
+    mode="ShiftInv" (``op_is_affine=False``) path makes. Finds the nev
+    eigenvalues of H closest to the target `e`.
+
+    ARPACK's own mode 3 assumes OP's eigenvalues theta are *exactly*
+    1/(lambda-sigma), so it can cheaply select/report Ritz pairs from
+    OP's own (free) Hessenberg matrix and untransform at the end. That
+    assumption breaks once OP is only approximate, so -- exactly like
+    arnolditk -- convergence and the reported eigenpairs are instead
+    recomputed every outer iteration from H's own exact (still cheap,
+    O(ncv^2)) representation on the Krylov basis OP builds
+    (``krylov_matrix_representation``/``diagonalize``/``select_states``/
+    ``unitary_transformation``, reused directly from ``krylov.py`` rather
+    than re-derived, since that machinery -- including its Ritz-value
+    conjugation convention for non-Hermitian H -- is already exercised by
+    arnolditk's own ShiftInv path). Only the *restart direction* (which
+    unwanted Krylov directions IRAM's implicit shifts filter away) still
+    uses OP's own cheap Hessenberg matrix with which="LM": largest
+    |OP-eigenvalue| corresponds to the H-eigenvalue closest to `e`,
+    exactly the criterion a shift-invert operator is built to sharpen --
+    that part of the algorithm only cares about OP's own Krylov
+    factorization, regardless of what physical operator OP approximates.
+
+    The residual/Ritz-estimate bound is a heuristic proxy, not a
+    rigorous one (there is no genuine Arnoldi relation tying H itself to
+    this basis): OP's own trailing residual norm times the candidate
+    H-eigenvector's last Krylov-basis component -- again the same proxy
+    arnolditk's ShiftInv path already relies on. Convergence is judged
+    against this bound directly (``delta``, an absolute threshold, not a
+    tolerance relative to the eigenvalue's own magnitude as in
+    ``mpsiram``), matching arnolditk's own ShiftInv convention, since
+    `e` may be numerically close to zero.
+    """
+    if wfskip is None: wfskip = []
+    else: wfskip = list(wfskip)
+    if ncv is None: ncv = 2 * nev + 4
+    ncv = max(ncv, nev + 2)
+    Mi = H - e
+    Op = lambda x: self.applyinverse(Mi, x, delta=delta, maxn=maxn)
+
+    def fe_target(es):
+        es = np.abs(es - e)
+        return np.where(es == np.min(es))[0][0]
+
+    kev = nev
+    resid = random_state(self, orthogonal=wfskip if wfskip else None)
+    rnorm = 1.0
+    V, Hm = [], np.zeros((0, 0), dtype=complex)
+    V, Hm, resid, rnorm = arnoldi_extend(self, Op, V, Hm, resid, rnorm,
+            0, kev, wfskip=wfskip, verbose=verbose)
+
+    for it in range(maxiter):
+        npcur = ncv - kev
+        if npcur > 0:
+            V, Hm, resid, rnorm = arnoldi_extend(self, Op, V, Hm, resid,
+                    rnorm, kev, npcur, wfskip=wfskip, verbose=verbose)
+
+        Htrue = krylov_matrix_representation(H, V)
+        ritz_true, vs_true = krylov_diagonalize(Htrue)
+        nsel = min(nev, len(V))
+        estore, vstore = krylov_select_states(ritz_true, vs_true.T,
+                fe_target, ne=nsel)
+        error = np.array([np.abs(rnorm * v0[-1]) for v0 in vstore])
+        nconv = int(np.sum(error <= delta))
+
+        if verbose > 0:
+            print("ShiftInv IRAM iter", it, "kev", kev, "nconv", nconv,
+                    "ritz", np.round(estore, 6), "error", np.round(error, 6))
+
+        np_apply = ncv - kev
+        if nconv >= nev or np_apply == 0:
+            break
+
+        ritz_op, bounds_op, _ = hessenberg_ritz(Hm, rnorm)
+        order_op = np.argsort(_goodness("LM", ritz_op))
+        ritz_op, bounds_op = ritz_op[order_op], bounds_op[order_op]
+
+        shifts = ritz_op[:np_apply]
+        shift_bounds = bounds_op[:np_apply]
+        shift_order = np.argsort(-np.abs(shift_bounds))
+        shifts = shifts[shift_order]
+
+        V, Hm, resid, rnorm = apply_shifts(V, Hm, resid, shifts, kev)
+
+    Htrue = krylov_matrix_representation(H, V)
+    ritz_true, vs_true = krylov_diagonalize(Htrue)
+    nsel = min(nev, len(V))
+    estore, vstore = krylov_select_states(ritz_true, vs_true.T,
+            fe_target, ne=nsel)
+    wfs = krylov_unitary_transformation(vstore, V)
+    es = np.array([wf.aMb(H, wf) for wf in wfs])
+    return es, wfs
 
 
 def excited_states(self, H, nwf=1, which="SR", recursive=True,

--- a/src/dmrgpy/algebra/arpacktk.py
+++ b/src/dmrgpy/algebra/arpacktk.py
@@ -1,0 +1,286 @@
+"""Matrix-free, pure-Python Implicitly Restarted Arnoldi Method (IRAM),
+adapted from ARPACK (https://bitbucket.org/chaoyang2013/arpack, SRC/zn*.f
+-- the double-complex non-symmetric driver znaupd/znaup2/znaitr/znapps/
+zneigh/zngets/zsortc) so it runs directly against dmrgpy's own MPS/ED
+wavefunction objects instead of flat numpy arrays, with no BLAS/LAPACK
+Fortran dependency and no reverse-communication interface (there is no
+separate process here, so Op(x) is just called directly).
+
+Why the *complex* ARPACK routines, not the real double-precision ones
+(dnaupd/...)?  dmrgpy's Hamiltonians and wavefunctions are complex-valued
+already (non-Hermitian models routinely have complex spectra), so there is
+nothing to gain from ARPACK's real-arithmetic double-shift trick (which
+exists purely to keep dnaupd's *dense linear algebra* in real BLAS/LAPACK
+for speed on flat arrays). Working in complex arithmetic throughout lets
+each implicit-restart shift be a single (possibly complex) Ritz value,
+applied with a single-shift QR step -- no need for dnapps's paired
+double-shift bookkeeping to keep complex-conjugate Ritz pairs together.
+
+Why numpy.linalg.qr instead of porting znapps's Givens-rotation bulge
+chase? Sorensen's 1992 "Implicit Application of Polynomial Filters in a
+k-Step Arnoldi Method" (the paper both dnapps and znapps implement) shows
+that applying a shift mu via a single-shift QR step of the *whole* current
+Hessenberg matrix H (Q,R = qr(H-mu*I); H <- Q^H H Q) produces exactly the
+same orthogonal transform as ARPACK's O(ncv^2) hand-rolled bulge chase --
+bulge chasing is only ARPACK's dense-linear-algebra *implementation*
+detail for that identity, not part of the mathematical algorithm. Since
+the Krylov subspace size ncv here is tiny (order 10-50) while a single
+Op(x) is an MPO*MPS application, the O(ncv^3) cost of a plain dense QR per
+shift is negligible -- there is nothing to gain from bulge chasing's extra
+implementation complexity. Applying each shift's QR to the *already
+transformed* H (not to a freshly-formed product polynomial prod(H-mu_i*I))
+keeps the conditioning equivalent to sequential bulge chasing rather than
+the numerically worse direct-polynomial formulation.
+
+Ported pieces, and their ARPACK sources:
+  arnoldi_extend  <- znaitr.f  (build/extend a length-k factorization by
+                      classical Gram-Schmidt with iterative refinement,
+                      the 0.717 ratio test and 2-pass retry policy taken
+                      directly from znaitr's STEP5/STEP6 comments)
+  hessenberg_ritz <- zneigh.f  (eigenvalues + Ritz estimates of H;
+                      zneigh needs zlahqr+ztrevc to get eigenvectors of a
+                      real-arithmetic-friendly Schur form -- here
+                      numpy.linalg.eig gives the same normalized
+                      eigenvectors of the small complex H directly)
+  select_shifts   <- zngets.f/zsortc.f (sort so the "wanted" Ritz values
+                      per `which` end up last; unwanted ones become
+                      shifts, most-uncertain-first)
+  apply_shifts    <- znapps.f (implicit restart -- see above for why QR
+                      replaces the bulge chase)
+  mpsiram         <- znaupd.f/znaup2.f (the outer driver: extend, check
+                      convergence, adjust kev to avoid stagnation exactly
+                      as znaup2 does, restart, repeat)
+
+This is deliberately the *matrix-free, mode-1* subset of ARPACK (OP=A,
+B=I; no shift-invert modes 2-4, no reverse communication, no B-inner
+product) -- everything dmrgpy's own MPS/ED objects need
+(``self.random_mps()``/``EDchain``, ``.dot()``, ``.normalize()``,
+``.copy()``, ``+``/``-``/scalar ``*``) and nothing more.
+"""
+import numpy as np
+
+from .arnolditk import random_state
+from . import arnolditk
+
+
+def _goodness(which, ritz):
+    """Score used to sort Ritz values so the *wanted* ones (per ARPACK's
+    which={LM,SM,LR,SR,LI,SI} convention) end up at the end of the array
+    -- see zngets.f/zsortc.f: after sorting ascending by this score, the
+    last kev entries are wanted, the first np are unwanted (shift
+    candidates)."""
+    if which == "LM": return np.abs(ritz)
+    if which == "SM": return -np.abs(ritz)
+    if which == "LR": return ritz.real
+    if which == "SR": return -ritz.real
+    if which == "LI": return ritz.imag
+    if which == "SI": return -ritz.imag
+    raise ValueError("Unknown which='%s'" % which)
+
+
+def arnoldi_extend(self, Op, V, H, resid, rnorm, k, npsteps,
+        wfskip=None, verbose=0):
+    """Port of znaitr: extend a length-k Arnoldi factorization
+    (Op*V_k - V_k*H_k = resid*e_k^T, V_k^H*resid = 0, ||resid|| = rnorm)
+    by npsteps more steps, using only Op(x) plus the generic wavefunction
+    operations (dot/normalize/+/-/scalar*). Every new vector costs
+    exactly one Op(x) call, same as arnolditk's own build_arnoldi_chain,
+    so existing Op(x)-counting instrumentation (see
+    examples/groundstate/arnoldi_benchmark) applies unmodified."""
+    if wfskip is None: wfskip = []
+    kplusp = k + npsteps
+    Hnew = np.zeros((kplusp, kplusp), dtype=complex)
+    if k > 0: Hnew[:k, :k] = H
+    Vout = list(V)
+    beta = rnorm
+    for j in range(k, kplusp):
+        if beta < 1e-12:
+            # invariant subspace hit mid-extension: restart from a fresh
+            # random vector orthogonal to the basis built so far (mirrors
+            # znaitr's dgetv0-based restart, minus the give-up-after-3-
+            # tries limit -- random_state() already loops until it finds
+            # a usable vector)
+            if verbose > 0: print("arnoldi_extend: invariant subspace, restarting")
+            resid = random_state(self, orthogonal=Vout + wfskip)
+            beta = 1.0
+        vj = resid * (1. / beta)
+        Vout.append(vj)
+        w = Op(vj)
+        if wfskip:
+            for s in wfskip:
+                w = w - s.dot(w) * s
+        coeffs = np.array([Vout[i].dot(w) for i in range(j + 1)], dtype=complex)
+        r = w
+        for i in range(j + 1): r = r - coeffs[i] * Vout[i]
+        if j > 0: Hnew[j, j - 1] = beta
+        Hnew[:j + 1, j] = coeffs
+        wnorm = np.sqrt(abs(w.dot(w)))
+        rnorm1 = np.sqrt(abs(r.dot(r)))
+        if wnorm > 0 and rnorm1 <= 0.717 * wnorm:
+            # iterative refinement (re-orthogonalization), up to 2 passes
+            # -- znaitr's STEP5, same 0.717 acceptance ratio and 2-try
+            # give-up policy
+            converged = False
+            for _try in range(2):
+                if wfskip:
+                    for s in wfskip:
+                        r = r - s.dot(r) * s
+                s = np.array([Vout[i].dot(r) for i in range(j + 1)], dtype=complex)
+                for i in range(j + 1): r = r - s[i] * Vout[i]
+                Hnew[:j + 1, j] += s
+                rnorm2 = np.sqrt(abs(r.dot(r)))
+                prev = rnorm1
+                rnorm1 = rnorm2
+                if rnorm2 > 0.717 * prev:
+                    converged = True
+                    break
+            if not converged:
+                # r lies numerically in span(V): treat as invariant subspace
+                r = r * 0.0
+                rnorm1 = 0.0
+        resid = r
+        beta = rnorm1
+    return Vout, Hnew, resid, beta
+
+
+def hessenberg_ritz(H, rnorm):
+    """Port of zneigh: eigenvalues of the (small, dense) Hessenberg
+    matrix H and their Ritz estimates (= rnorm * |last eigenvector
+    component|, from the Arnoldi relation Op*V - V*H = resid*e_k^T).
+    numpy.linalg.eig already returns eigenvectors normalized to unit
+    Euclidean norm, exactly what zneigh's own post-processing does by
+    hand after zlahqr+ztrevc -- nothing extra needed here."""
+    ritz, Y = np.linalg.eig(H)
+    bounds = rnorm * np.abs(Y[-1, :])
+    return ritz, bounds, Y
+
+
+def apply_shifts(V, H, resid, shifts, kev):
+    """Port of znapps (see module docstring for why dense QR replaces the
+    bulge chase): compress a length len(V) Arnoldi factorization down to
+    length kev by applying the given shifts."""
+    kplusp = H.shape[0]
+    Hc = H.copy()
+    Q = np.eye(kplusp, dtype=complex)
+    Ident = np.eye(kplusp, dtype=complex)
+    for mu in shifts:
+        Qi, _ = np.linalg.qr(Hc - mu * Ident)
+        Hc = Qi.conj().T @ Hc @ Qi
+        Q = Q @ Qi
+    Vnew = []
+    for i in range(kev + 1):
+        wf = Q[0, i] * V[0]
+        for j in range(1, kplusp):
+            wf = wf + Q[j, i] * V[j]
+        Vnew.append(wf)
+    betak = Hc[kev, kev - 1]
+    sigmak = Q[kplusp - 1, kev - 1]
+    resid_new = sigmak * resid
+    if abs(betak) > 1e-13:
+        resid_new = resid_new + betak * Vnew[kev]
+    Hnew = Hc[:kev, :kev].copy()
+    rnorm_new = np.sqrt(abs(resid_new.dot(resid_new)))
+    return Vnew[:kev], Hnew, resid_new, rnorm_new
+
+
+def mpsiram(self, H, which="SR", nev=1, ncv=None, tol=1e-8, maxiter=200,
+        verbose=0, wfskip=None):
+    """Implicitly Restarted Arnoldi Method (port of znaupd/znaup2),
+    matrix-free: finds the nev eigenpairs of H selected by `which`
+    ({LM,SM,LR,SR,LI,SI}, ARPACK's own convention) using only Op(x)=H*x
+    applications plus generic wavefunction algebra -- no auxiliary
+    spectral-radius shift is needed the way arnolditk's mode="GS" uses
+    one, since which="SR" already targets the smallest-real-part
+    eigenvalues directly (exact shifts, not an ad hoc global one).
+
+    Returns (es, wfs): es are <wf|H|wf> recomputed against the original
+    (unshifted) H for accuracy/parity with arnolditk's own convention,
+    wfs are normalized MPS/ED-state linear combinations of the final
+    Krylov basis, ordered most-wanted-first.
+    """
+    if wfskip is None: wfskip = []
+    if ncv is None: ncv = 2 * nev + 4
+    ncv = max(ncv, nev + 2)
+    M = self.toMPO(H, mode=arnolditk.arnoldimode)
+    Op = lambda x: M * x
+
+    eps23 = np.finfo(float).eps ** (2. / 3.)
+    kev = nev
+    resid = random_state(self, orthogonal=wfskip if wfskip else None)
+    rnorm = 1.0
+    V, Hm = [], np.zeros((0, 0), dtype=complex)
+    V, Hm, resid, rnorm = arnoldi_extend(self, Op, V, Hm, resid, rnorm,
+            0, kev, wfskip=wfskip, verbose=verbose)
+
+    for it in range(maxiter):
+        npcur = ncv - kev
+        if npcur > 0:
+            V, Hm, resid, rnorm = arnoldi_extend(self, Op, V, Hm, resid,
+                    rnorm, kev, npcur, wfskip=wfskip, verbose=verbose)
+
+        ritz, bounds, Y = hessenberg_ritz(Hm, rnorm)
+        order = np.argsort(_goodness(which, ritz))
+        ritz, bounds = ritz[order], bounds[order]
+
+        np_apply = ncv - kev
+        wanted_ritz = ritz[np_apply:]
+        wanted_bounds = bounds[np_apply:]
+        scale = np.maximum(eps23, np.abs(wanted_ritz))
+        nconv = int(np.sum(wanted_bounds <= tol * scale))
+
+        if verbose > 0:
+            print("IRAM iter", it, "kev", kev, "nconv", nconv,
+                    "ritz", np.round(wanted_ritz, 6))
+
+        if nconv >= nev or np_apply == 0:
+            break
+
+        # stagnation-avoidance: temporarily grow kev, exactly as
+        # znaup2's own heuristic (nev = nev + min(nconv,np/2)), so
+        # repeatedly-shifted-away near-converged directions don't stall
+        # the iteration
+        if nconv > 0:
+            bump = min(nconv, np_apply // 2)
+            if bump > 0:
+                kev = min(kev + bump, ncv - 2)
+
+        np_apply = ncv - kev
+        shifts = ritz[:np_apply]
+        shift_bounds = bounds[:np_apply]
+        # apply the most-uncertain (largest Ritz estimate) shifts first,
+        # as zngets does, to limit forward instability of the sweep
+        shift_order = np.argsort(-np.abs(shift_bounds))
+        shifts = shifts[shift_order]
+
+        V, Hm, resid, rnorm = apply_shifts(V, Hm, resid, shifts, kev)
+
+    ritz, bounds, Y = hessenberg_ritz(Hm, rnorm)
+    order = np.argsort(_goodness(which, ritz))
+    ritz, Y = ritz[order], Y[:, order]
+    nsel = min(nev, Hm.shape[0])
+    Y_sel = Y[:, -nsel:]
+
+    wfs = []
+    for i in range(nsel):
+        y = Y_sel[:, i]
+        wf = y[0] * V[0]
+        for j in range(1, len(V)):
+            wf = wf + y[j] * V[j]
+        wfs.append(wf.normalize())
+    es = np.array([wf.aMb(H, wf) for wf in wfs])
+    # most-wanted first (Y_sel's last column was the most wanted)
+    return es[::-1], wfs[::-1]
+
+
+def lowest_energy_non_hermitian(self, H, n=1, **kwargs):
+    """Smallest-real-part eigenpairs of a (possibly non-Hermitian) H via
+    IRAM -- drop-in comparison point for
+    arnolditk.lowest_energy_non_hermitian (mode="GS")."""
+    return mpsiram(self, H, which="SR", nev=n, **kwargs)
+
+
+def lowest_energy(self, H, n=1, **kwargs):
+    """Ground state(s) of a Hermitian H via IRAM -- for a Hermitian H the
+    smallest-real-part eigenvalue is the ground state, same convention as
+    arnolditk.lowest_energy."""
+    return mpsiram(self, H, which="SR", nev=n, **kwargs)

--- a/src/dmrgpy/algebra/arpacktk.py
+++ b/src/dmrgpy/algebra/arpacktk.py
@@ -69,7 +69,6 @@ from . import arnolditk
 from .krylov import krylov_matrix_representation
 from .krylov import diagonalize as krylov_diagonalize
 from .krylov import select_states as krylov_select_states
-from .krylov import unitary_transformation as krylov_unitary_transformation
 
 
 def _goodness(which, ritz):
@@ -164,6 +163,29 @@ def hessenberg_ritz(H, rnorm):
     return ritz, bounds, Y
 
 
+def sort_ritz(which, ritz, bounds):
+    """Sort (ritz,bounds) ascending by _goodness(which,ritz) -- the
+    wanted entries (per `which`) end up last, per zngets.f/zsortc.f's
+    convention (see _goodness's own docstring)."""
+    order = np.argsort(_goodness(which, ritz))
+    return ritz[order], bounds[order]
+
+
+def select_shifts(ritz, bounds, np_apply):
+    """Port of zngets.f: given an already which-sorted (ritz,bounds)
+    pair (see sort_ritz), the first np_apply entries are the unwanted
+    directions to use as implicit-restart shifts. Returns them reordered
+    so the most-uncertain one (largest Ritz estimate) is applied first,
+    limiting the forward instability of the shift sweep -- used
+    identically by both mpsiram (which="LM"/"SM"/.../the caller's own
+    criterion) and mpsiram_shift_invert (always which="LM" on OP's own
+    Hessenberg matrix, see its docstring)."""
+    shifts = ritz[:np_apply]
+    shift_bounds = bounds[:np_apply]
+    order = np.argsort(-np.abs(shift_bounds))
+    return shifts[order]
+
+
 def apply_shifts(V, H, resid, shifts, kev):
     """Port of znapps (see module docstring for why dense QR replaces the
     bulge chase): compress a length len(V) Arnoldi factorization down to
@@ -228,8 +250,7 @@ def mpsiram(self, H, which="SR", nev=1, ncv=None, tol=1e-8, maxiter=200,
                     rnorm, kev, npcur, wfskip=wfskip, verbose=verbose)
 
         ritz, bounds, Y = hessenberg_ritz(Hm, rnorm)
-        order = np.argsort(_goodness(which, ritz))
-        ritz, bounds = ritz[order], bounds[order]
+        ritz, bounds = sort_ritz(which, ritz, bounds)
 
         np_apply = ncv - kev
         wanted_ritz = ritz[np_apply:]
@@ -254,13 +275,7 @@ def mpsiram(self, H, which="SR", nev=1, ncv=None, tol=1e-8, maxiter=200,
                 kev = min(kev + bump, ncv - 2)
 
         np_apply = ncv - kev
-        shifts = ritz[:np_apply]
-        shift_bounds = bounds[:np_apply]
-        # apply the most-uncertain (largest Ritz estimate) shifts first,
-        # as zngets does, to limit forward instability of the sweep
-        shift_order = np.argsort(-np.abs(shift_bounds))
-        shifts = shifts[shift_order]
-
+        shifts = select_shifts(ritz, bounds, np_apply)
         V, Hm, resid, rnorm = apply_shifts(V, Hm, resid, shifts, kev)
 
     ritz, bounds, Y = hessenberg_ritz(Hm, rnorm)
@@ -294,30 +309,43 @@ def mpsiram_shift_invert(self, H, e=0.0, nev=1, ncv=None, delta=1e-3,
     1/(lambda-sigma), so it can cheaply select/report Ritz pairs from
     OP's own (free) Hessenberg matrix and untransform at the end. That
     assumption breaks once OP is only approximate, so -- exactly like
-    arnolditk -- convergence and the reported eigenpairs are instead
-    recomputed every outer iteration from H's own exact (still cheap,
-    O(ncv^2)) representation on the Krylov basis OP builds
-    (``krylov_matrix_representation``/``diagonalize``/``select_states``/
-    ``unitary_transformation``, reused directly from ``krylov.py`` rather
-    than re-derived, since that machinery -- including its Ritz-value
-    conjugation convention for non-Hermitian H -- is already exercised by
-    arnolditk's own ShiftInv path). Only the *restart direction* (which
-    unwanted Krylov directions IRAM's implicit shifts filter away) still
-    uses OP's own cheap Hessenberg matrix with which="LM": largest
-    |OP-eigenvalue| corresponds to the H-eigenvalue closest to `e`,
-    exactly the criterion a shift-invert operator is built to sharpen --
-    that part of the algorithm only cares about OP's own Krylov
-    factorization, regardless of what physical operator OP approximates.
+    arnolditk -- the reported eigenpairs are instead recomputed every
+    outer iteration from H's own exact (still cheap, O(ncv^2))
+    representation on the Krylov basis OP builds
+    (``krylov_matrix_representation``/``diagonalize``/``select_states``,
+    reused directly from ``krylov.py`` rather than re-derived, since that
+    machinery -- including its Ritz-value conjugation convention for
+    non-Hermitian H -- is already exercised by arnolditk's own ShiftInv
+    path). Only the *restart direction* (which unwanted Krylov
+    directions IRAM's implicit shifts filter away) uses OP's own cheap
+    Hessenberg matrix with which="LM": largest |OP-eigenvalue|
+    corresponds to the H-eigenvalue closest to `e`, exactly the
+    criterion a shift-invert operator is built to sharpen -- that part
+    of the algorithm only cares about OP's own Krylov factorization,
+    regardless of what physical operator OP approximates.
 
-    The residual/Ritz-estimate bound is a heuristic proxy, not a
-    rigorous one (there is no genuine Arnoldi relation tying H itself to
-    this basis): OP's own trailing residual norm times the candidate
-    H-eigenvector's last Krylov-basis component -- again the same proxy
-    arnolditk's ShiftInv path already relies on. Convergence is judged
-    against this bound directly (``delta``, an absolute threshold, not a
-    tolerance relative to the eigenvalue's own magnitude as in
-    ``mpsiram``), matching arnolditk's own ShiftInv convention, since
-    `e` may be numerically close to zero.
+    Convergence is certified with a genuine residual
+    ``||H*wf - theta*wf||`` against the *original* H directly (one extra
+    H-application per candidate per outer iteration -- cheap next to the
+    several correction-vector solves, each itself an iterative multi-step
+    matvec loop, already spent building/extending the Krylov chain this
+    iteration), not the cheaper ``rnorm*|last Krylov component|`` proxy
+    ``mpsiram`` uses for its own (non-shift-invert, Op-is-exact)
+    Hessenberg residual. That proxy measures how well *Op's* Krylov
+    chain has converged, not whether a candidate is a genuine H
+    eigenvector -- confirmed directly to matter here: OP's chain can
+    report a vanishing residual (e.g. after ``arnoldi_extend`` gives up
+    re-orthogonalizing and hard-zeros its own residual, or once the
+    Krylov basis V has numerically drifted from orthonormality after
+    several restarts) for a candidate that is nowhere near an actual
+    eigenvector of H, which silently corrupted ~20% of trials in testing
+    (e.g. a 4-site non-Hermitian degeneracy count landing on 1 instead of
+    the true 2) before this genuine-residual check was added. Also
+    guards against a reconstruction with collapsed (numerically zero)
+    norm directly (rather than letting the ``wf.normalize()`` inside
+    ``krylov.unitary_transformation`` return ``None`` and crash on the
+    next ``.copy()``): treated as unconverged during the loop, and raised
+    as a clear error if it persists at the very end.
     """
     if wfskip is None: wfskip = []
     else: wfskip = list(wfskip)
@@ -325,10 +353,33 @@ def mpsiram_shift_invert(self, H, e=0.0, nev=1, ncv=None, delta=1e-3,
     ncv = max(ncv, nev + 2)
     Mi = H - e
     Op = lambda x: self.applyinverse(Mi, x, delta=delta, maxn=maxn)
+    MH = self.toMPO(H, mode=arnolditk.arnoldimode)
 
     def fe_target(es):
         es = np.abs(es - e)
         return np.where(es == np.min(es))[0][0]
+
+    def candidates(V):
+        Htrue = krylov_matrix_representation(H, V)
+        ritz_true, vs_true = krylov_diagonalize(Htrue)
+        nsel = min(nev, len(V))
+        estore, vstore = krylov_select_states(ritz_true, vs_true.T,
+                fe_target, ne=nsel)
+        wfs, errs = [], []
+        for theta, y in zip(estore, vstore):
+            wf = np.conjugate(y[0]) * V[0]
+            for i in range(1, len(V)):
+                wf = wf + np.conjugate(y[i]) * V[i]
+            nrm = np.sqrt(abs(wf.dot(wf)))
+            if nrm < 1e-8: # collapsed reconstruction: certainly not converged
+                wfs.append(None)
+                errs.append(np.inf)
+                continue
+            wf = wf * (1. / nrm)
+            r = MH * wf - theta * wf
+            errs.append(np.sqrt(abs(r.dot(r))))
+            wfs.append(wf)
+        return np.array(estore), wfs, np.array(errs)
 
     kev = nev
     resid = random_state(self, orthogonal=wfskip if wfskip else None)
@@ -337,47 +388,90 @@ def mpsiram_shift_invert(self, H, e=0.0, nev=1, ncv=None, delta=1e-3,
     V, Hm, resid, rnorm = arnoldi_extend(self, Op, V, Hm, resid, rnorm,
             0, kev, wfskip=wfskip, verbose=verbose)
 
+    estore = wfs_cand = errs = None
     for it in range(maxiter):
         npcur = ncv - kev
         if npcur > 0:
             V, Hm, resid, rnorm = arnoldi_extend(self, Op, V, Hm, resid,
                     rnorm, kev, npcur, wfskip=wfskip, verbose=verbose)
 
-        Htrue = krylov_matrix_representation(H, V)
-        ritz_true, vs_true = krylov_diagonalize(Htrue)
-        nsel = min(nev, len(V))
-        estore, vstore = krylov_select_states(ritz_true, vs_true.T,
-                fe_target, ne=nsel)
-        error = np.array([np.abs(rnorm * v0[-1]) for v0 in vstore])
-        nconv = int(np.sum(error <= delta))
+        estore, wfs_cand, errs = candidates(V)
+        nconv = int(np.sum(errs <= delta))
 
         if verbose > 0:
             print("ShiftInv IRAM iter", it, "kev", kev, "nconv", nconv,
-                    "ritz", np.round(estore, 6), "error", np.round(error, 6))
+                    "ritz", np.round(estore, 6), "error", np.round(errs, 6))
 
         np_apply = ncv - kev
         if nconv >= nev or np_apply == 0:
             break
 
-        ritz_op, bounds_op, _ = hessenberg_ritz(Hm, rnorm)
-        order_op = np.argsort(_goodness("LM", ritz_op))
-        ritz_op, bounds_op = ritz_op[order_op], bounds_op[order_op]
+        # stagnation-avoidance: temporarily grow kev, mirroring mpsiram's
+        # own heuristic, since the same repeatedly-shifted-away
+        # near-converged directions can stall this loop too
+        if nconv > 0:
+            bump = min(nconv, np_apply // 2)
+            if bump > 0:
+                kev = min(kev + bump, ncv - 2)
+        np_apply = ncv - kev
 
-        shifts = ritz_op[:np_apply]
-        shift_bounds = bounds_op[:np_apply]
-        shift_order = np.argsort(-np.abs(shift_bounds))
-        shifts = shifts[shift_order]
+        ritz_op, bounds_op, _ = hessenberg_ritz(Hm, rnorm)
+        ritz_op, bounds_op = sort_ritz("LM", ritz_op, bounds_op)
+        shifts = select_shifts(ritz_op, bounds_op, np_apply)
 
         V, Hm, resid, rnorm = apply_shifts(V, Hm, resid, shifts, kev)
+        estore = wfs_cand = errs = None # V changed: last candidates() is stale
 
-    Htrue = krylov_matrix_representation(H, V)
-    ritz_true, vs_true = krylov_diagonalize(Htrue)
-    nsel = min(nev, len(V))
-    estore, vstore = krylov_select_states(ritz_true, vs_true.T,
-            fe_target, ne=nsel)
-    wfs = krylov_unitary_transformation(vstore, V)
-    es = np.array([wf.aMb(H, wf) for wf in wfs])
-    return es, wfs
+    if estore is None: # loop ran out of maxiter right after a restart
+        estore, wfs_cand, errs = candidates(V)
+    if any(wf is None for wf in wfs_cand):
+        raise RuntimeError(
+            "mpsiram_shift_invert: a requested eigenvector reconstruction "
+            "collapsed to numerically zero norm (the Krylov basis lost "
+            "orthonormality after too many restarts) -- retry with a "
+            "larger ncv, fewer nev, or a tighter maxn/delta for the "
+            "correction-vector solve")
+    return estore, wfs_cand
+
+
+def shift_invert_excited_states(self, H, e=0.0, nwf=1, wfskip=None, **kwargs):
+    """Find nwf eigenvalues closest to `e`, one at a time, each deflated
+    against the previously found ones via wfskip -- generally more
+    reliable than a single simultaneous multi-target search (nev=nwf in
+    one mpsiram_shift_invert call), exactly like excited_states' own
+    recursive=True default for the non-shift-invert search (see its
+    docstring): a shared Krylov subspace across several targets can fail
+    to resolve near-degenerate clusters.
+
+    Caveat specific to deflation for non-Hermitian H: the wfskip
+    mechanism removes a candidate's overlap with already-found states
+    using the plain Hermitian inner product (``.dot()``), the same
+    mechanism arnolditk's own wfskip uses. That is only a rigorous
+    orthogonal projection when the eigenvectors involved are mutually
+    orthogonal -- true for a Hermitian H, *not* guaranteed for a
+    non-Hermitian one, whose right eigenvectors for distinct eigenvalues
+    need not be orthogonal under the standard inner product (only
+    biorthogonal with the *left* eigenvectors are, which this deflation
+    does not use). Confirmed directly: for an exact complex-conjugate
+    degenerate ground-state pair, |<v1|v2>| ~= 0.40, and recursive
+    deflation still would not reliably resolve the exact partner of an
+    already-found member (it reliably lands on *some* other genuine
+    eigenvalue, just not necessarily that specific one) -- a structural
+    limitation of this (and arnolditk's) deflation approach for
+    non-orthogonal clusters, not something one-at-a-time search alone
+    fixes. Genuinely reliable resolution of such pairs would need
+    biorthogonal deflation (using left eigenvectors too, as NH-DMRG
+    does) -- out of scope here."""
+    if wfskip is None: wfskip = []
+    else: wfskip = list(wfskip)
+    eout, wfout = [], []
+    for i in range(nwf):
+        es, wfs = mpsiram_shift_invert(self, H, e=e, nev=1, wfskip=wfskip,
+                **kwargs)
+        eout.append(es[0])
+        wfout.append(wfs[0])
+        wfskip.append(wfs[0])
+    return np.array(eout), wfout
 
 
 def excited_states(self, H, nwf=1, which="SR", recursive=True,

--- a/src/dmrgpy/algebra/arpacktk.py
+++ b/src/dmrgpy/algebra/arpacktk.py
@@ -51,16 +51,31 @@ Ported pieces, and their ARPACK sources:
                       convergence, adjust kev to avoid stagnation exactly
                       as znaup2 does, restart, repeat)
 
-This is the *matrix-free, mode-1* subset of ARPACK (OP=A, B=I; no
-reverse communication, no B-inner product) -- everything dmrgpy's own
-MPS/ED objects need (``self.random_mps()``/``EDchain``, ``.dot()``,
-``.normalize()``, ``.copy()``, ``+``/``-``/scalar ``*``) and nothing
-more -- plus ``mpsiram_shift_invert``, a shift-invert mode (ARPACK's
-mode 3, OP=inv(A-sigma*I), B=I) adapted to dmrgpy's only *approximate*
-matrix inverse (``self.applyinverse``, an iterative correction-vector
-solve, not an exact linear solve) -- see its own docstring for how that
-changes the convergence/selection machinery relative to ARPACK's own
-mode-3 assumption of an exact inverse.
+The core (``mpsiram``) is the *matrix-free, mode-1* subset of ARPACK
+(OP=A, B=I; no reverse communication, no B-inner product) -- everything
+dmrgpy's own MPS/ED objects need (``self.random_mps()``/``EDchain``,
+``.dot()``, ``.normalize()``, ``.copy()``, ``+``/``-``/scalar ``*``) and
+nothing more. Two more ARPACK modes build on it:
+
+  ``mpsiram_shift_invert`` -- ARPACK mode 3, OP=inv(A-sigma*I), B=I,
+  adapted to dmrgpy's only *approximate* matrix inverse
+  (``self.applyinverse``, an iterative correction-vector solve, not an
+  exact linear solve) -- see its own docstring for how that changes the
+  convergence/selection machinery relative to ARPACK's own mode-3
+  assumption of an exact inverse.
+
+  ``mpsiram_generalized`` -- ARPACK mode 2, the generalized eigenproblem
+  A*x=lambda*M*x (OP=inv(M)*A, B=M): the Krylov basis must be
+  orthonormal in the M-weighted inner product <u,v>_M=<u|M|v> instead of
+  the plain one, so it uses a separate ``arnoldi_extend_generalized``
+  rather than ``arnoldi_extend`` (see that function's own docstring for
+  why it's kept separate rather than adding a conditional B to
+  ``arnoldi_extend`` itself). Reuses ``self.applyinverse`` too (the same
+  approximate-inverse caveat as mode 3 applies, here with the trivial
+  shift sigma=0), but -- unlike mode 3 -- OP's own Hessenberg matrix
+  eigenvalues remain directly meaningful (no shift to untransform
+  through), so convergence/selection stay on the standard ``mpsiram``
+  pattern, just built with the M-inner product.
 """
 import numpy as np
 
@@ -151,6 +166,77 @@ def arnoldi_extend(self, Op, V, H, resid, rnorm, k, npsteps,
     return Vout, Hnew, resid, beta
 
 
+def arnoldi_extend_generalized(self, Op, B, V, H, resid, rnorm, k, npsteps,
+        wfskip=None, verbose=0):
+    """Generalized-inner-product counterpart of arnoldi_extend, for
+    ARPACK mode 2 (A*x=lambda*M*x, M Hermitian positive definite,
+    OP=inv(M)*A, B=M): the identical classical-Gram-Schmidt-with-
+    iterative-refinement algorithm, but every inner product/norm uses
+    <u,v>_B = <u|B|v> instead of the plain <u|v>, matching mode 2's
+    B-orthogonal Krylov basis (V^H*B*V=I) rather than mode 1/3's plain
+    orthogonal one (B=I). Kept as a separate function rather than adding
+    an optional B to arnoldi_extend itself (mirroring how
+    mpsiram_shift_invert is a separate function from mpsiram, not a
+    branch inside it): the extra per-inner-product B-application this
+    needs throughout would otherwise have to be threaded past every one
+    of arnoldi_extend's .dot() calls behind a conditional, for no benefit
+    to the already-tested, B=I-only mode-1/mode-3 callers. B is applied
+    fresh wherever needed here (no incremental linear-combination
+    caching of B images, unlike e.g. the Ritz-estimate bookkeeping
+    elsewhere) -- simpler to verify correct at the cost of a few extra
+    (cheap MPO-application-class, not full Op(x)-class) B-evaluations
+    per Krylov step, acceptable for a mode with no established dmrgpy
+    call site yet to optimize against."""
+    def bdot(u, v): return u.dot(B(v))
+    if wfskip is None: wfskip = []
+    kplusp = k + npsteps
+    Hnew = np.zeros((kplusp, kplusp), dtype=complex)
+    if k > 0: Hnew[:k, :k] = H
+    Vout = list(V)
+    beta = rnorm
+    for j in range(k, kplusp):
+        if beta < 1e-12:
+            if verbose > 0:
+                print("arnoldi_extend_generalized: invariant subspace, restarting")
+            resid = random_state(self, orthogonal=Vout + wfskip)
+            beta = np.sqrt(abs(bdot(resid, resid)))
+        vj = resid * (1. / beta)
+        Vout.append(vj)
+        w = Op(vj)
+        if wfskip:
+            for s in wfskip:
+                w = w - bdot(s, w) * s
+        coeffs = np.array([bdot(Vout[i], w) for i in range(j + 1)], dtype=complex)
+        r = w
+        for i in range(j + 1): r = r - coeffs[i] * Vout[i]
+        if j > 0: Hnew[j, j - 1] = beta
+        Hnew[:j + 1, j] = coeffs
+        wnorm = np.sqrt(abs(bdot(w, w)))
+        rnorm1 = np.sqrt(abs(bdot(r, r)))
+        if wnorm > 0 and rnorm1 <= 0.717 * wnorm:
+            # iterative refinement, same 0.717/2-try policy as arnoldi_extend
+            converged = False
+            for _try in range(2):
+                if wfskip:
+                    for s in wfskip:
+                        r = r - bdot(s, r) * s
+                s = np.array([bdot(Vout[i], r) for i in range(j + 1)], dtype=complex)
+                for i in range(j + 1): r = r - s[i] * Vout[i]
+                Hnew[:j + 1, j] += s
+                rnorm2 = np.sqrt(abs(bdot(r, r)))
+                prev = rnorm1
+                rnorm1 = rnorm2
+                if rnorm2 > 0.717 * prev:
+                    converged = True
+                    break
+            if not converged:
+                r = r * 0.0
+                rnorm1 = 0.0
+        resid = r
+        beta = rnorm1
+    return Vout, Hnew, resid, beta
+
+
 def hessenberg_ritz(H, rnorm):
     """Port of zneigh: eigenvalues of the (small, dense) Hessenberg
     matrix H and their Ritz estimates (= rnorm * |last eigenvector
@@ -186,10 +272,15 @@ def select_shifts(ritz, bounds, np_apply):
     return shifts[order]
 
 
-def apply_shifts(V, H, resid, shifts, kev):
+def apply_shifts(V, H, resid, shifts, kev, B=None):
     """Port of znapps (see module docstring for why dense QR replaces the
     bulge chase): compress a length len(V) Arnoldi factorization down to
-    length kev by applying the given shifts."""
+    length kev by applying the given shifts. B (optional): the ARPACK
+    mode-2/generalized inner-product weight (B=None, the default, is
+    mode 1/3's B=I) -- only affects the final residual norm, since the
+    rest of this routine is pure dense linear algebra on the Hessenberg
+    matrix plus linear combinations of V, agnostic to which inner
+    product built them."""
     kplusp = H.shape[0]
     Hc = H.copy()
     Q = np.eye(kplusp, dtype=complex)
@@ -210,7 +301,8 @@ def apply_shifts(V, H, resid, shifts, kev):
     if abs(betak) > 1e-13:
         resid_new = resid_new + betak * Vnew[kev]
     Hnew = Hc[:kev, :kev].copy()
-    rnorm_new = np.sqrt(abs(resid_new.dot(resid_new)))
+    Bresid = resid_new if B is None else B(resid_new)
+    rnorm_new = np.sqrt(abs(resid_new.dot(Bresid)))
     return Vnew[:kev], Hnew, resid_new, rnorm_new
 
 
@@ -468,6 +560,128 @@ def shift_invert_excited_states(self, H, e=0.0, nwf=1, wfskip=None, **kwargs):
     for i in range(nwf):
         es, wfs = mpsiram_shift_invert(self, H, e=e, nev=1, wfskip=wfskip,
                 **kwargs)
+        eout.append(es[0])
+        wfout.append(wfs[0])
+        wfskip.append(wfs[0])
+    return np.array(eout), wfout
+
+
+def mpsiram_generalized(self, A, M, which="SR", nev=1, ncv=None, tol=1e-8,
+        maxiter=200, delta=1e-3, maxn=20, verbose=0, wfskip=None):
+    """Generalized-eigenvalue IRAM (ARPACK mode 2: A*x = lambda*M*x, M
+    Hermitian positive definite, OP=inv(M)*A, B=M), finding the nev
+    eigenpairs selected by `which` ({LM,SM,LR,SR,LI,SI}, same convention
+    as mpsiram).
+
+    OP(x) applies A, then the approximate inv(M) via
+    self.applyinverse(M, A*x, delta, maxn) -- the identical iterative
+    correction-vector solve mpsiram_shift_invert already uses for
+    inv(A-sigma*M), here with the trivial shift sigma=0 (dmrgpy has no
+    exact MPO inverse, same caveat as mode 3). Unlike mode 1/3 (B=I),
+    the Krylov basis here must be orthonormal in the M-weighted inner
+    product <u,v>_M = <u|M|v>, not the plain Hermitian one -- see
+    arnoldi_extend_generalized. Because OP is only approximate, its own
+    Hessenberg matrix's eigenvalues are still directly meaningful here
+    (unlike mode 3): mode 2 has no shift to untransform through, OP's
+    eigenvalues approximate A's own generalized eigenvalues directly
+    (OP=inv(M)*A, so an exact OP would have exactly A's eigenvalues), so
+    the standard mpsiram-style convergence/selection (on OP's own
+    Hessenberg matrix) is used, just built with the M-inner product.
+
+    Returns (es, wfs): es are the generalized Rayleigh quotient
+    <wf|A|wf>/<wf|M|wf> -- invariant under wf's overall scale, so this
+    is correct regardless of which normalization convention wfs
+    themselves carry. wfs are plain-normalized (<wf|wf>=1, the same
+    convention every other wavefunction in this codebase uses, *not*
+    M-normalized), MPS/ED-state linear combinations of the final Krylov
+    basis, ordered most-wanted-first.
+    """
+    if wfskip is None: wfskip = []
+    if ncv is None: ncv = 2 * nev + 4
+    ncv = max(ncv, nev + 2)
+    MA = self.toMPO(A, mode=arnolditk.arnoldimode)
+    MM = self.toMPO(M, mode=arnolditk.arnoldimode)
+    Op = lambda x: self.applyinverse(M, MA * x, delta=delta, maxn=maxn)
+    B = lambda x: MM * x
+
+    eps23 = np.finfo(float).eps ** (2. / 3.)
+    kev = nev
+    resid = random_state(self, orthogonal=wfskip if wfskip else None)
+    rnorm = np.sqrt(abs(resid.dot(B(resid)))) # true M-norm, not assumed 1
+    V, Hm = [], np.zeros((0, 0), dtype=complex)
+    V, Hm, resid, rnorm = arnoldi_extend_generalized(self, Op, B, V, Hm,
+            resid, rnorm, 0, kev, wfskip=wfskip, verbose=verbose)
+
+    for it in range(maxiter):
+        npcur = ncv - kev
+        if npcur > 0:
+            V, Hm, resid, rnorm = arnoldi_extend_generalized(self, Op, B,
+                    V, Hm, resid, rnorm, kev, npcur, wfskip=wfskip,
+                    verbose=verbose)
+
+        ritz, bounds, Y = hessenberg_ritz(Hm, rnorm)
+        ritz, bounds = sort_ritz(which, ritz, bounds)
+
+        np_apply = ncv - kev
+        wanted_ritz = ritz[np_apply:]
+        wanted_bounds = bounds[np_apply:]
+        scale = np.maximum(eps23, np.abs(wanted_ritz))
+        nconv = int(np.sum(wanted_bounds <= tol * scale))
+
+        if verbose > 0:
+            print("Generalized IRAM iter", it, "kev", kev, "nconv", nconv,
+                    "ritz", np.round(wanted_ritz, 6))
+
+        if nconv >= nev or np_apply == 0:
+            break
+
+        if nconv > 0:
+            bump = min(nconv, np_apply // 2)
+            if bump > 0:
+                kev = min(kev + bump, ncv - 2)
+
+        np_apply = ncv - kev
+        shifts = select_shifts(ritz, bounds, np_apply)
+        V, Hm, resid, rnorm = apply_shifts(V, Hm, resid, shifts, kev, B=B)
+
+    ritz, bounds, Y = hessenberg_ritz(Hm, rnorm)
+    order = np.argsort(_goodness(which, ritz))
+    ritz, Y = ritz[order], Y[:, order]
+    nsel = min(nev, Hm.shape[0])
+    Y_sel = Y[:, -nsel:]
+
+    wfs = []
+    for i in range(nsel):
+        y = Y_sel[:, i]
+        wf = y[0] * V[0]
+        for j in range(1, len(V)):
+            wf = wf + y[j] * V[j]
+        wfs.append(wf.normalize())
+    es = np.array([wf.aMb(A, wf) / wf.aMb(M, wf) for wf in wfs])
+    return es[::-1], wfs[::-1]
+
+
+def generalized_excited_states(self, A, M, nwf=1, which="SR", recursive=True,
+        wfskip=None, **kwargs):
+    """Find nwf generalized eigenpairs (A*x=lambda*M*x), either
+    recursively -- one at a time, each deflated against the previously
+    found ones via wfskip -- or as a single simultaneous block IRAM
+    search (nev=nwf in one mpsiram_generalized call). Mirrors
+    excited_states' own recursive toggle; see its docstring and
+    shift_invert_excited_states' docstring for the same caveat about
+    .dot()-based deflation not being rigorous for non-Hermitian A."""
+    if wfskip is None: wfskip = []
+    else: wfskip = list(wfskip)
+    if nwf == 1:
+        return mpsiram_generalized(self, A, M, which=which, nev=1,
+                wfskip=wfskip, **kwargs)
+    if not recursive:
+        return mpsiram_generalized(self, A, M, which=which, nev=nwf,
+                wfskip=wfskip, **kwargs)
+    eout, wfout = [], []
+    for i in range(nwf):
+        es, wfs = mpsiram_generalized(self, A, M, which=which, nev=1,
+                wfskip=wfskip, **kwargs)
         eout.append(es[0])
         wfout.append(wfs[0])
         wfskip.append(wfs[0])

--- a/src/dmrgpy/algebra/arpacktk.py
+++ b/src/dmrgpy/algebra/arpacktk.py
@@ -272,6 +272,31 @@ def mpsiram(self, H, which="SR", nev=1, ncv=None, tol=1e-8, maxiter=200,
     return es[::-1], wfs[::-1]
 
 
+def excited_states(self, H, nwf=1, which="SR", recursive=True,
+        wfskip=None, **kwargs):
+    """Find nwf eigenpairs of H, either recursively -- one at a time,
+    each deflated against the previously found ones via wfskip -- or as
+    a single simultaneous block IRAM search (nev=nwf in one call).
+    Mirrors arnolditk's own recursive_arnoldi toggle: recursive is safer
+    on (near-)degenerate spectra, since each state gets its own
+    independently-seeded restart cycle rather than sharing one Krylov
+    subspace across all nwf targets, at the cost of nwf independent
+    restarts instead of one."""
+    if wfskip is None: wfskip = []
+    else: wfskip = list(wfskip)
+    if nwf == 1:
+        return mpsiram(self, H, which=which, nev=1, wfskip=wfskip, **kwargs)
+    if not recursive:
+        return mpsiram(self, H, which=which, nev=nwf, wfskip=wfskip, **kwargs)
+    eout, wfout = [], []
+    for i in range(nwf):
+        es, wfs = mpsiram(self, H, which=which, nev=1, wfskip=wfskip, **kwargs)
+        eout.append(es[0])
+        wfout.append(wfs[0])
+        wfskip.append(wfs[0])
+    return np.array(eout), wfout
+
+
 def lowest_energy_non_hermitian(self, H, n=1, **kwargs):
     """Smallest-real-part eigenpairs of a (possibly non-Hermitian) H via
     IRAM -- drop-in comparison point for

--- a/src/dmrgpy/degeneracy.py
+++ b/src/dmrgpy/degeneracy.py
@@ -41,13 +41,25 @@ def gs_degeneracy_simple(self,dmode="real",delta=1e-2,n=1,**kwargs):
 
 def eigenvalue_degeneracy(self,A,e,n=3,emode="real",delta=1e-2):
     """Given an operator and a certain eigenvalue, estimate
-    what is the degeneracy"""
+    what is the degeneracy.
+
+    For a non-Hermitian A, an exactly-degenerate cluster whose right
+    eigenvectors are not mutually orthogonal (e.g. a complex-conjugate
+    pair -- confirmed possible with substantial overlap, |<v1|v2>| of
+    order 0.4, not merely a small numerical artifact) can be undercounted:
+    the underlying deflation is only a heuristic there, not a rigorous
+    orthogonal projection -- see shift_invert_excited_states's docstring.
+    """
     # shift-invert IRAM (ARPACK mode 3, adapted for dmrgpy's only
     # approximate applyinverse -- see arpacktk.mpsiram_shift_invert's
-    # docstring)
-    from .algebra.arpacktk import mpsiram_shift_invert
+    # docstring), one eigenvalue at a time with deflation
+    # (shift_invert_excited_states): this routine's whole purpose is
+    # resolving (near-)degenerate clusters near e, which a single
+    # simultaneous multi-target search can fail to do (see
+    # shift_invert_excited_states's own docstring).
+    from .algebra.arpacktk import shift_invert_excited_states
     while True: # this is mostly a DMRG implementation
-        es,ws = mpsiram_shift_invert(self,A,e=e,delta=delta,nev=n+2,
+        es,ws = shift_invert_excited_states(self,A,e=e,delta=delta,nwf=n+2,
             maxiter=20,verbose=1)
         if emode=="real":
             emin = np.min(es.real) # ground state energy

--- a/src/dmrgpy/degeneracy.py
+++ b/src/dmrgpy/degeneracy.py
@@ -42,6 +42,12 @@ def gs_degeneracy_simple(self,dmode="real",delta=1e-2,n=1,**kwargs):
 def eigenvalue_degeneracy(self,A,e,n=3,emode="real",delta=1e-2):
     """Given an operator and a certain eigenvalue, estimate
     what is the degeneracy"""
+    # mode="ShiftInv" needs an operator that is only an *approximate*
+    # inverse of (A-e) (self.applyinverse, an iterative correction-vector
+    # solve) -- algebra/arpacktk.py only implements ARPACK's mode-1
+    # (standard eigenproblem, Op=A) IRAM, not the shift-invert modes
+    # (ARPACK modes 2-4), so this stays on arnolditk's own op_is_affine=
+    # False path, which already handles a non-affine Op correctly.
     from .algebra.arnolditk import mpsarnoldi
     while True: # this is mostly a DMRG implementation
         es,ws = mpsarnoldi(self,A,e=e,delta=delta,mode="ShiftInv",

--- a/src/dmrgpy/degeneracy.py
+++ b/src/dmrgpy/degeneracy.py
@@ -42,18 +42,13 @@ def gs_degeneracy_simple(self,dmode="real",delta=1e-2,n=1,**kwargs):
 def eigenvalue_degeneracy(self,A,e,n=3,emode="real",delta=1e-2):
     """Given an operator and a certain eigenvalue, estimate
     what is the degeneracy"""
-    # mode="ShiftInv" needs an operator that is only an *approximate*
-    # inverse of (A-e) (self.applyinverse, an iterative correction-vector
-    # solve) -- algebra/arpacktk.py only implements ARPACK's mode-1
-    # (standard eigenproblem, Op=A) IRAM, not the shift-invert modes
-    # (ARPACK modes 2-4), so this stays on arnolditk's own op_is_affine=
-    # False path, which already handles a non-affine Op correctly.
-    from .algebra.arnolditk import mpsarnoldi
+    # shift-invert IRAM (ARPACK mode 3, adapted for dmrgpy's only
+    # approximate applyinverse -- see arpacktk.mpsiram_shift_invert's
+    # docstring)
+    from .algebra.arpacktk import mpsiram_shift_invert
     while True: # this is mostly a DMRG implementation
-        es,ws = mpsarnoldi(self,A,e=e,delta=delta,mode="ShiftInv",
-            recursive_arnoldi=False,nwf=n+2,n0=0,
-            verbose=1,maxit=20,nkry_min = 2*n
-            )
+        es,ws = mpsiram_shift_invert(self,A,e=e,delta=delta,nev=n+2,
+            maxiter=20,verbose=1)
         if emode=="real":
             emin = np.min(es.real) # ground state energy
             des = np.abs(es.real-emin)**2 # distance to the minimum energy

--- a/src/dmrgpy/excited.py
+++ b/src/dmrgpy/excited.py
@@ -109,7 +109,7 @@ from .algebra.arnolditk import gram_smith
 
 
 def excited_states_non_hermitian(self,n=3,recursive=True,
-        maxit=40,ncv=None,
+        maxit=40,ncv=10,
      **kwargs):
     # recursive=True (one state at a time, each deflated against the
     # previous ones) is the default rather than a single simultaneous
@@ -127,13 +127,20 @@ def excited_states_non_hermitian(self,n=3,recursive=True,
     # see examples/non_hermitian/arnoldi_vs_iram_benchmark. arnolditk
     # remains available directly (mpsalgebra.mpsarnoldi) for comparison
     # or for the ShiftInv/projected-operator modes IRAM does not support.
+    # ncv=10 restores the same Krylov-subspace margin the old
+    # arnolditk-based call explicitly used (nkry_max=10, wider than
+    # arnolditk's own generic default of ne+4=6 for the recursive ne=1
+    # search) -- IRAM's own generic default (2*nev+4) would silently
+    # shrink this back down to 6 for the common recursive n=1-per-call
+    # case, right where the near-degenerate-safe extra margin matters
+    # most.
     from .algebra import arpacktk
     (es,wf) = arpacktk.excited_states(self,self.hamiltonian,
                 nwf=n, # number of wavefunctions
                 which="SR", # smallest real part = "ground state" convention
                 recursive=recursive, # recursive?
                 maxiter = maxit, # max number of IRAM restart cycles
-                ncv = ncv, # Krylov subspace size (None -> IRAM default)
+                ncv = ncv, # Krylov subspace size
                 **kwargs)
     from .algebra.algebra import sorteigen
     es,wf = sorteigen(es,wf)

--- a/src/dmrgpy/excited.py
+++ b/src/dmrgpy/excited.py
@@ -109,24 +109,31 @@ from .algebra.arnolditk import gram_smith
 
 
 def excited_states_non_hermitian(self,n=3,recursive=True,
-        maxit=40,nkry_min =3,nkry_max =10,
+        maxit=40,ncv=None,
      **kwargs):
     # recursive=True (one state at a time, each deflated against the
     # previous ones) is the default rather than a single simultaneous
-    # (n>1) Arnoldi search: a shared Krylov subspace across several
+    # (n>1) IRAM search: a shared Krylov subspace across several
     # requested eigenvalues can fail to resolve a (near-)degenerate pair
     # -- confirmed on a non-Hermitian chain with a 2-fold-degenerate
     # excited state, where the simultaneous search converged to two
     # spurious values instead. The one-at-a-time search is slower but
     # reliable, since each state gets its own warm start explicitly
-    # deflated against the others.
-    from . import mpsalgebra
-    (es,wf) = mpsalgebra.mpsarnoldi(self,self.hamiltonian,mode="GS",
+    # deflated against the others. Default solver is now the Implicitly
+    # Restarted Arnoldi Method (algebra/arpacktk.py, ported from ARPACK)
+    # rather than arnolditk's explicit-restart Arnoldi: IRAM reuses its
+    # compressed Krylov subspace across restarts instead of rebuilding it
+    # from scratch, needing fewer H|psi> applications on most spectra --
+    # see examples/non_hermitian/arnoldi_vs_iram_benchmark. arnolditk
+    # remains available directly (mpsalgebra.mpsarnoldi) for comparison
+    # or for the ShiftInv/projected-operator modes IRAM does not support.
+    from .algebra import arpacktk
+    (es,wf) = arpacktk.excited_states(self,self.hamiltonian,
                 nwf=n, # number of wavefunctions
-                recursive_arnoldi=recursive, # recursive?
-                maxit = maxit, # max number of Arnoldi iterations
-                nkry_min = nkry_min, # minimum number of Krylov vectors
-                nkry_max = nkry_max, # maximum number of Krylov vectors
+                which="SR", # smallest real part = "ground state" convention
+                recursive=recursive, # recursive?
+                maxiter = maxit, # max number of IRAM restart cycles
+                ncv = ncv, # Krylov subspace size (None -> IRAM default)
                 **kwargs)
     from .algebra.algebra import sorteigen
     es,wf = sorteigen(es,wf)

--- a/src/dmrgpy/excited.py
+++ b/src/dmrgpy/excited.py
@@ -109,7 +109,7 @@ from .algebra.arnolditk import gram_smith
 
 
 def excited_states_non_hermitian(self,n=3,recursive=True,
-        maxit=40,ncv=10,
+        maxit=40,ncv=10,nkry_min=None,nkry_max=None,
      **kwargs):
     # recursive=True (one state at a time, each deflated against the
     # previous ones) is the default rather than a single simultaneous
@@ -134,6 +134,16 @@ def excited_states_non_hermitian(self,n=3,recursive=True,
     # shrink this back down to 6 for the common recursive n=1-per-call
     # case, right where the near-degenerate-safe extra margin matters
     # most.
+    # nkry_min/nkry_max are accepted only for backward compatibility with
+    # the old arnolditk-based signature (an adaptive Krylov-size range) --
+    # any caller that used to pass them explicitly would otherwise now
+    # hit a TypeError several calls deep (they'd flow through **kwargs
+    # into mpsiram, which has no catch-all). IRAM has no equivalent
+    # adaptive range, only a single fixed ncv per restart cycle, so
+    # nkry_max (the closest matching concept, the "widest" Krylov size
+    # arnolditk would ever grow to) overrides ncv when given; nkry_min
+    # has no equivalent and is accepted but otherwise unused.
+    if nkry_max is not None: ncv = nkry_max
     from .algebra import arpacktk
     (es,wf) = arpacktk.excited_states(self,self.hamiltonian,
                 nwf=n, # number of wavefunctions

--- a/src/dmrgpy/fermionchain.py
+++ b/src/dmrgpy/fermionchain.py
@@ -556,9 +556,15 @@ class Spinon_Chain(Spinful_Fermionic_Chain):
         """Redefine the ground state method"""
         if self.computed_gs: return self.wf0 # return the wavefunction
         P = 1. # parton projector
-        for i in range(len(self.Sx)): 
+        for i in range(len(self.Sx)):
             P = P*(-2*self.Nup[i]*self.Ndn[i] + self.Ndn[i] + self.Nup[i])
             #P = P*(1.- self.Nup[i]*self.Ndn[i]) #  Gutzwiller projection
+        # kept on arnolditk: this bakes the projector P directly into the
+        # Krylov operator (Op = M*(P*x)), a mode algebra/arpacktk.py's
+        # IRAM does not support. Also confirmed independently broken
+        # ("'NoneType' object has no attribute 'build_operator'", raised
+        # before this call is even reached) -- pre-existing, unrelated to
+        # the solver choice, not fixed here.
         from .mpsalgebra import mpsarnoldi
         super().gs_energy(**kwargs) # get the GS
         wf = self.wf0

--- a/src/dmrgpy/mpsalgebra.py
+++ b/src/dmrgpy/mpsalgebra.py
@@ -181,6 +181,7 @@ from .algebra.arpacktk import lowest_energy as lowest_energy_iram
 from .algebra.arpacktk import lowest_energy_non_hermitian as lowest_energy_non_hermitian_iram
 from .algebra.arpacktk import excited_states as mps_excited_states
 from .algebra.arpacktk import mpsiram_shift_invert
+from .algebra.arpacktk import shift_invert_excited_states
 
 # IRAM (algebra/arpacktk.py, ported from ARPACK) is the default MPS
 # Arnoldi solver: it reuses its compressed Krylov subspace across

--- a/src/dmrgpy/mpsalgebra.py
+++ b/src/dmrgpy/mpsalgebra.py
@@ -180,6 +180,7 @@ from .algebra.arpacktk import mpsiram
 from .algebra.arpacktk import lowest_energy as lowest_energy_iram
 from .algebra.arpacktk import lowest_energy_non_hermitian as lowest_energy_non_hermitian_iram
 from .algebra.arpacktk import excited_states as mps_excited_states
+from .algebra.arpacktk import mpsiram_shift_invert
 
 # IRAM (algebra/arpacktk.py, ported from ARPACK) is the default MPS
 # Arnoldi solver: it reuses its compressed Krylov subspace across

--- a/src/dmrgpy/mpsalgebra.py
+++ b/src/dmrgpy/mpsalgebra.py
@@ -182,6 +182,8 @@ from .algebra.arpacktk import lowest_energy_non_hermitian as lowest_energy_non_h
 from .algebra.arpacktk import excited_states as mps_excited_states
 from .algebra.arpacktk import mpsiram_shift_invert
 from .algebra.arpacktk import shift_invert_excited_states
+from .algebra.arpacktk import mpsiram_generalized
+from .algebra.arpacktk import generalized_excited_states
 
 # IRAM (algebra/arpacktk.py, ported from ARPACK) is the default MPS
 # Arnoldi solver: it reuses its compressed Krylov subspace across

--- a/src/dmrgpy/mpsalgebra.py
+++ b/src/dmrgpy/mpsalgebra.py
@@ -176,6 +176,10 @@ from .algebra.arnolditk import lowest_energy as lowest_energy_arnoldi
 from .algebra.arnolditk import lowest_energy_non_hermitian as lowest_energy_non_hermitian_arnoldi
 from .algebra.arnolditk import gram_smith_single
 
+from .algebra.arpacktk import mpsiram
+from .algebra.arpacktk import lowest_energy as lowest_energy_iram
+from .algebra.arpacktk import lowest_energy_non_hermitian as lowest_energy_non_hermitian_iram
+
 
 def toMPO(self,H,mode="DMRG"):
     """Transport an operator into a matrix-product operator"""

--- a/src/dmrgpy/mpsalgebra.py
+++ b/src/dmrgpy/mpsalgebra.py
@@ -179,6 +179,17 @@ from .algebra.arnolditk import gram_smith_single
 from .algebra.arpacktk import mpsiram
 from .algebra.arpacktk import lowest_energy as lowest_energy_iram
 from .algebra.arpacktk import lowest_energy_non_hermitian as lowest_energy_non_hermitian_iram
+from .algebra.arpacktk import excited_states as mps_excited_states
+
+# IRAM (algebra/arpacktk.py, ported from ARPACK) is the default MPS
+# Arnoldi solver: it reuses its compressed Krylov subspace across
+# restarts instead of rebuilding it from scratch, needing fewer H|psi>
+# applications than arnolditk's explicit-restart Arnoldi on most spectra
+# -- see examples/non_hermitian/arnoldi_vs_iram_benchmark. The _arnoldi
+# and _iram suffixed names above stay available for explicit selection or
+# head-to-head comparison; these bare names are the new default.
+lowest_energy = lowest_energy_iram
+lowest_energy_non_hermitian = lowest_energy_non_hermitian_iram
 
 
 def toMPO(self,H,mode="DMRG"):

--- a/tests/test_arpacktk_iram.py
+++ b/tests/test_arpacktk_iram.py
@@ -13,6 +13,7 @@ import pytest
 from dmrgpy import spinchain, fermionchain
 from dmrgpy.algebra import arnolditk
 from dmrgpy.algebra.arpacktk import mpsiram, mpsiram_shift_invert
+from dmrgpy.algebra.arpacktk import mpsiram_generalized, generalized_excited_states
 
 
 def _heisenberg_chain(n=6, seed=1):
@@ -156,3 +157,73 @@ def test_mpsiram_dmrg_mode_matches_ed(itensor_version):
     es_ed = np.sort(np.array(sc.get_excited(mode="ED", n=1)).real)
     es, wfs = mpsiram(sc, h, which="SR", nev=1, tol=1e-6)
     assert abs(es[0].real - es_ed[0]) < 1e-4
+
+
+def _generalized_fermion_problem(n=5, seed=2):
+    """A*x = lambda*M*x: A a Hermitian interacting fermion Hamiltonian,
+    M = 1 + 0.5*sum(N_i) a Hermitian positive-definite weight operator
+    (diagonal, eigenvalues in [1, 1+0.5n], never zero)."""
+    rng = np.random.RandomState(seed)
+    fc = fermionchain.Fermionic_Chain(n)
+    a = 0
+    for i in range(n - 1):
+        a = a + rng.random() * (fc.Cdag[i] * fc.C[i + 1] + fc.Cdag[i + 1] * fc.C[i])
+    for i in range(n - 1):
+        a = a + rng.random() * (fc.N[i] - 0.5) * (fc.N[i + 1] - 0.5)
+    m = 1
+    for i in range(n):
+        m = m + 0.5 * fc.N[i]
+    fc.set_hamiltonian(a)
+    return fc, a, m
+
+
+def _generalized_ground_truth(fc, a, m):
+    import scipy.linalg as sla
+    Amat = fc.get_ED_obj().MO2matrix(a)
+    Mmat = fc.get_ED_obj().MO2matrix(m)
+    Amat = Amat.toarray() if hasattr(Amat, "toarray") else np.array(Amat)
+    Mmat = Mmat.toarray() if hasattr(Mmat, "toarray") else np.array(Mmat)
+    return np.sort(sla.eigh(Amat, Mmat, eigvals_only=True))
+
+
+def test_mpsiram_generalized_ground_state_ed():
+    """mode 2 (A*x=lambda*M*x, OP=inv(M)*A, B=M) ground state must match
+    scipy.linalg.eigh's generalized Hermitian-definite eigensolver."""
+    fc, a, m = _generalized_fermion_problem(n=5, seed=2)
+    arnolditk.arnoldimode = "ED"
+    w = _generalized_ground_truth(fc, a, m)
+    es, wfs = mpsiram_generalized(fc, a, m, which="SR", nev=1, tol=1e-8)
+    assert abs(es[0].real - w[0]) < 1e-5
+    wf = wfs[0]
+    assert abs(wf.dot(wf) - 1.0) < 1e-8 # plain-normalized, not M-normalized
+
+
+def test_mpsiram_generalized_simultaneous_multi_eigenvalue_ed():
+    fc, a, m = _generalized_fermion_problem(n=5, seed=2)
+    arnolditk.arnoldimode = "ED"
+    w = _generalized_ground_truth(fc, a, m)
+    es, wfs = mpsiram_generalized(fc, a, m, which="SR", nev=3, tol=1e-6)
+    for e_iram, e_true in zip(sorted(es.real), w[:3]):
+        assert abs(e_iram - e_true) < 1e-4
+
+
+def test_generalized_excited_states_recursive_ed():
+    fc, a, m = _generalized_fermion_problem(n=5, seed=2)
+    arnolditk.arnoldimode = "ED"
+    w = _generalized_ground_truth(fc, a, m)
+    es, wfs = generalized_excited_states(fc, a, m, nwf=3, which="SR",
+            recursive=True, tol=1e-6)
+    for e_iram, e_true in zip(sorted(es.real), w[:3]):
+        assert abs(e_iram - e_true) < 1e-4
+
+
+@pytest.mark.parametrize("itensor_version", ["python"])
+def test_mpsiram_generalized_dmrg_mode_matches_ed(itensor_version):
+    """Real MPS/MPO (pyitensor backend) mode-2 ground state must agree
+    with the generalized-eigenvalue ED ground truth."""
+    fc, a, m = _generalized_fermion_problem(n=4, seed=2)
+    w = _generalized_ground_truth(fc, a, m)
+    fc.setup_python()
+    arnolditk.arnoldimode = "DMRG"
+    es, wfs = mpsiram_generalized(fc, a, m, which="SR", nev=1, tol=1e-6)
+    assert abs(es[0].real - w[0]) < 1e-4

--- a/tests/test_arpacktk_iram.py
+++ b/tests/test_arpacktk_iram.py
@@ -16,6 +16,34 @@ from dmrgpy.algebra.arpacktk import mpsiram, mpsiram_shift_invert
 from dmrgpy.algebra.arpacktk import mpsiram_generalized, generalized_excited_states
 
 
+@pytest.fixture(autouse=True)
+def _isolate_shared_global_state():
+    """Two pieces of shared, module/process-global state this file must
+    not leak or depend on:
+
+    arnolditk.arnoldimode -- the module-level flag arpacktk.py's
+    random_state()/toMPO() read to pick ED vs DMRG. Tests here set it to
+    exercise both modes; without saving/restoring it, whatever the last
+    test in this file left it set to would leak into every other test
+    file that runs after it (this file has no control over execution
+    order).
+
+    numpy's global RNG -- edtk/edchain.py's State.random_state() (the ED
+    IRAM start-vector generator) draws from np.random.random() directly,
+    not a seeded local generator, so how many prior np.random calls
+    happened anywhere earlier in the process (other tests, or even
+    earlier iterations of the same IRAM run) affects the exact numerical
+    trajectory and hence convergence precision -- confirmed directly: a
+    recursive multi-state test passed in isolation but failed when run
+    after other tests in this file consumed different amounts of the
+    global stream. Seeding it fresh before every test makes each test's
+    outcome depend only on its own random draws, not on execution order."""
+    original = arnolditk.arnoldimode
+    np.random.seed(12345)
+    yield
+    arnolditk.arnoldimode = original
+
+
 def _heisenberg_chain(n=6, seed=1):
     rng = np.random.RandomState(seed)
     sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
@@ -120,6 +148,30 @@ def test_excited_states_non_hermitian_default_matches_ed():
     es_sorted = np.array(sorted(es, key=lambda x: x.real))
     for e_iram, e_ed in zip(es_sorted, es_ed):
         assert abs(e_iram.real - e_ed.real) < 1e-3
+
+
+def test_excited_states_non_hermitian_accepts_legacy_nkry_kwargs():
+    """excited_states_non_hermitian's old arnolditk-based signature had
+    nkry_min/nkry_max as explicit named parameters; the arpacktk swap
+    replaced them with ncv, but any caller still passing nkry_min/
+    nkry_max explicitly (e.g. via get_excited_states(..., nkry_min=...))
+    would otherwise hit a TypeError several calls deep once those stray
+    kwargs reached mpsiram (no **kwargs catch-all there) -- confirmed via
+    direct reproduction. Both must still be accepted (and produce a
+    correct result), even though IRAM has no direct equivalent of
+    arnolditk's adaptive Krylov-size range."""
+    fc, h = _staggered_fermion_chain(n=4, seed=3)
+    fc.setup_python()
+    es_ed = np.array(sorted(fc.get_excited(mode="ED", n=3), key=lambda x: x.real))
+    es, wfs = fc.get_excited_states(n=2, nkry_min=2)
+    es_sorted = np.array(sorted(es, key=lambda x: x.real))
+    for e_iram, e_ed in zip(es_sorted, es_ed[:2]):
+        assert abs(e_iram.real - e_ed.real) < 1e-2
+    # nkry_max together with nkry_min must also still work
+    es2, wfs2 = fc.get_excited_states(n=2, nkry_min=3, nkry_max=8)
+    es2_sorted = np.array(sorted(es2, key=lambda x: x.real))
+    for e_iram, e_ed in zip(es2_sorted, es_ed[:2]):
+        assert abs(e_iram.real - e_ed.real) < 1e-2
 
 
 def test_eigenvalue_degeneracy_non_degenerate_target_ed():

--- a/tests/test_arpacktk_iram.py
+++ b/tests/test_arpacktk_iram.py
@@ -1,0 +1,158 @@
+"""Regression coverage for algebra/arpacktk.py's Implicitly Restarted
+Arnoldi Method (IRAM, ported from ARPACK), the default MPS Arnoldi
+solver used by get_excited_states (non-Hermitian, n>=2) and by
+degeneracy.py's eigenvalue_degeneracy. Before this file existed, none of
+that code path had any pytest coverage at all -- a real crash/silent-
+wrong-answer bug in mpsiram_shift_invert would have shipped silently
+through run_tests.py staying green (found and fixed via manual stress
+testing, see the PR history).
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import spinchain, fermionchain
+from dmrgpy.algebra import arnolditk
+from dmrgpy.algebra.arpacktk import mpsiram, mpsiram_shift_invert
+
+
+def _heisenberg_chain(n=6, seed=1):
+    rng = np.random.RandomState(seed)
+    sc = spinchain.Spin_Chain(["S=1/2" for _ in range(n)])
+    h = 0
+    for i in range(n - 1):
+        h = h + rng.random() * sc.Sx[i] * sc.Sx[i + 1]
+        h = h + rng.random() * sc.Sy[i] * sc.Sy[i + 1]
+        h = h + rng.random() * sc.Sz[i] * sc.Sz[i + 1]
+    sc.set_hamiltonian(h)
+    return sc, h
+
+
+def _staggered_fermion_chain(n=6, seed=4):
+    """Interacting fermion chain with a staggered imaginary potential --
+    non-Hermitian, complex spectrum, exact complex-conjugate degenerate
+    ground state (used elsewhere in this repo, e.g.
+    examples/non_hermitian/nhdmrg_VS_ED_VS_arnoldi)."""
+    rng = np.random.RandomState(seed)
+    fc = fermionchain.Fermionic_Chain(n)
+    mh = np.zeros((n, n), dtype=complex)
+    for i in range(n - 1):
+        mh[i, i + 1] = 1.0
+        mh[i + 1, i] = 1.0
+    for i in range(n):
+        mh[i, i] = 1j * (-1) ** i
+    h = 0
+    for i in range(n):
+        for j in range(n):
+            h = h + mh[i, j] * fc.Cdag[i] * fc.C[j]
+    for i in range(n - 1):
+        h = h + (fc.N[i] - 0.5) * (fc.N[i + 1] - 0.5)
+    fc.set_hamiltonian(h)
+    return fc, h
+
+
+def test_mpsiram_hermitian_ground_state_ed():
+    sc, h = _heisenberg_chain(n=6, seed=1)
+    arnolditk.arnoldimode = "ED"
+    es_ed = np.sort(np.array(sc.get_excited(mode="ED", n=1)).real)
+    es, wfs = mpsiram(sc, h, which="SR", nev=1, tol=1e-8)
+    assert abs(es[0].real - es_ed[0]) < 1e-6
+    wf = wfs[0]
+    assert abs(wf.dot(wf) - 1.0) < 1e-8 # normalized
+
+
+def test_mpsiram_simultaneous_multi_eigenvalue_ed():
+    """A genuine nev=3 simultaneous block search (not one-at-a-time)."""
+    sc, h = _heisenberg_chain(n=6, seed=1)
+    arnolditk.arnoldimode = "ED"
+    es_ed = np.sort(np.array(sc.get_excited(mode="ED", n=3)).real)
+    es, wfs = mpsiram(sc, h, which="SR", nev=3, tol=1e-6)
+    assert len(es) == 3
+    for e_iram, e_ed in zip(sorted(es.real), es_ed):
+        assert abs(e_iram - e_ed) < 1e-4
+
+
+def test_mpsiram_non_hermitian_conjugate_pair_ed():
+    fc, h = _staggered_fermion_chain(n=6, seed=4)
+    arnolditk.arnoldimode = "ED"
+    es_ed = np.array(sorted(fc.get_excited(mode="ED", n=6), key=lambda x: x.real))
+    es, wfs = mpsiram(fc, h, which="SR", nev=1, tol=1e-6)
+    assert abs(es[0].real - es_ed[0].real) < 1e-4
+    assert min(abs(es[0] - x) for x in es_ed) < 1e-4
+
+
+def test_mpsiram_shift_invert_finds_nearest_eigenvalue_ed():
+    sc, h = _heisenberg_chain(n=6, seed=1)
+    arnolditk.arnoldimode = "ED"
+    es_ed = np.sort(np.array(sc.get_excited(mode="ED", n=6)).real)
+    target = es_ed[2] + 0.01
+    es, wfs = mpsiram_shift_invert(sc, h, e=target, nev=1, delta=1e-6, maxn=40)
+    closest = es_ed[np.argmin(np.abs(es_ed - target))]
+    assert abs(es[0].real - closest) < 1e-3
+
+
+def test_mpsiram_shift_invert_deflated_second_state_is_a_genuine_eigenvalue_ed():
+    """A recursive (deflated) second shift-invert search must still land
+    on *some* genuine eigenvalue of H, not a spurious combination --
+    even though it is not guaranteed to land on the exact conjugate
+    partner of the first (see module note on deflation and non-Hermitian
+    operators: right eigenvectors of a non-Hermitian H need not be
+    mutually orthogonal under the plain Hermitian inner product -- e.g.
+    confirmed directly for this model's ground-state conjugate pair,
+    |<v1|v2>| ~= 0.40 -- so .dot()-based deflation, used identically by
+    arnolditk's own wfskip mechanism, is only a heuristic here, not a
+    rigorous one)."""
+    fc, h = _staggered_fermion_chain(n=6, seed=4)
+    arnolditk.arnoldimode = "ED"
+    es_ed = np.array(sorted(fc.get_excited(mode="ED", n=6), key=lambda x: x.real))
+    e0 = es_ed[0].real
+    es, wfs = mpsiram_shift_invert(fc, h, e=1.2 * e0, nev=2, delta=1e-3, maxn=40)
+    for e in es:
+        assert min(abs(e - x) for x in es_ed) < 1e-2
+
+
+def test_excited_states_non_hermitian_default_matches_ed():
+    """get_excited_states' non-Hermitian route (excited.py's
+    excited_states_non_hermitian, IRAM by default) must agree with ED."""
+    fc, h = _staggered_fermion_chain(n=6, seed=4)
+    es_ed = np.array(sorted(fc.get_excited(mode="ED", n=3), key=lambda x: x.real))
+    es, wfs = fc.get_excited_states(n=3, purify=False)
+    es_sorted = np.array(sorted(es, key=lambda x: x.real))
+    for e_iram, e_ed in zip(es_sorted, es_ed):
+        assert abs(e_iram.real - e_ed.real) < 1e-3
+
+
+def test_eigenvalue_degeneracy_non_degenerate_target_ed():
+    """degeneracy.py's eigenvalue_degeneracy (shift-invert IRAM, called
+    recursively with deflation) targeted at a genuinely non-degenerate
+    eigenvalue must report a degeneracy close to 1.
+
+    Note: this deliberately avoids this model's own exact
+    complex-conjugate ground-state pair as a target -- right
+    eigenvectors of a non-Hermitian H need not be mutually orthogonal
+    under the plain Hermitian inner product (confirmed directly here,
+    |<v1|v2>| ~= 0.40 for that pair), so the .dot()-based deflation this
+    routine relies on (identical to arnolditk's own wfskip mechanism) is
+    only a heuristic, not a rigorous one, for resolving non-orthogonal
+    degenerate clusters -- a pre-existing characteristic of the
+    deflation approach itself, not specific to this solver."""
+    from dmrgpy.degeneracy import eigenvalue_degeneracy
+    fc, h = _staggered_fermion_chain(n=4, seed=3)
+    arnolditk.arnoldimode = "ED"
+    es_ed = np.array(sorted(fc.get_excited(mode="ED", n=6), key=lambda x: x.real))
+    # the "-0.25" level in this model is an isolated, non-degenerate
+    # eigenvalue (confirmed via the ED spectrum)
+    target = es_ed[np.argmin(np.abs(es_ed.real - (-0.25)))].real
+    deg = eigenvalue_degeneracy(fc, h, target, n=1, delta=5e-2)
+    assert 0.8 < deg < 1.5
+
+
+@pytest.mark.parametrize("itensor_version", ["python"])
+def test_mpsiram_dmrg_mode_matches_ed(itensor_version):
+    """Real MPS/MPO (pyitensor backend, no compiled extension needed)
+    ground state via IRAM must agree with ED."""
+    sc, h = _heisenberg_chain(n=4, seed=1)
+    sc.setup_python()
+    arnolditk.arnoldimode = "DMRG"
+    es_ed = np.sort(np.array(sc.get_excited(mode="ED", n=1)).real)
+    es, wfs = mpsiram(sc, h, which="SR", nev=1, tol=1e-6)
+    assert abs(es[0].real - es_ed[0]) < 1e-4


### PR DESCRIPTION
## Summary

Ports ARPACK's Implicitly Restarted Arnoldi Method (`znaupd`/`znaup2`/`znaitr`/`znapps`/`zneigh`/`zngets`, from [bitbucket.org/chaoyang2013/arpack](https://bitbucket.org/chaoyang2013/arpack)) into pure Python (`src/dmrgpy/algebra/arpacktk.py`), operating directly on dmrgpy's MPS/ED wavefunction objects — no BLAS/LAPACK dependency, no reverse-communication interface. Covers three ARPACK modes:

- **Mode 1** (`mpsiram`) — the standard eigenproblem `A·x = λ·x`. **This is the default MPS Arnoldi solver**, replacing arnolditk at production call sites: `excited.py`'s `excited_states_non_hermitian` (via `get_excited_states` for non-Hermitian $H$) and `mpsalgebra.py`'s bare `lowest_energy`/`lowest_energy_non_hermitian`. arnolditk's original implementation stays available for comparison and for a couple of cases IRAM doesn't (yet) cover.
- **Mode 3** (`mpsiram_shift_invert`) — shift-invert, `OP=(A−σI)⁻¹`, finding eigenvalues nearest a target energy. `degeneracy.py`'s `eigenvalue_degeneracy` (used by `gs_degeneracy(mode="DMRG")`) is built on it, adapted for dmrgpy's only *approximate* matrix inverse.
- **Mode 2** (`mpsiram_generalized`) — the generalized eigenproblem `A·x = λ·M·x` for Hermitian positive-definite `M` (`OP=M⁻¹A`, `B=M`), verified against `scipy.linalg.eigh`'s generalized eigensolver in both ED and real DMRG mode.

## Code review rounds

Two background `/code-review` passes on this branch flagged issues that were investigated (direct reproduction, not just code reading) and addressed:

**Round 1** — a confirmed silent-wrong-answer bug in `mpsiram_shift_invert` (`gs_degeneracy(mode="DMRG")` returning ~1.0 instead of the true ~2.0 in ~20% of stress-test trials), fixed with a genuine-residual convergence check; plus a related crash risk, missing stagnation-avoidance, code duplication, a silently-shrunk Krylov-subspace margin, stale documentation, and the first pytest coverage for this module. Investigation also uncovered and documented a deeper, pre-existing structural limitation shared with arnolditk's own deflation mechanism (non-orthogonal right eigenvectors of non-Hermitian operators).

**Round 2** — two more confirmed issues:
- `excited_states_non_hermitian`'s old signature had `nkry_min`/`nkry_max` as explicit parameters; the arpacktk swap replaced them with `ncv`, so any caller still passing them (reproduced directly via `get_excited_states(n=2, nkry_min=2)` with a real DMRG backend selected) hit a `TypeError` several calls deep. Fixed by restoring both as accepted parameters (`nkry_max` maps to `ncv`).
- `tests/test_arpacktk_iram.py` mutated a shared global (`arnolditk.arnoldimode`) with no teardown, and relied on numpy's unseeded global RNG — reproduced directly as a test that passed in isolation but failed as part of the full file. Fixed with a single autouse fixture that isolates both.

## Test plan

- [x] `python3 -m pytest tests/` — 126 passed (was 113 at the start of this PR; +13 new), 37 skipped, 16 pre-existing failures (all due to no compiled C++ extension in this sandbox / unrelated chain-type limitations — identical failure set throughout this PR, no regressions)
- [x] ED-mode correctness vs exact diagonalization for all three modes; real DMRG-mode (pyitensor) correctness for all three modes
- [x] `eigenvalue_degeneracy`/`gs_degeneracy(mode="DMRG")` correctly detects a known ~2-fold degeneracy end-to-end
- [x] Legacy `nkry_min`/`nkry_max` kwargs verified working again against ED ground truth
- [x] Previously-flaky recursive test now passes deterministically across repeated full-suite runs
- [x] `.tex` docs compile cleanly with `pdflatex` throughout

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t