### PR TITLE
Implement infinite DMRG (iDMRG) for translationally-invariant chains

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -211,6 +211,88 @@ default) or `"python"` for cross-backend agreement. ED
 (`pyboson/boson.py::BosonChain`) always builds the exact requested
 per-site dimension regardless of backend.
 
+### 4.1b Infinite chains (`infinitechain.py`, `pyitensor/idmrg.py`)
+
+`Infinite_Many_Body_Chain`/`Infinite_Spin_Chain` (`infinitechain.py`) are
+a deliberately **independent** object, not a `Many_Body_Chain` subclass:
+`Many_Body_Chain`'s whole design (mode dispatch between DMRG/ED, a fixed
+`self.ns`-length site list, KPM/dynamics/entanglement/excited-states
+machinery) assumes a *finite* chain throughout, and none of that has any
+meaning for a translationally-invariant, infinite unit-cell chain. Only
+`itensor_version="python"` is supported (constructing anything else
+raises `NotImplementedError`) — infinite DMRG (iDMRG) has no C++/Julia
+backend yet. The public surface is deliberately narrow: `set_hamiltonian`,
+`gs_energy` (energy *per site*, the physically meaningful quantity for an
+infinite system), and static `vev`/`correlator` — no excited states, no
+dynamics, no entanglement/entropy in v1.
+
+The Hamiltonian is built from `SxL[i]`/`SxC[i]`/`SxR[i]`-suffixed
+operators (previous/central/next unit cell, `i=0..n_uc-1`) rather than
+absolute site indices; `_canonicalize_hamiltonian` validates every term
+touches at most two adjacent cells and shifts away the `L` suffix (`L→C`,
+`C→R`) before storing, so the stored Hamiltonian is uniformly "intra-cell
+`C` terms" + "`C`-to-`R` inter-cell terms", each physical bond attributed
+to exactly one cell.
+
+`pyitensor/idmrg.py` implements the actual growing/infinite-size
+algorithm (White 1992, generalized to an `n_uc`-site unit cell per
+McCulloch 2008): `_build_automaton` builds the periodic per-sublattice
+MPO tensor directly as a hand-rolled finite-state automaton (not
+extracted from a compressed finite reference system — an earlier design
+that was tried and abandoned, see the module's own docstring for the two
+independent bugs that approach hit), then `idmrg_ground_state` grows two
+environments `HL`/`HR` from `HL=HR=None`, one unit cell at a time,
+reusing `dmrg.py`'s own `_lanczos_ground_state` and `kernels.make_matvec`
+for each micro-step's local 2-site solve (no separate Lanczos
+implementation). Static correlators are reconstructed after convergence
+from the last macro-iteration's own per-sublattice left-canonical
+tensors via the standard infinite-MPS transfer-matrix formalism (dominant
+left/right fixed points of the per-unit-cell transfer operator).
+
+**Currently limited to `n_uc<=2`** (enforced at `Infinite_Many_Body_Chain`
+construction) — the micro-step loop's sublattice pairing
+(`p_L=mstep`, `p_R=n_uc-1-mstep`) only produces two genuinely *adjacent*
+active sites for `n_uc` in `{1, 2}`; for `n_uc>=3` an intermediate
+micro-step's two active sites are several real, not-yet-inserted sites
+apart, and `_build_automaton`'s own per-sublattice pending-channel
+content differs between them (not just its count), so there is no way to
+even wire them together correctly without a genuine redesign of the
+growth scheme — flagged as a known follow-up rather than attempted.
+
+**A confirmed, fixed bug worth knowing about if this module is touched
+again**: `idmrg_ground_state` re-mints a fresh mpo-axis Index for `HL`'s
+and `HR`'s own environment tensor at the end of *every* micro-step,
+rather than reusing whatever Index `_build_automaton` happened to label
+that channel space with. This is required because `_build_automaton`'s
+`boundary_idx` pool has only `n_uc` distinct Index objects total, reused
+verbatim every time a given sublattice position comes up again (every
+macro-iteration past the first) — left un-broken, `HL`'s and `HR`'s own
+mpo axes can end up being the *same* Index object (guaranteed for
+`n_uc=1`, where a single sublattice's left and right automaton legs are
+literally identical), corrupting the effective Hamiltonian from the
+second macro-iteration onward once both environments are non-trivial and
+used together in the same local 2-site solve. Confirmed directly by
+extracting the dense effective Hamiltonian at macro-iteration 2 of a
+uniform `n_uc=1` Heisenberg chain and finding its full eigenvalue
+spectrum did not match exact 6-site ED at all, while macro-iteration 1's
+spectrum matched to machine precision — the same self-referencing-Index
+hazard already seen once in this module (`_project_channel`'s own
+docstring), here manifesting across the growth loop's iterations rather
+than within a single tensor. `idmrg.py`'s module docstring and the inline
+comments in `idmrg_ground_state`/`_relabel_pos` have the full derivation.
+
+A separate, milder issue in the same neighborhood: `U_list[0]`'s own left
+bond and `U_list[n_uc-1]`'s own right bond are, in a truly periodic MPS,
+the *same* wraparound bond, but each is independently truncated by its
+own micro-step's SVD — nothing guarantees they come out numerically
+equal, and two independent SVDs occasionally round a borderline singular
+value across the `cutoff` threshold differently for what is conceptually
+one bond. `_dominant_right_fixed_point` (used by both `onsite_expectation`
+and `two_point_correlator`) now raises a clear `RuntimeError` when this
+happens instead of a cryptic `reshape` crash; a smaller `maxm` that
+actually binds (forcing both bonds to the same truncated dimension)
+avoids it, see `tests/test_infinite_chain.py`'s own comment on this.
+
 ### 4.2 Operator representation: `MultiOperator`
 
 Hamiltonians and observables are built as `MultiOperator` objects
@@ -1461,6 +1543,7 @@ bookkeeping fixes referenced above -- it was ~13x before them).
 |---|---|
 | `src/dmrgpy/` | the Python library |
 | `src/dmrgpy/manybodychain.py` | `Many_Body_Chain`, the shared base class |
+| `src/dmrgpy/infinitechain.py`, `pyitensor/idmrg.py` | `Infinite_Many_Body_Chain` and infinite DMRG (iDMRG), pyitensor-only |
 | `src/dmrgpy/multioperator.py`, `multioperatortk/` | backend-agnostic operator representation |
 | `src/dmrgpy/mode.py`, `cppext.py` | DMRG/ED and backend dispatch |
 | `src/dmrgpy/mpscpp2/`, `mpscpp3/` | vendored ITensor C++ (v2, v3) + pybind11 bindings |

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -282,6 +282,103 @@ cross-backend agreement. ED (\texttt{pyboson/boson.py::BosonChain})
 always builds the exact requested per-site dimension regardless of
 backend.
 
+\subsection{Infinite chains (\texttt{infinitechain.py}, \texttt{pyitensor/idmrg.py})}
+
+\texttt{Infinite\_Many\_Body\_Chain}/\texttt{Infinite\_Spin\_Chain}
+(\texttt{infinitechain.py}) are a deliberately \textbf{independent}
+object, not a \texttt{Many\_Body\_Chain} subclass:
+\texttt{Many\_Body\_Chain}'s whole design (mode dispatch between
+DMRG/ED, a fixed \texttt{self.ns}-length site list,
+KPM/dynamics/entanglement/excited-states machinery) assumes a
+\emph{finite} chain throughout, and none of that has any meaning for a
+translationally-invariant, infinite unit-cell chain. Only
+\texttt{itensor\_version="python"} is supported (constructing anything
+else raises \texttt{NotImplementedError}) -- infinite DMRG (iDMRG) has
+no C++/Julia backend yet. The public surface is deliberately narrow:
+\texttt{set\_hamiltonian}, \texttt{gs\_energy} (energy \emph{per site},
+the physically meaningful quantity for an infinite system), and static
+\texttt{vev}/\texttt{correlator} -- no excited states, no dynamics, no
+entanglement/entropy in v1.
+
+The Hamiltonian is built from
+\texttt{SxL[i]}/\texttt{SxC[i]}/\texttt{SxR[i]}-suffixed operators
+(previous/central/next unit cell, \texttt{i=0..n\_uc-1}) rather than
+absolute site indices; \texttt{\_canonicalize\_hamiltonian} validates
+every term touches at most two adjacent cells and shifts away the
+\texttt{L} suffix (\texttt{L}$\to$\texttt{C}, \texttt{C}$\to$\texttt{R})
+before storing, so the stored Hamiltonian is uniformly "intra-cell
+\texttt{C} terms" + "\texttt{C}-to-\texttt{R} inter-cell terms", each
+physical bond attributed to exactly one cell.
+
+\texttt{pyitensor/idmrg.py} implements the actual growing/infinite-size
+algorithm (White 1992, generalized to an \texttt{n\_uc}-site unit cell
+per McCulloch 2008): \texttt{\_build\_automaton} builds the periodic
+per-sublattice MPO tensor directly as a hand-rolled finite-state
+automaton (not extracted from a compressed finite reference system -- an
+earlier design that was tried and abandoned, see the module's own
+docstring for the two independent bugs that approach hit), then
+\texttt{idmrg\_ground\_state} grows two environments \texttt{HL}/\texttt{HR}
+from \texttt{HL=HR=None}, one unit cell at a time, reusing
+\texttt{dmrg.py}'s own \texttt{\_lanczos\_ground\_state} and
+\texttt{kernels.make\_matvec} for each micro-step's local 2-site solve
+(no separate Lanczos implementation). Static correlators are
+reconstructed after convergence from the last macro-iteration's own
+per-sublattice left-canonical tensors via the standard infinite-MPS
+transfer-matrix formalism (dominant left/right fixed points of the
+per-unit-cell transfer operator).
+
+\textbf{Currently limited to \texttt{n\_uc<=2}} (enforced at
+\texttt{Infinite\_Many\_Body\_Chain} construction) -- the micro-step
+loop's sublattice pairing (\texttt{p\_L=mstep},
+\texttt{p\_R=n\_uc-1-mstep}) only produces two genuinely \emph{adjacent}
+active sites for \texttt{n\_uc} in $\{1, 2\}$; for \texttt{n\_uc>=3} an
+intermediate micro-step's two active sites are several real,
+not-yet-inserted sites apart, and \texttt{\_build\_automaton}'s own
+per-sublattice pending-channel content differs between them (not just
+its count), so there is no way to even wire them together correctly
+without a genuine redesign of the growth scheme -- flagged as a known
+follow-up rather than attempted.
+
+\textbf{A confirmed, fixed bug worth knowing about if this module is
+touched again}: \texttt{idmrg\_ground\_state} re-mints a fresh mpo-axis
+Index for \texttt{HL}'s and \texttt{HR}'s own environment tensor at the
+end of \emph{every} micro-step, rather than reusing whatever Index
+\texttt{\_build\_automaton} happened to label that channel space with.
+This is required because \texttt{\_build\_automaton}'s
+\texttt{boundary\_idx} pool has only \texttt{n\_uc} distinct Index
+objects total, reused verbatim every time a given sublattice position
+comes up again (every macro-iteration past the first) -- left
+un-broken, \texttt{HL}'s and \texttt{HR}'s own mpo axes can end up being
+the \emph{same} Index object (guaranteed for \texttt{n\_uc=1}, where a
+single sublattice's left and right automaton legs are literally
+identical), corrupting the effective Hamiltonian from the second
+macro-iteration onward once both environments are non-trivial and used
+together in the same local 2-site solve. Confirmed directly by
+extracting the dense effective Hamiltonian at macro-iteration 2 of a
+uniform \texttt{n\_uc=1} Heisenberg chain and finding its full
+eigenvalue spectrum did not match exact 6-site ED at all, while
+macro-iteration 1's spectrum matched to machine precision -- the same
+self-referencing-Index hazard already seen once in this module
+(\texttt{\_project\_channel}'s own docstring), here manifesting across
+the growth loop's iterations rather than within a single tensor.
+\texttt{idmrg.py}'s module docstring and the inline comments in
+\texttt{idmrg\_ground\_state}/\texttt{\_relabel\_pos} have the full
+derivation.
+
+A separate, milder issue in the same neighborhood:
+\texttt{U\_list[0]}'s own left bond and \texttt{U\_list[n\_uc-1]}'s own
+right bond are, in a truly periodic MPS, the \emph{same} wraparound
+bond, but each is independently truncated by its own micro-step's SVD --
+nothing guarantees they come out numerically equal, and two independent
+SVDs occasionally round a borderline singular value across the
+\texttt{cutoff} threshold differently for what is conceptually one bond.
+\texttt{\_dominant\_right\_fixed\_point} (used by both
+\texttt{onsite\_expectation} and \texttt{two\_point\_correlator}) now
+raises a clear \texttt{RuntimeError} when this happens instead of a
+cryptic \texttt{reshape} crash; a smaller \texttt{maxm} that actually
+binds (forcing both bonds to the same truncated dimension) avoids it,
+see \texttt{tests/test\_infinite\_chain.py}'s own comment on this.
+
 \subsection{Operator representation: \texttt{MultiOperator}}
 
 Hamiltonians and observables are built as \texttt{MultiOperator} objects
@@ -1757,6 +1854,7 @@ Path & Contents \\
 \endhead
 \texttt{src/dmrgpy/} & the Python library \\
 \texttt{src/dmrgpy/manybodychain.py} & \texttt{Many\_Body\_Chain}, the shared base class \\
+\texttt{src/dmrgpy/infinitechain.py}, \texttt{pyitensor/idmrg.py} & \texttt{Infinite\_Many\_Body\_Chain} and infinite DMRG (iDMRG), pyitensor-only \\
 \texttt{src/dmrgpy/multioperator.py}, \texttt{multioperatortk/} & backend-agnostic operator representation \\
 \texttt{src/dmrgpy/mode.py}, \texttt{cppext.py} & DMRG/ED and backend dispatch \\
 \texttt{src/dmrgpy/mpscpp2/}, \texttt{mpscpp3/} & vendored ITensor C++ (v2, v3) + pybind11 bindings \\

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -29,6 +29,7 @@ reference on small systems.
 15. [Post-processing tools](#15-post-processing-tools)
 16. [Worked-example cookbook](#16-worked-example-cookbook)
 17. [STM/Kondo tunneling spectra (third-order perturbation theory)](#17-stmkondo-tunneling-spectra-third-order-perturbation-theory)
+18. [Infinite chains (iDMRG)](#18-infinite-chains-idmrg)
 
 ## 1. Physical models and Hilbert spaces
 
@@ -1524,3 +1525,45 @@ produces, silently zeroing the entire term). The second-order term
 percent at thresholds, consistent with the expected
 $\delta$-broadening/moment-truncation error on top of what the ED path
 already has.
+
+## 18. Infinite chains (iDMRG)
+
+Every method above works on a *finite* chain of `n` sites. `Infinite_Many_Body_Chain`/`Infinite_Spin_Chain` (`infinitechain.py`) instead describe a translationally-invariant chain that repeats a fixed-size **unit cell** forever in both directions, and solve it with infinite DMRG (iDMRG, White's growing algorithm generalized to a multi-site unit cell) rather than sweeping a fixed-length system. Currently limited to a 1- or 2-site unit cell (`n_uc<=2`) and the pure-Python `pyitensor` backend — a >2-site unit cell raises `NotImplementedError` at construction, see `pyitensor/idmrg.py`'s module docstring for why.
+
+**Building the Hamiltonian: `L`/`C`/`R`-suffixed operators.** Instead of one operator list per absolute site index, an infinite chain exposes each operator three times per unit-cell site `i` (`i=0..n_uc-1`): `SxC[i]` (site `i` of the *central* cell — ordinary intra-cell use), `SxR[i]` (site `i` of the *next* cell), and `SxL[i]` (site `i` of the *previous* cell, provided purely so a coupling can be phrased in whichever direction reads most naturally). A term may touch at most two *adjacent* unit cells (any subset of `{L,C}` or of `{C,R}`, never both `L` and `R` at once) — `set_hamiltonian` raises `ValueError` otherwise:
+
+```python
+from dmrgpy import infinitechain
+ic = infinitechain.Infinite_Spin_Chain(["1/2"])       # n_uc=1, uniform chain
+h = ic.SxC[0]*ic.SxR[0] + ic.SyC[0]*ic.SyR[0] + ic.SzC[0]*ic.SzR[0]  # NN Heisenberg
+ic.set_hamiltonian(h)
+```
+
+A two-site unit cell can express a dimerized (alternating-bond) chain, and a coupling can skip over an intermediate site by reaching straight from `C` to `R`:
+
+```python
+ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+h = (1.0*(ic.SxC[0]*ic.SxC[1] + ic.SyC[0]*ic.SyC[1] + ic.SzC[0]*ic.SzC[1])   # strong intra-cell bond
+     + 0.4*(ic.SxC[1]*ic.SxR[0] + ic.SyC[1]*ic.SyR[0] + ic.SzC[1]*ic.SzR[0]))  # weak inter-cell bond
+ic.set_hamiltonian(h)
+```
+
+**Ground-state energy density.** Since the chain is infinite, the physically meaningful quantity is the energy *per site*, not a total:
+
+```python
+density = ic.gs_energy()   # converged energy density (or the best value reached after ic.maxiter)
+ic.converged                # True iff the density stabilized below ic.etol
+```
+
+`ic.maxm`/`ic.cutoff` cap the bond dimension/SVD truncation exactly like a finite chain's `maxm`/`cutoff`; `ic.maxiter`/`ic.etol` are iDMRG-specific: `maxiter` macro-iterations (each adds one full unit cell to each side) are run, stopping early once the energy-density finite difference between consecutive macro-iterations drops below `etol`. For a *gapless* model (e.g. the uniform Heisenberg chain above) this finite-difference convergence is only power-law in the number of iterations at any fixed `maxm`, not exponential, so it may not trip `etol` within a practical `maxiter` even though the energy density itself is already accurate to several digits — check the returned value directly rather than relying solely on `ic.converged`. A *gapped* model (e.g. the dimerized chain above, or any chain with `j_weak` bonds well below the uniform point) has a finite correlation length and converges both faster and more reliably.
+
+**Static correlators.** After `gs_energy()` (called automatically by `vev`/`correlator` if not already run), one- and two-point expectation values of the converged infinite chain are available via the standard infinite-MPS transfer-matrix formalism:
+
+```python
+ic.vev("Sz", 0)                    # <Sz> at site 0 of the unit cell
+ic.correlator("Sz", 0, "Sz", r)    # <Sz(0) Sz(0+r)>, r measured in physical sites, r>=0
+```
+
+Because these are reconstructed *after* convergence from the last macro-iteration's own tensors (a good, but not exact, stand-in for a truly periodic MPS unit cell — the growing algorithm never explicitly re-canonicalizes into one), correlators converge more slowly than the energy density itself as a function of `maxiter` at fixed `maxm` — a model-agnostic self-consistency check that always holds exactly for a truly periodic unit cell, `<H_uc>` (the sum of every bond's correlator inside one unit cell) equals `n_uc * density`, is a useful way to judge whether `maxiter` is large enough for a given calculation.
+
+Excited states, dynamics, and entanglement/entropy are not implemented for infinite chains yet — only ground-state energy density and static correlators.

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1749,4 +1749,99 @@ too, agreeing to within a few tens of percent at thresholds, consistent
 with the expected $\delta$-broadening/moment-truncation error on top of
 what the ED path already has.
 
+\section{Infinite chains (iDMRG)}
+
+Every method above works on a \emph{finite} chain of \texttt{n} sites.
+\texttt{Infinite\_Many\_Body\_Chain}/\texttt{Infinite\_Spin\_Chain}
+(\texttt{infinitechain.py}) instead describe a translationally-invariant
+chain that repeats a fixed-size \textbf{unit cell} forever in both
+directions, and solve it with infinite DMRG (iDMRG, White's growing
+algorithm generalized to a multi-site unit cell) rather than sweeping a
+fixed-length system. Currently limited to a 1- or 2-site unit cell
+(\texttt{n\_uc<=2}) and the pure-Python \texttt{pyitensor} backend -- a
+$>$2-site unit cell raises \texttt{NotImplementedError} at construction,
+see \texttt{pyitensor/idmrg.py}'s module docstring for why.
+
+\textbf{Building the Hamiltonian: \texttt{L}/\texttt{C}/\texttt{R}-suffixed
+operators.} Instead of one operator list per absolute site index, an
+infinite chain exposes each operator three times per unit-cell site
+\texttt{i} (\texttt{i=0..n\_uc-1}): \texttt{SxC[i]} (site \texttt{i} of
+the \emph{central} cell -- ordinary intra-cell use), \texttt{SxR[i]}
+(site \texttt{i} of the \emph{next} cell), and \texttt{SxL[i]} (site
+\texttt{i} of the \emph{previous} cell, provided purely so a coupling can
+be phrased in whichever direction reads most naturally). A term may
+touch at most two \emph{adjacent} unit cells (any subset of
+\texttt{\{L,C\}} or of \texttt{\{C,R\}}, never both \texttt{L} and
+\texttt{R} at once) -- \texttt{set\_hamiltonian} raises
+\texttt{ValueError} otherwise:
+
+\begin{lstlisting}
+from dmrgpy import infinitechain
+ic = infinitechain.Infinite_Spin_Chain(["1/2"])       # n_uc=1, uniform chain
+h = ic.SxC[0]*ic.SxR[0] + ic.SyC[0]*ic.SyR[0] + ic.SzC[0]*ic.SzR[0]  # NN Heisenberg
+ic.set_hamiltonian(h)
+\end{lstlisting}
+
+A two-site unit cell can express a dimerized (alternating-bond) chain,
+and a coupling can skip over an intermediate site by reaching straight
+from \texttt{C} to \texttt{R}:
+
+\begin{lstlisting}
+ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+h = (1.0*(ic.SxC[0]*ic.SxC[1] + ic.SyC[0]*ic.SyC[1] + ic.SzC[0]*ic.SzC[1])   # strong intra-cell bond
+     + 0.4*(ic.SxC[1]*ic.SxR[0] + ic.SyC[1]*ic.SyR[0] + ic.SzC[1]*ic.SzR[0]))  # weak inter-cell bond
+ic.set_hamiltonian(h)
+\end{lstlisting}
+
+\textbf{Ground-state energy density.} Since the chain is infinite, the
+physically meaningful quantity is the energy \emph{per site}, not a
+total:
+
+\begin{lstlisting}
+density = ic.gs_energy()   # converged energy density (or the best value reached after ic.maxiter)
+ic.converged                # True iff the density stabilized below ic.etol
+\end{lstlisting}
+
+\texttt{ic.maxm}/\texttt{ic.cutoff} cap the bond dimension/SVD truncation
+exactly like a finite chain's \texttt{maxm}/\texttt{cutoff};
+\texttt{ic.maxiter}/\texttt{ic.etol} are iDMRG-specific: \texttt{maxiter}
+macro-iterations (each adds one full unit cell to each side) are run,
+stopping early once the energy-density finite difference between
+consecutive macro-iterations drops below \texttt{etol}. For a
+\emph{gapless} model (e.g.\ the uniform Heisenberg chain above) this
+finite-difference convergence is only power-law in the number of
+iterations at any fixed \texttt{maxm}, not exponential, so it may not
+trip \texttt{etol} within a practical \texttt{maxiter} even though the
+energy density itself is already accurate to several digits -- check the
+returned value directly rather than relying solely on
+\texttt{ic.converged}. A \emph{gapped} model (e.g.\ the dimerized chain
+above, or any chain with \texttt{j\_weak} bonds well below the uniform
+point) has a finite correlation length and converges both faster and
+more reliably.
+
+\textbf{Static correlators.} After \texttt{gs\_energy()} (called
+automatically by \texttt{vev}/\texttt{correlator} if not already run),
+one- and two-point expectation values of the converged infinite chain are
+available via the standard infinite-MPS transfer-matrix formalism:
+
+\begin{lstlisting}
+ic.vev("Sz", 0)                    # <Sz> at site 0 of the unit cell
+ic.correlator("Sz", 0, "Sz", r)    # <Sz(0) Sz(0+r)>, r measured in physical sites, r>=0
+\end{lstlisting}
+
+Because these are reconstructed \emph{after} convergence from the last
+macro-iteration's own tensors (a good, but not exact, stand-in for a
+truly periodic MPS unit cell -- the growing algorithm never explicitly
+re-canonicalizes into one), correlators converge more slowly than the
+energy density itself as a function of \texttt{maxiter} at fixed
+\texttt{maxm} -- a model-agnostic self-consistency check that always
+holds exactly for a truly periodic unit cell, $\langle H_{uc}\rangle$
+(the sum of every bond's correlator inside one unit cell) equals
+\texttt{n\_uc * density}, is a useful way to judge whether
+\texttt{maxiter} is large enough for a given calculation.
+
+Excited states, dynamics, and entanglement/entropy are not implemented
+for infinite chains yet -- only ground-state energy density and static
+correlators.
+
 \end{document}

--- a/examples/idmrg/heisenberg_infinite/main.py
+++ b/examples/idmrg/heisenberg_infinite/main.py
@@ -1,0 +1,39 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+import numpy as np  # conventional numpy library
+from dmrgpy import infinitechain  # infinite-DMRG (iDMRG) chain object
+
+#################################################
+### Infinite, translationally-invariant chain ###
+#################################################
+# Infinite_Spin_Chain is defined by a single n_uc-site unit cell (here
+# n_uc=1, a uniform chain) instead of a fixed total length -- couplings
+# are written with the SxC/SxR (central-cell/next-cell) operator
+# convention, see infinitechain.py's own docstring.
+ic = infinitechain.Infinite_Spin_Chain(["1/2"])
+
+h = (ic.SxC[0]*ic.SxR[0] + ic.SyC[0]*ic.SyR[0] + ic.SzC[0]*ic.SzR[0])
+ic.set_hamiltonian(h)
+
+ic.maxm = 30      # wavefunction bond dimension cap
+ic.maxiter = 40   # iDMRG macro-iterations (growth steps)
+ic.etol = 1e-9    # energy-density convergence tolerance
+ic.verbose = True  # print the energy density after every macro-iteration
+
+density = ic.gs_energy()
+
+exact = 0.25 - np.log(2)  # Bethe-ansatz ground-state energy density
+print()
+print("iDMRG converged:", ic.converged)
+print("iDMRG energy density:      ", density)
+print("exact (Bethe ansatz) value:", exact)
+print("absolute error:            ", abs(density - exact))
+
+# Static correlators of the converged infinite chain (transfer-matrix
+# formalism, see idmrg.py's onsite_expectation/two_point_correlator).
+print()
+print("<Sz> (expect ~0 by symmetry):", ic.vev("Sz", 0))
+for r in range(1, 4):
+    c = ic.correlator("Sz", 0, "Sz", r)
+    print("<Sz(0)Sz({})> =".format(r), c)

--- a/src/dmrgpy/infinitechain.py
+++ b/src/dmrgpy/infinitechain.py
@@ -78,6 +78,12 @@ def _canonicalize_hamiltonian(h, n_uc):
     < n_uc) never has to special-case it."""
     intra_terms, inter_terms = [], []
     for term in h.op:
+        distinct_sites = {site for _name, site in term[1:]}
+        if len(distinct_sites) > 2:
+            raise ValueError(
+                "Infinite_Many_Body_Chain.set_hamiltonian: a term touches "
+                "more than 2 distinct sites ({}) -- only 1- and 2-site "
+                "terms are supported".format(term))
         groups = _term_groups(term, n_uc)
         if "L" in groups and "R" in groups:
             raise ValueError(
@@ -86,8 +92,17 @@ def _canonicalize_hamiltonian(h, n_uc):
                 "({}) -- only couplings between at most two adjacent unit "
                 "cells are supported".format(term))
         if "L" in groups:
+            # groups is a subset of {L,C} here (L+R together already
+            # raised above) -- shifting every site by +n_uc moves an
+            # L-range site (-n_uc<=site<0) into the C range and a
+            # C-range site (0<=site<n_uc) into the R range, so *both*
+            # labels advance one step, not just L. Leaving an original
+            # "C" labeled "C" post-shift mis-filed e.g. SxL[0]*SxC[0]
+            # (n_uc=2) under h_intra as ['Sx',0],['Sx',2] -- a term that
+            # actually touches the next cell (site 2 >= n_uc) -- instead
+            # of h_inter, violating this function's own documented split.
             term = [term[0]] + [[name, site + n_uc] for name, site in term[1:]]
-            groups = {("C" if g == "L" else g) for g in groups}
+            groups = {{"L": "C", "C": "R"}[g] for g in groups}
         if groups == {"R"}:
             term = [term[0]] + [[name, site - n_uc] for name, site in term[1:]]
             groups = {"C"}
@@ -135,7 +150,12 @@ class Infinite_Many_Body_Chain:
         self.cutoff = 1e-12     # SVD truncation
         self.maxiter = 200      # iDMRG macro-iterations (growth steps)
         self.etol = 1e-10       # energy-density convergence tolerance
-        self.niter = 30         # per-micro-step Lanczos iteration count
+        self.niter = 30         # per-micro-step Lanczos iteration count --
+                                 # note idmrg.py's _local_two_site_solve
+                                 # always runs at least 200 (a validated,
+                                 # load-bearing floor, see its own comment),
+                                 # so any value <=200 here has no effect;
+                                 # only raising it above 200 does anything
         self.verbose = False
 
         self.hamiltonian = None  # user-facing MultiOperator (L/C/R indices)
@@ -164,6 +184,22 @@ class Infinite_Many_Body_Chain:
         """h: a MultiOperator built from this chain's SxL/SxC/SxR-style
         (or get_operator(...,group=...)-built) operators -- see this
         module's docstring for the validity/canonicalization rules."""
+        # NOTE: v1 is Hermitian-only (see this module's docstring) and
+        # idmrg_ground_state has no Hermiticity check of its own, unlike
+        # the finite-chain path (groundstate.py), which gates on
+        # MultiOperator.is_hermitian() and routes a non-Hermitian
+        # Hamiltonian to a dedicated NH-DMRG solver instead -- a real gap
+        # for this module. A symbolic is_hermitian() check was tried here
+        # and reverted: confirmed directly (also on an ordinary *finite*
+        # Spin_Chain, so this is a pre-existing, general limitation, not
+        # specific to this module) that is_hermitian()'s simplify() step
+        # does not recognize that reversing a product of operators on
+        # *different* sites (as get_dagger() does) gives an equivalent
+        # term to the un-reversed original, so it false-rejects an
+        # ordinary Sx[i]*Sx[j]+Sy[i]*Sy[j]+Sz[i]*Sz[j] Heisenberg term --
+        # the single most common Hamiltonian shape this module exists to
+        # support. Left as a known, documented gap rather than shipping
+        # that regression.
         h = multioperator.obj2MO(h)
         self._h_intra, self._h_inter = _canonicalize_hamiltonian(h, self.n_uc)
         self.hamiltonian = h
@@ -193,10 +229,13 @@ class Infinite_Many_Body_Chain:
         translational invariance this is identical for every group, `group`
         is accepted purely so callers can write whichever reads most
         naturally (SxL/SxC/SxR all describe the same infinite chain)."""
-        if self._result is None:
-            self.gs_energy()
         if group not in ("L", "C", "R"):
             raise ValueError("vev: group must be 'L', 'C' or 'R', got {!r}".format(group))
+        if not (0 <= p < self.n_uc):
+            raise ValueError("vev: p must be in 0..{} (n_uc-1), got {!r}".format(
+                self.n_uc - 1, p))
+        if self._result is None:
+            self.gs_energy()
         from .pyitensor import idmrg
         return idmrg.onsite_expectation(self._result, opname, p)
 
@@ -204,6 +243,9 @@ class Infinite_Many_Body_Chain:
         """<opname_i(site p_i) opname_j(site p_i + r)>, r measured in
         physical sites (r>=0) -- see pyitensor.idmrg.two_point_correlator
         for the r=0 (same-site) convention."""
+        if not (0 <= p_i < self.n_uc):
+            raise ValueError("correlator: p_i must be in 0..{} (n_uc-1), got {!r}".format(
+                self.n_uc - 1, p_i))
         if self._result is None:
             self.gs_energy()
         from .pyitensor import idmrg

--- a/src/dmrgpy/infinitechain.py
+++ b/src/dmrgpy/infinitechain.py
@@ -1,0 +1,227 @@
+"""Infinite_Many_Body_Chain: a translationally-invariant chain defined by a
+single n_uc-site unit cell (rather than a fixed total length), solved via
+infinite DMRG (iDMRG, see pyitensor/idmrg.py for the algorithm). This is a
+deliberately independent object, NOT a Many_Body_Chain subclass --
+Many_Body_Chain's whole design (mode dispatch between DMRG/ED, a fixed
+`self.ns`-length site list, KPM/dynamics/entanglement/excited-states
+machinery, ...) assumes a *finite* chain throughout, and none of the finite
+notions (an ED cross-check, a fixed number of sites) have any meaning for
+an infinite system. Only `itensor_version="python"` is supported (iDMRG has
+no C++/Julia backend yet) -- passing anything else raises NotImplementedError
+rather than silently doing something else.
+
+== Hamiltonian specification: L/C/R-suffixed operators ==
+
+Every named operator is exposed three times, as flat suffixed attributes:
+`SxC[i]` (site i of the *central* cell, i=0..n_uc-1 -- ordinary intra-cell
+use, matching today's `Spin_Chain.Sx[i]`-style convention), `SxR[i]` (site i
+of the *next* cell), and `SxL[i]` (site i of the *previous* cell, provided
+purely as an ergonomic mirror so a coupling can be phrased in whichever
+direction is physically natural, e.g. `SxL[i]*SxC[j]` instead of manually
+reflecting indices into a `SxC[i]*SxR[j]` term).
+
+A term is valid iff the set of cell-groups (L/C/R) it touches is a subset of
+{L,C} or of {C,R} -- i.e. it may touch one or two *adjacent* cells, but
+never L and R at once (that would span three cells, out of scope) --
+`set_hamiltonian` validates this and raises ValueError otherwise. Any term
+touching an L-suffixed operator is canonicalized by shifting it one cell to
+the right (L->C, C->R), so the stored Hamiltonian is uniformly "intra-cell C
+terms" + "C-to-R inter-cell terms", each physical bond attributed to
+exactly one cell -- avoiding any double-counting between a cell's own C-R
+terms and its right neighbor's L-C terms, the same way a user is already
+expected not to redundantly write both `Sx[i]*Sx[i+1]` and `Sx[i+1]*Sx[i]`
+for one bond in existing finite-chain code today.
+"""
+
+from . import multioperator
+from .multioperator import MultiOperator
+
+
+def _term_groups(term, n_uc):
+    """The set of cell-groups ('L','C','R') a term's site indices touch,
+    using this module's convention: site<0 -> L, 0<=site<n_uc -> C,
+    site>=n_uc -> R."""
+    groups = set()
+    for _name, site in term[1:]:
+        if site < 0:
+            groups.add("L")
+        elif site < n_uc:
+            groups.add("C")
+        else:
+            groups.add("R")
+    return groups
+
+
+def _wrap_terms(op_terms, name):
+    out = MultiOperator.__new__(MultiOperator)
+    out.name = name
+    out.op = op_terms
+    out.i = len(op_terms) - 1
+    return out
+
+
+def _canonicalize_hamiltonian(h, n_uc):
+    """Validate and split a user-supplied unit-cell MultiOperator (built
+    from SxL/SxC/SxR-style operators) into (h_intra, h_inter): h_intra
+    holds every term touching only the central cell (site indices
+    0..n_uc-1), h_inter holds every term touching the next cell too (some
+    site index >= n_uc, and at least one site index < n_uc -- see below)
+    -- see this module's docstring for why L is canonicalized away
+    (shifted into C/R) before this split, and why that correctly avoids
+    double-counting any bond.
+
+    A term touching *only* R-range sites (no C touch at all -- e.g. a bare
+    `SxR[i]*SxR[j]` coupling) is a pure intra-cell term of the *next* cell,
+    written via R purely for the user's own convenience; it is shifted
+    down by n_uc and filed under h_intra too, so idmrg.py's automaton
+    builder (which requires every 2-site term's smaller site index to be
+    < n_uc) never has to special-case it."""
+    intra_terms, inter_terms = [], []
+    for term in h.op:
+        groups = _term_groups(term, n_uc)
+        if "L" in groups and "R" in groups:
+            raise ValueError(
+                "Infinite_Many_Body_Chain.set_hamiltonian: a term spans "
+                "both the previous (L) and next (R) unit cell at once "
+                "({}) -- only couplings between at most two adjacent unit "
+                "cells are supported".format(term))
+        if "L" in groups:
+            term = [term[0]] + [[name, site + n_uc] for name, site in term[1:]]
+            groups = {("C" if g == "L" else g) for g in groups}
+        if groups == {"R"}:
+            term = [term[0]] + [[name, site - n_uc] for name, site in term[1:]]
+            groups = {"C"}
+        if groups <= {"C"}:
+            intra_terms.append(term)
+        else:
+            inter_terms.append(term)
+    return _wrap_terms(intra_terms, "h_intra"), _wrap_terms(inter_terms, "h_inter")
+
+
+class Infinite_Many_Body_Chain:
+    """iDMRG-only counterpart of Many_Body_Chain (manybodychain.py) -- see
+    this module's docstring. Exposes only the narrow subset of modes v1
+    supports: `set_hamiltonian`, `gs_energy` (converged energy *per site*),
+    and static one-/two-point expectation values (`vev`/`correlator`)."""
+
+    def __init__(self, site_types, itensor_version="python"):
+        if itensor_version != "python":
+            raise NotImplementedError(
+                "Infinite_Many_Body_Chain: only itensor_version=\"python\" "
+                "is implemented (iDMRG has no C++/Julia backend yet)")
+        self.itensor_version = itensor_version
+        self.site_types = list(site_types)
+        self.n_uc = len(self.site_types)
+        if self.n_uc < 1:
+            raise ValueError("Infinite_Many_Body_Chain: the unit cell needs "
+                              "at least one site")
+        if self.n_uc > 2:
+            raise NotImplementedError(
+                "Infinite_Many_Body_Chain: unit cells with more than 2 "
+                "sites (n_uc={}) are not supported yet -- the growth loop's "
+                "micro-step sublattice pairing (pyitensor/idmrg.py's "
+                "p_L=mstep, p_R=n_uc-1-mstep) only produces genuinely "
+                "adjacent active sites for n_uc in {{1, 2}}; for n_uc>=3 it "
+                "pairs non-adjacent sublattice positions whose automaton "
+                "channels carry different, bond-specific pending content "
+                "(not just a matching channel count), so contracting them "
+                "together would silently mix unrelated bond content rather "
+                "than just fail to contract. Fixing this needs a genuine "
+                "redesign of the micro-step growth scheme, not a small "
+                "patch -- flagged as a known follow-up rather than "
+                "attempted here.".format(self.n_uc))
+
+        self.maxm = 30          # wavefunction bond dimension cap
+        self.cutoff = 1e-12     # SVD truncation
+        self.maxiter = 200      # iDMRG macro-iterations (growth steps)
+        self.etol = 1e-10       # energy-density convergence tolerance
+        self.niter = 30         # per-micro-step Lanczos iteration count
+        self.verbose = False
+
+        self.hamiltonian = None  # user-facing MultiOperator (L/C/R indices)
+        self._h_intra = None
+        self._h_inter = None
+        self._result = None      # pyitensor.idmrg.IDMRGResult once converged
+        self.e0 = None           # converged ground-state energy per site
+        self.converged = None
+
+    def get_operator(self, name, i, group="C"):
+        """A bare, symbolic 1-site MultiOperator for `name` at site `i`
+        (0..n_uc-1) of cell-group `group` ('L','C','R') -- mirrors
+        Many_Body_Chain.get_operator's `multioperator.obj2MO([[name,i]])`,
+        just with the L/C/R site-index offset applied first."""
+        if group == "C":
+            site = i
+        elif group == "R":
+            site = self.n_uc + i
+        elif group == "L":
+            site = i - self.n_uc
+        else:
+            raise ValueError("get_operator: group must be 'L', 'C' or 'R', got {!r}".format(group))
+        return multioperator.obj2MO([[name, site]])
+
+    def set_hamiltonian(self, h):
+        """h: a MultiOperator built from this chain's SxL/SxC/SxR-style
+        (or get_operator(...,group=...)-built) operators -- see this
+        module's docstring for the validity/canonicalization rules."""
+        h = multioperator.obj2MO(h)
+        self._h_intra, self._h_inter = _canonicalize_hamiltonian(h, self.n_uc)
+        self.hamiltonian = h
+        self._result = None
+        self.e0 = None
+        self.converged = None
+
+    def gs_energy(self):
+        """Run iDMRG to convergence (or self.maxiter macro-iterations) and
+        return the ground-state energy *per site* -- the physically
+        meaningful observable for an infinite system (a total energy would
+        be unboundedly large)."""
+        if self._h_intra is None:
+            raise RuntimeError(
+                "Infinite_Many_Body_Chain.gs_energy called before set_hamiltonian")
+        from .pyitensor import idmrg
+        self._result = idmrg.idmrg_ground_state(
+            self.site_types, self._h_intra.op, self._h_inter.op, self.n_uc,
+            maxm=self.maxm, cutoff=self.cutoff, maxiter=self.maxiter,
+            etol=self.etol, niter=self.niter, verbose=self.verbose)
+        self.e0 = self._result.e0
+        self.converged = self._result.converged
+        return self.e0
+
+    def vev(self, opname, p, group="C"):
+        """<opname> at site p (0..n_uc-1) of cell-group `group` -- by
+        translational invariance this is identical for every group, `group`
+        is accepted purely so callers can write whichever reads most
+        naturally (SxL/SxC/SxR all describe the same infinite chain)."""
+        if self._result is None:
+            self.gs_energy()
+        if group not in ("L", "C", "R"):
+            raise ValueError("vev: group must be 'L', 'C' or 'R', got {!r}".format(group))
+        from .pyitensor import idmrg
+        return idmrg.onsite_expectation(self._result, opname, p)
+
+    def correlator(self, opname_i, p_i, opname_j, r):
+        """<opname_i(site p_i) opname_j(site p_i + r)>, r measured in
+        physical sites (r>=0) -- see pyitensor.idmrg.two_point_correlator
+        for the r=0 (same-site) convention."""
+        if self._result is None:
+            self.gs_energy()
+        from .pyitensor import idmrg
+        return idmrg.two_point_correlator(self._result, opname_i, p_i, opname_j, r)
+
+
+class Infinite_Spin_Chain(Infinite_Many_Body_Chain):
+    """Infinite counterpart of spinchain.Spin_Chain: a unit cell of `spins`
+    (a list of n_uc spin labels, e.g. "1/2","1",... -- see
+    spinchain.label2site), with SxC/SyC/SzC/SxL/SyL/SzL/SxR/SyR/SzR
+    per-site operator lists (length n_uc each)."""
+
+    def __init__(self, spins, **kwargs):
+        from .spinchain import label2site
+        site_types = [label2site[s] for s in spins]
+        Infinite_Many_Body_Chain.__init__(self, site_types, **kwargs)
+        n = self.n_uc
+        for name in ("Sx", "Sy", "Sz"):
+            for group in ("L", "C", "R"):
+                setattr(self, name + group,
+                        [self.get_operator(name, i, group) for i in range(n)])

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -165,6 +165,24 @@ PYBIND11_MODULE(_dmrgcpp, m)
                "(terms_a) -- see Chain::nhdmrg_generalized's own comment "
                "for the algorithm. Returns (lambda, psil, psir) with "
                "<psil|psir>=1, same convention as nhdmrg().")
+        .def("idmrg_ground_state",[](Chain& self, std::vector<PyTerm> const& terms_intra,
+                                      std::vector<PyTerm> const& terms_inter,
+                                      int maxm, double cutoff, int maxiter, double etol,
+                                      int krylovdim, int restarts) {
+                auto out = self.idmrg_ground_state(terms_from_python(terms_intra),
+                    terms_from_python(terms_inter),maxm,cutoff,maxiter,etol,
+                    krylovdim,restarts);
+                return py::make_tuple(out.density,out.converged,out.niter_done);
+            }, py::arg("terms_intra"),py::arg("terms_inter"),
+               py::arg("maxm"),py::arg("cutoff"),py::arg("maxiter"),py::arg("etol"),
+               py::arg("krylovdim")=30,py::arg("restarts")=2,
+               "Infinite DMRG (iDMRG) ground-state energy density -- this "
+               "Chain must have been constructed with site_types = the "
+               "n_uc-site unit cell (not a full chain), see "
+               "Chain::idmrg_ground_state's own comment for the algorithm "
+               "and scope (Hermitian, n_uc<=2, no fermionic terms, no "
+               "static correlators yet). Returns (density, converged, "
+               "niter_done).")
         .def("vev",[](Chain& self, std::vector<PyTerm> const& terms,
                        MPS const& wf, int npow) {
                 return self.vev(terms_from_python(terms),wf,npow);

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -90,6 +90,66 @@ struct NHDMRGResult
     MPS psil, psir;
     };
 
+// C++ port of pyitensor/idmrg.py's IDMRGResult -- see
+// Chain::idmrg_ground_state's own doc comment for the algorithm and the
+// scope this port covers (ground-state energy density only for now,
+// static correlators not yet ported).
+struct IdmrgResult
+    {
+    double density = 0.0; // converged (or best-so-far) energy per site
+    bool converged = false;
+    int niter_done = 0; // macro-iterations actually run
+    };
+
+// A finite-state-automaton "channel" at one sublattice position, in the
+// exact sense idmrg.py's own _build_automaton docstring documents: "S"
+// (start, kind=0) self-loops via Id and is the only channel a new 2-site
+// term may start from; "F" (accumulator, kind=1) self-loops via Id
+// (picking up onsite terms) and receives completed pending channels;
+// kind=2 is a "pending" channel for a still-open 2-site term, identified
+// by (bond_index, r) exactly as in the Python port.
+struct IdmrgChan
+    {
+    int kind; // 0=S, 1=F, 2=pending
+    int bond_index; // valid iff kind==2
+    int r; // valid iff kind==2
+    };
+
+// A classified 2-site term (idmrg.py's "bonds" dict) -- mat_a/mat_b are
+// dense, row-major (d*d)-sized operator matrices in the same (in,out)
+// convention as ITensor's own SiteSet::op() (see idmrg_op_dense).
+// Fermionic terms (carry_ferm) are not supported by this C++ port yet
+// (always false here) -- see Chain::idmrg_ground_state's own comment.
+struct IdmrgBond
+    {
+    int rel_a, rel_b;
+    std::vector<Cplx> mat_a, mat_b;
+    bool carry_ferm;
+    Cplx coef;
+    };
+
+// A classified 1-site (onsite) term (idmrg.py's "onsite" list entries).
+struct IdmrgOnsite
+    {
+    int rel;
+    Cplx coef;
+    std::vector<Cplx> mat;
+    };
+
+// The precomputed, dense transition-matrix content for one sublattice
+// position p's automaton tensor -- idmrg.py's own W_bulk[p], but kept as
+// plain data (never a persistent ITensor, see idmrg_ground_state's own
+// comment for why) so a fresh ITensor with fresh Index objects can be
+// built from it on demand. flat[(li*right_n+ri)*d*d + s_in*d + s_out] is
+// the (s_in,s_out) matrix element of the li->ri channel transition (all
+// zero, i.e. absent from the automaton, unless idmrg_build_row's own
+// transition rules set it).
+struct IdmrgAutomatonRow
+    {
+    int p, d, left_n, right_n;
+    std::vector<Cplx> flat;
+    };
+
 class Chain
     {
     public:
@@ -1866,6 +1926,211 @@ class Chain
         return mu;
         }
 
+    // Infinite DMRG (iDMRG): C++ port of pyitensor/idmrg.py's growing/
+    // infinite-size algorithm (White 1992, generalized to an n_uc-site
+    // unit cell per McCulloch 2008) -- see that module's own docstring
+    // for the full derivation and bug history; this is a line-for-line
+    // translation of its logic (automaton construction, growth loop,
+    // local 2-site solve, HL/HR extension), not an independent
+    // re-derivation, specifically to avoid reintroducing bugs that were
+    // already found and fixed there over an extensive debugging session.
+    //
+    // This Chain instance must be constructed with site_types = the
+    // *n_uc-site unit cell* (not a full chain) -- infinitechain.py's
+    // itensor_version=3 path does exactly this
+    // (cppext.get_backend(3).Chain(self.site_types)), so sites_ here
+    // directly serves as the unit cell's own SiteSet (sites_.si(p+1),
+    // sites_.op(name,p+1) for p=0..n_uc-1), matching pyitensor's own
+    // sites_uc = SiteX(site_types). n_uc = sites_.length().
+    //
+    // Scope, matching infinitechain.py's v1: Hermitian only (no
+    // Hermiticity check here, same documented-but-unenforced precondition
+    // gs_energy_generalized has for its own A), n_uc<=2 only (rejected
+    // explicitly below -- see idmrg.py's own module docstring for why
+    // n_uc>=3 needs a genuine redesign of the growth loop's sublattice
+    // pairing), and fermionic (Jordan-Wigner-threaded) terms not
+    // supported yet (idmrg_classify_terms always sets carry_ferm=false;
+    // fine for spin/boson-type models, silently wrong for a fermionic
+    // one -- no detection/guard for that case yet). Ground-state energy
+    // density only -- static correlators (onsite_expectation/
+    // two_point_correlator) are not ported to C++ yet; run gs_energy()
+    // via this method for the energy, then reuse pyitensor's own
+    // idmrg.py correlator functions against a separately-run
+    // itensor_version="python" IDMRGResult if correlators are needed.
+    //
+    // terms_intra/terms_inter: 1-based-site MOTerm lists in exactly
+    // infinitechain.py's own h_intra/h_inter split (see
+    // _canonicalize_hamiltonian), but shifted from that module's 0-based
+    // MultiOperator.op site convention to this codebase's usual 1-based
+    // AutoMPO/HTerm convention -- the Python-side caller does this shift
+    // (a trivial +1 per site, no Jordan-Wigner transform, since idmrg.py
+    // never uses MultiOperator's own global JW machinery -- it threads
+    // fermionic strings itself per bond, not implemented here yet, see
+    // above), mirroring MultiOperator.to_terms()'s own site-shift
+    // convention (used by every *other* method in this file) without its
+    // JW transform.
+    //
+    // Real ITensor v3 is *stricter* than pyitensor's own array-backed
+    // ITensor reimplementation about Index identity: IndexSet::checkIndexSet()
+    // throws ITError("Duplicate indices in index set") the instant a
+    // tensor would carry the same Index object on two different axes --
+    // exactly the construction idmrg.py's own W_bulk[p] persistent-tensor
+    // design relies on for n_uc=1 (a single sublattice's left and right
+    // automaton legs are literally the same Index there), and exactly
+    // the root cause of that module's own worst bug (HL's and HR's own
+    // mpo axes colliding across macro-iterations, see idmrg.py's
+    // idmrg_ground_state comment). This port sidesteps the whole bug
+    // class from the start rather than retrofitting a fix: it never
+    // builds a persistent, reusable W_bulk[p] ITensor at all. Instead
+    // idmrg_build_row precomputes each sublattice's channel-transition
+    // content as a plain dense array (IdmrgAutomatonRow), and a fresh
+    // ITensor is minted from that data -- with fresh Index objects on
+    // every leg that needs independence -- every single time it's used,
+    // both for the local-solve W_pL/W_pR and for the HL/HR extension
+    // step's own re-minted mpo axis (idmrg_make_W/idmrg_make_W_start/
+    // idmrg_make_W_end below), i.e. this port is built from the start
+    // with the exact fix idmrg.py's own idmrg_ground_state() had to
+    // retrofit after finding that collision, not a naive first attempt
+    // at the naive (persistent-tensor) design.
+    IdmrgResult
+    idmrg_ground_state(std::vector<MOTerm> const& terms_intra,
+                        std::vector<MOTerm> const& terms_inter,
+                        int maxm, double cutoff, int maxiter, double etol,
+                        int krylovdim, int restarts)
+        {
+        int n_uc = sites_.length();
+        if (n_uc>2)
+            Error("Chain::idmrg_ground_state: n_uc>2 is not supported yet "
+                  "(see this method's own comment)");
+        if (maxiter<2)
+            Error("Chain::idmrg_ground_state: maxiter must be >= 2 (energy "
+                  "density is a finite difference between two "
+                  "macro-iterations)");
+
+        std::vector<IdmrgOnsite> onsite;
+        std::vector<IdmrgBond> bonds;
+        idmrg_classify_terms(terms_intra,terms_inter,n_uc,onsite,bonds);
+
+        std::vector<std::vector<IdmrgChan>> chans(n_uc);
+        for (int p=0;p<n_uc;++p) chans[p] = idmrg_channels_at(bonds,n_uc,p);
+
+        std::vector<IdmrgAutomatonRow> rows;
+        rows.reserve(n_uc);
+        for (int p=0;p<n_uc;++p)
+            rows.push_back(idmrg_build_row(p,n_uc,bonds,onsite,
+                                            chans[p],chans[(p+1)%n_uc]));
+
+        ITensor HL, HR; // default-constructed = "None" (see this file's
+                        // own porting-notes comment on ITensor's explicit
+                        // operator bool())
+        Index HL_bra, HL_ket, HR_bra, HR_ket, HL_mpo, HR_mpo;
+        bool have_HL_ket=false, have_HR_ket=false;
+
+        double energy = 0.0;
+        bool have_prev_energy=false, have_prev_density=false;
+        double prev_energy=0.0, prev_density=0.0;
+        bool converged=false;
+        int macro_iter=0;
+
+        for (macro_iter=0; macro_iter<maxiter; ++macro_iter)
+            {
+            for (int mstep=0; mstep<n_uc; ++mstep)
+                {
+                int p_L = mstep;
+                int p_R = n_uc-1-mstep;
+                bool first_step = (macro_iter==0 && mstep==0);
+                bool same_phys = (p_L==p_R);
+
+                Index phys_L_in = sites_.si(p_L+1);
+                Index phys_L_out = prime(phys_L_in);
+                Index phys_R_in = same_phys ? sim(sites_.si(p_R+1)) : sites_.si(p_R+1);
+                Index phys_R_out = prime(phys_R_in);
+
+                // Crossing bond between W_pL and W_pR within *this*
+                // micro-step's own local solve -- guaranteed the same
+                // dimension on both sides since n_uc<=2 keeps
+                // (p_L+1)%n_uc == p_R (see this method's own comment on
+                // why n_uc>=3 breaks this pairing).
+                Index cross_idx = Index(rows[p_L].right_n,"Link");
+
+                ITensor W_pL, W_pR;
+                if (first_step)
+                    {
+                    W_pL = idmrg_make_W_start(rows[p_L],cross_idx,phys_L_in,phys_L_out);
+                    W_pR = idmrg_make_W_end(rows[p_R],cross_idx,phys_R_in,phys_R_out);
+                    }
+                else
+                    {
+                    W_pL = idmrg_make_W(rows[p_L],HL_mpo,cross_idx,phys_L_in,phys_L_out);
+                    W_pR = idmrg_make_W(rows[p_R],cross_idx,HR_mpo,phys_R_in,phys_R_out);
+                    }
+
+                auto [energy_here,U,V,new_bond_u,new_bond_v] = idmrg_local_solve(
+                    HL,W_pL,phys_L_in,W_pR,phys_R_in,HR,
+                    HL_bra,HL_ket,have_HL_ket,HR_bra,HR_ket,have_HR_ket,
+                    cutoff,maxm,krylovdim,restarts);
+                energy = energy_here;
+
+                Index left_ket_old = HL_ket; bool have_left_ket_old = have_HL_ket;
+                Index right_ket_old = HR_ket; bool have_right_ket_old = have_HR_ket;
+
+                // Fresh, independently-minted mpo-axis identities for the
+                // *extend* step only (not used in the solve above, so
+                // this doesn't disturb the W_pL/W_pR crossing bond the
+                // solve just relied on) -- guarantees the new HL's and
+                // HR's own mpo axes can never collide with each other or
+                // with a future reuse of rows[p], regardless of how
+                // small n_uc is (see this method's own top comment).
+                Index new_HL_mpo = sim(cross_idx);
+                ITensor W_pL_ext = replaceInds(W_pL,{cross_idx},{new_HL_mpo});
+                Index new_HR_mpo = sim(cross_idx);
+                ITensor W_pR_ext = replaceInds(W_pR,{cross_idx},{new_HR_mpo});
+
+                bool have_HL = bool(HL), have_HR = bool(HR);
+                auto [newHL,newHL_bra] = idmrg_extend_HL(
+                    HL,HL_bra,have_HL,W_pL_ext,U,
+                    left_ket_old,have_left_ket_old,new_bond_u);
+                HL = newHL; HL_bra = newHL_bra;
+                HL_ket = new_bond_u; have_HL_ket = true;
+
+                auto [newHR,newHR_bra] = idmrg_extend_HR(
+                    HR,HR_bra,have_HR,W_pR_ext,V,
+                    right_ket_old,have_right_ket_old,new_bond_v);
+                HR = newHR; HR_bra = newHR_bra;
+                HR_ket = new_bond_v; have_HR_ket = true;
+
+                HL_mpo = new_HL_mpo;
+                HR_mpo = new_HR_mpo;
+                }
+
+            bool have_density = have_prev_energy;
+            double density = have_density ? (energy-prev_energy)/(2.0*n_uc) : 0.0;
+            if (verbose_)
+                println("idmrg macro-iter ",macro_iter,": E=",energy,
+                        " density=",(have_density?density:0.0));
+            if (have_density && have_prev_density &&
+                std::abs(density-prev_density)<etol)
+                converged = true;
+            prev_energy = energy; have_prev_energy = true;
+            if (have_density) { prev_density = density; have_prev_density = true; }
+            if (converged) break;
+            }
+
+        IdmrgResult out;
+        out.density = prev_density;
+        out.converged = converged;
+        // C++'s own for-loop increments macro_iter to maxiter itself (not
+        // maxiter-1) before the loop condition fails and exits, unlike
+        // Python's "for macro_iter in range(maxiter)" whose loop variable
+        // retains its *last-assigned* value (maxiter-1) when not broken
+        // out of early -- min() here reconciles the two conventions so
+        // niter_done matches Python's own idmrg_ground_state exactly in
+        // both the converged (break, macro_iter<maxiter) and
+        // ran-to-completion (macro_iter==maxiter) cases.
+        out.niter_done = std::min(macro_iter+1,maxiter);
+        return out;
+        }
+
     private:
     // v2's plain "MPS(sites_)" (no InitState) doesn't carry over as a bare
     // MPS(SiteSet)/InitState-based product state: with sites_ built
@@ -2215,6 +2480,433 @@ class Chain
             if (resid_est<1e-10*(1.0+std::abs(ebest))) break;
             }
         return {lambda,x0};
+        }
+
+    // -- iDMRG private helpers (Chain::idmrg_ground_state, public, above) --
+    // A direct C++ translation of pyitensor/idmrg.py's _term_site_matrices/
+    // _classify_terms/_active_channels_at/_onsite_matrix/_build_automaton --
+    // see that module's own docstrings for the algorithm; comments here
+    // only note where the C++ port genuinely differs (dense-array-only
+    // automaton storage, 1-based sites, no fermionic support yet).
+
+    // Dense (row-major, (in,out)-convention) matrix for a named single-site
+    // operator at 0-based sublattice position p0based -- the C++ analogue
+    // of pyitensor's SiteType.matrix(name), read directly off
+    // SiteSet::op() (unprimed leg "In", primed leg "Out", same convention
+    // _term_site_matrices's own docstring cross-references).
+    std::vector<Cplx>
+    idmrg_op_dense(int p0based, std::string const& name) const
+        {
+        int site1 = p0based+1;
+        int d = dim(sites_.si(site1));
+        auto Op = sites_.op(name,site1);
+        auto s = sites_.si(site1);
+        auto sp = prime(s);
+        std::vector<Cplx> M(d*d,Cplx(0,0));
+        for (int i=1;i<=d;++i)
+        for (int j=1;j<=d;++j)
+            M[(i-1)*d+(j-1)] = eltC(Op,s(i),sp(j));
+        return M;
+        }
+
+    static std::vector<Cplx>
+    idmrg_matmul(std::vector<Cplx> const& A, std::vector<Cplx> const& B, int d)
+        {
+        std::vector<Cplx> C(d*d,Cplx(0,0));
+        for (int i=0;i<d;++i)
+        for (int j=0;j<d;++j)
+            {
+            Cplx acc(0,0);
+            for (int k=0;k<d;++k) acc += A[i*d+k]*B[k*d+j];
+            C[i*d+j] = acc;
+            }
+        return C;
+        }
+
+    // Classifies every term (terms_intra ++ terms_inter, MOTerm's own
+    // 1-based sites converted to 0-based here to match idmrg.py's own
+    // arithmetic exactly) into 1-site (onsite) and 2-site (bonds) pieces,
+    // composing multiple same-site operator factors via reversed matrix
+    // product exactly like _term_site_matrices does (mats[-1] first,
+    // then left-multiplied by each earlier factor in reverse -- i.e. for
+    // factors written [A,B,C] at one site, the composed matrix is C@B@A).
+    void
+    idmrg_classify_terms(std::vector<MOTerm> const& terms_intra,
+                          std::vector<MOTerm> const& terms_inter, int n_uc,
+                          std::vector<IdmrgOnsite>& onsite,
+                          std::vector<IdmrgBond>& bonds) const
+        {
+        std::vector<MOTerm> all_terms = terms_intra;
+        all_terms.insert(all_terms.end(),terms_inter.begin(),terms_inter.end());
+        for (auto const& term : all_terms)
+            {
+            std::map<int,std::vector<std::string>> by_site;
+            for (auto const& f : term.factors) by_site[f.site-1].push_back(f.name);
+            std::vector<int> rel_sites;
+            for (auto const& kv : by_site) rel_sites.push_back(kv.first);
+            std::sort(rel_sites.begin(),rel_sites.end());
+            if (rel_sites.size()>2)
+                Error("Chain::idmrg_ground_state: a term touches more than "
+                      "2 distinct sites -- only 1- and 2-site terms are "
+                      "supported");
+            std::vector<std::vector<Cplx>> mats;
+            for (int rel : rel_sites)
+                {
+                int p = ((rel % n_uc)+n_uc) % n_uc;
+                auto const& names = by_site[rel];
+                int d = dim(sites_.si(p+1));
+                auto combined = idmrg_op_dense(p,names.back());
+                for (int k=(int)names.size()-2;k>=0;--k)
+                    combined = idmrg_matmul(combined,idmrg_op_dense(p,names[k]),d);
+                mats.push_back(std::move(combined));
+                }
+            if (rel_sites.size()==1)
+                onsite.push_back(IdmrgOnsite{rel_sites[0],term.coef,mats[0]});
+            else if (rel_sites.size()==2)
+                {
+                int a = rel_sites[0], b = rel_sites[1];
+                if (a>=n_uc)
+                    Error("Chain::idmrg_ground_state: internal error -- "
+                          "inter-cell term does not touch the central cell");
+                bonds.push_back(IdmrgBond{a,b,mats[0],mats[1],false,term.coef});
+                }
+            }
+        }
+
+    // [(bond_index,r), ...] for every 2-site term with a "pending"
+    // instance active just before absorbing sublattice p -- exactly
+    // idmrg.py's own _active_channels_at, same formula/derivation (see
+    // that function's own docstring for why "+1").
+    std::vector<std::pair<int,int>>
+    idmrg_active_channels_at(std::vector<IdmrgBond> const& bonds, int n_uc, int p) const
+        {
+        std::vector<std::pair<int,int>> out;
+        for (int bi=0;bi<(int)bonds.size();++bi)
+            {
+            int reach = bonds[bi].rel_b - bonds[bi].rel_a;
+            for (int r=1;r<=reach;++r)
+                {
+                int m = ((bonds[bi].rel_b - r + 1) % n_uc + n_uc) % n_uc;
+                if (m==p) out.push_back({bi,r});
+                }
+            }
+        return out;
+        }
+
+    std::vector<IdmrgChan>
+    idmrg_channels_at(std::vector<IdmrgBond> const& bonds, int n_uc, int p) const
+        {
+        std::vector<IdmrgChan> chans;
+        chans.push_back(IdmrgChan{0,-1,-1}); // S
+        chans.push_back(IdmrgChan{1,-1,-1}); // F
+        for (auto const& br : idmrg_active_channels_at(bonds,n_uc,p))
+            chans.push_back(IdmrgChan{2,br.first,br.second});
+        return chans;
+        }
+
+    // Sum of coef*mat over every onsite term attributed to sublattice p --
+    // an empty vector (not a zero matrix) means "no onsite term here",
+    // exactly like idmrg.py's own _onsite_matrix returning None.
+    std::vector<Cplx>
+    idmrg_onsite_matrix(std::vector<IdmrgOnsite> const& onsite, int p, int d) const
+        {
+        std::vector<Cplx> mat;
+        for (auto const& o : onsite)
+            {
+            if (o.rel != p) continue;
+            if (mat.empty())
+                {
+                mat.resize(d*d);
+                for (int k=0;k<d*d;++k) mat[k] = o.coef*o.mat[k];
+                }
+            else
+                for (int k=0;k<d*d;++k) mat[k] += o.coef*o.mat[k];
+            }
+        return mat;
+        }
+
+    // The dense transition-matrix content for sublattice p, given its own
+    // left/right channel lists -- a direct translation of
+    // _build_automaton's own big if/elif transition-rule chain (see that
+    // function's docstring for the derivation of each case). Fermionic
+    // strings are not supported yet (the last branch always uses Id,
+    // never sites_.op("F",...); idmrg_classify_terms always sets
+    // carry_ferm=false so this is never exercised differently).
+    IdmrgAutomatonRow
+    idmrg_build_row(int p, int n_uc, std::vector<IdmrgBond> const& bonds,
+                     std::vector<IdmrgOnsite> const& onsite,
+                     std::vector<IdmrgChan> const& left,
+                     std::vector<IdmrgChan> const& right) const
+        {
+        int d = dim(sites_.si(p+1));
+        auto onsite_mat = idmrg_onsite_matrix(onsite,p,d);
+        IdmrgAutomatonRow row;
+        row.p=p; row.d=d; row.left_n=(int)left.size(); row.right_n=(int)right.size();
+        row.flat.assign((size_t)row.left_n*row.right_n*d*d,Cplx(0,0));
+        auto setmat = [&](int li,int ri,std::vector<Cplx> const& mat)
+            {
+            size_t base = ((size_t)li*row.right_n+ri)*d*d;
+            for (int k=0;k<d*d;++k) row.flat[base+k] = mat[k];
+            };
+        auto eye = [&]()
+            {
+            std::vector<Cplx> I(d*d,Cplx(0,0));
+            for (int i=0;i<d;++i) I[i*d+i] = Cplx(1,0);
+            return I;
+            };
+        for (int li=0;li<row.left_n;++li)
+        for (int ri=0;ri<row.right_n;++ri)
+            {
+            auto const& lch = left[li];
+            auto const& rch = right[ri];
+            bool l_triv = (lch.kind==0 || lch.kind==1);
+            bool r_triv = (rch.kind==0 || rch.kind==1);
+            if (lch.kind==0 && rch.kind==0)
+                {
+                setmat(li,ri,eye());
+                }
+            else if (lch.kind==1 && rch.kind==1)
+                {
+                auto mat = eye();
+                if (!onsite_mat.empty())
+                    for (int k=0;k<d*d;++k) mat[k] += onsite_mat[k];
+                setmat(li,ri,mat);
+                }
+            else if (lch.kind==0 && !r_triv)
+                {
+                auto const& b = bonds[rch.bond_index];
+                if (rch.r==b.rel_b-b.rel_a && b.rel_a==p)
+                    {
+                    std::vector<Cplx> mat(d*d);
+                    for (int k=0;k<d*d;++k) mat[k] = b.coef*b.mat_a[k];
+                    setmat(li,ri,mat);
+                    }
+                }
+            else if (rch.kind==1 && !l_triv)
+                {
+                auto const& b = bonds[lch.bond_index];
+                if (lch.r==1) setmat(li,ri,b.mat_b);
+                }
+            else if (!l_triv && !r_triv)
+                {
+                if (lch.bond_index==rch.bond_index && rch.r==lch.r-1)
+                    setmat(li,ri,eye()); // carry_ferm always false in this port
+                }
+            }
+        return row;
+        }
+
+    // Fresh ITensor from row's dense data (bulk case: rank 4). left_idx's
+    // dim must equal row.left_n, right_idx's row.right_n, phys_in/out's
+    // row.d -- the caller is responsible for supplying Index objects of
+    // the right dimension (idmrg_ground_state always does, by
+    // construction: cross_idx/HL_mpo/HR_mpo are minted or tracked with
+    // exactly these dimensions).
+    ITensor
+    idmrg_make_W(IdmrgAutomatonRow const& row, Index left_idx, Index right_idx,
+                 Index phys_in, Index phys_out) const
+        {
+        ITensor T(left_idx,phys_in,phys_out,right_idx);
+        for (int li=0;li<row.left_n;++li)
+        for (int ri=0;ri<row.right_n;++ri)
+        for (int si=0;si<row.d;++si)
+        for (int so=0;so<row.d;++so)
+            {
+            Cplx v = row.flat[((size_t)li*row.right_n+ri)*row.d*row.d + si*row.d+so];
+            if (v != Cplx(0,0))
+                T.set({left_idx(li+1),phys_in(si+1),phys_out(so+1),right_idx(ri+1)},v);
+            }
+        return T;
+        }
+
+    // Boundary tensor for the very first-ever micro-step's left side:
+    // row's "S" row only (li=0) -- the C++ analogue of idmrg.py's
+    // _project_channel(W_bulk[0],"left",0), but built directly from dense
+    // data instead of projecting an existing persistent ITensor (this
+    // port never builds one, see idmrg_ground_state's own top comment).
+    ITensor
+    idmrg_make_W_start(IdmrgAutomatonRow const& row, Index right_idx,
+                        Index phys_in, Index phys_out) const
+        {
+        ITensor T(phys_in,phys_out,right_idx);
+        int li = 0; // S
+        for (int ri=0;ri<row.right_n;++ri)
+        for (int si=0;si<row.d;++si)
+        for (int so=0;so<row.d;++so)
+            {
+            Cplx v = row.flat[((size_t)li*row.right_n+ri)*row.d*row.d + si*row.d+so];
+            if (v != Cplx(0,0))
+                T.set({phys_in(si+1),phys_out(so+1),right_idx(ri+1)},v);
+            }
+        return T;
+        }
+
+    // Boundary tensor for the very first-ever micro-step's right side:
+    // row's "F" column only (ri=1) -- analogue of
+    // _project_channel(W_bulk[n_uc-1],"right",1).
+    ITensor
+    idmrg_make_W_end(IdmrgAutomatonRow const& row, Index left_idx,
+                      Index phys_in, Index phys_out) const
+        {
+        ITensor T(left_idx,phys_in,phys_out);
+        int ri = 1; // F
+        for (int li=0;li<row.left_n;++li)
+        for (int si=0;si<row.d;++si)
+        for (int so=0;so<row.d;++so)
+            {
+            Cplx v = row.flat[((size_t)li*row.right_n+ri)*row.d*row.d + si*row.d+so];
+            if (v != Cplx(0,0))
+                T.set({left_idx(li+1),phys_in(si+1),phys_out(so+1)},v);
+            }
+        return T;
+        }
+
+    // One micro-step's local ground-state solve: the effective 2-site
+    // Hamiltonian sandwiched by (HL, W_pL, W_pR, HR), diagonalized via
+    // arnoldi_smallest_real(..., Sel::SR) (the smallest-real-part Ritz
+    // value of a Hermitian operator *is* its ground state, so the
+    // existing non-Hermitian-capable Arnoldi engine already used by
+    // nhdmrg_one_sweep above is reused directly rather than writing a
+    // second, Hermitian-only Krylov solver) -- matches idmrg.py's own
+    // _local_two_site_solve (kernels.make_matvec + dmrg._lanczos_ground_state),
+    // but ITensor's own operator* already does all the index-matching
+    // contraction that Python's kernels.py has to hand-roll. No
+    // pre-existing ket tensor to seed the local guess from (every
+    // micro-step inserts brand-new sites), so the Arnoldi start vector is
+    // always a fresh random one (randomITensorC), matching
+    // idmrg.py's own rationale (see that function's own docstring on why
+    // mpscpp3/pyitensor never seed DMRG from a product state). U and V
+    // are returned *without* S (the singular values are discarded): HL/HR
+    // are block operators built by a similarity transform through U (or
+    // V) alone, exactly idmrg.py's own convention -- see that function's
+    // own extensive comment on why absorbing sqrt(S) into both sides
+    // instead is wrong (confirmed there against independent ED).
+    //
+    // A dedicated Hermitian Lanczos solver with early-exit convergence
+    // checking (mirroring pyitensor's own _lanczos_ground_state) was
+    // tried here to cut the remaining Krylov-solve cost further, but was
+    // reverted after it produced measurably wrong ground-state energies
+    // once bond dimension grew large (traced to some accumulated-error or
+    // logic issue in that from-scratch routine that this port's own
+    // regression tests didn't catch quickly enough to trust shipping it)
+    // -- arnoldi_smallest_real's own double-reorthogonalization,
+    // proven-correct machinery is kept here instead. See this codebase's
+    // iDMRG optimization history for the (much larger) fix that *is* kept:
+    // idmrg_extend_HL/HR's contraction-order reordering below.
+    std::tuple<double,ITensor,ITensor,Index,Index>
+    idmrg_local_solve(ITensor const& HL, ITensor const& W_pL, Index phys_L,
+                       ITensor const& W_pR, Index phys_R, ITensor const& HR,
+                       Index HL_bra, Index HL_ket, bool have_HL_ket,
+                       Index HR_bra, Index HR_ket, bool have_HR_ket,
+                       double cutoff, int maxdim, int krylovdim, int restarts) const
+        {
+        std::vector<Index> order_in;
+        if (have_HL_ket) order_in.push_back(HL_ket);
+        order_in.push_back(phys_L);
+        order_in.push_back(phys_R);
+        if (have_HR_ket) order_in.push_back(HR_ket);
+        auto x0 = randomITensorC(IndexSet(order_in));
+
+        // matvec must be an endomorphism on v's own index space (same
+        // indices in and out) for arnoldi_smallest_real's own inner
+        // products (dag(V.at(i))*w) to reduce to a scalar -- true for
+        // nhdmrg_one_sweep's own apply_proj only because its psil/psir
+        // *share* link-index identities by construction (bra vs ket
+        // there is a *temporary* prime distinction within one
+        // computation, undone by noPrime()); HL's/HR's own bra Index
+        // (minted via sim(), not prime(), in idmrg_extend_HL/HR below)
+        // is a *permanently* distinct object from their own ket Index,
+        // so noPrime() alone does not reconcile the physical-leg
+        // "out"->"in" relabeling with the link-leg "bra"->"ket" one --
+        // do the latter explicitly.
+        auto matvec = [&](ITensor v) -> ITensor
+            {
+            if (HL) v *= HL;
+            v *= W_pL;
+            v *= W_pR;
+            if (HR) v *= HR;
+            v.noPrime();
+            if (have_HL_ket) v = replaceInds(v,{HL_bra},{HL_ket});
+            if (have_HR_ket) v = replaceInds(v,{HR_bra},{HR_ket});
+            return v;
+            };
+
+        auto result = arnoldi_smallest_real(matvec,x0,krylovdim,restarts,Sel::SR,Cplx(0,0));
+        double energy = result.first.real();
+        ITensor theta = result.second;
+
+        std::vector<Index> left_inds;
+        if (have_HL_ket) left_inds.push_back(HL_ket);
+        left_inds.push_back(phys_L);
+        auto [U,S,V] = svd(theta,IndexSet(left_inds),{"Cutoff",cutoff,"MaxDim",maxdim});
+        Index new_bond_u = commonIndex(U,S);
+        Index new_bond_v = commonIndex(S,V);
+        return {energy,U,V,new_bond_u,new_bond_v};
+        }
+
+    // Absorb the newly-solved left-canonical site tensor U into HL, using
+    // MPO tensor W_p for the sublattice just absorbed -- the C++ analogue
+    // of idmrg.py's _extend_HL, but using ITensor's own operator*
+    // (automatic index-matching contraction) instead of Python's
+    // contract_many()+manual bra-Index substitution. left_ket_old is U's
+    // own link toward the *existing* HL (only used if have_left_ket_old);
+    // right_ket_new is U's own freshly-minted link away from HL (always
+    // present). Returns (new_HL, new_HL_bra) where new_HL_bra is
+    // right_ket_new's own bra-side counterpart, to be threaded into the
+    // *next* call.
+    std::pair<ITensor,Index>
+    idmrg_extend_HL(ITensor const& HL, Index HL_bra, bool have_HL,
+                     ITensor const& W_p, ITensor const& U,
+                     Index left_ket_old, bool have_left_ket_old,
+                     Index right_ket_new) const
+        {
+        Index right_bra_new = sim(right_ket_new);
+        ITensor bra_piece = dag(prime(U,TagSet("Site")));
+        if (have_left_ket_old)
+            bra_piece = replaceInds(bra_piece,{left_ket_old},{HL_bra});
+        bra_piece = replaceInds(bra_piece,{right_ket_new},{right_bra_new});
+        // Contraction order matters here even though the result doesn't:
+        // U (and, before the replaceInds calls above, bra_piece) still
+        // carries its own un-renamed copies of left_ket_old/right_ket_new,
+        // which only cancel once HL itself is multiplied in (HL is the
+        // only piece sharing HL_bra/HL_mpo/left_ket_old all at once). The
+        // naive left-to-right "bra_piece*W_p*U" order defers that
+        // cancellation to the very last step, so the (bra_piece*W_p)*U
+        // contraction shares only the physical index (dim d) and produces
+        // a huge near-outer-product intermediate carrying every one of
+        // HL_bra/HL_ket_old/right_bra_new/right_ket_new's own maxdim-sized
+        // legs at once (maxdim^4 elements) before immediately collapsing
+        // back down to a small rank-3 result -- confirmed by profiling:
+        // this was >90% of the C++ port's total iDMRG runtime before this
+        // fix. Contracting HL in first keeps every intermediate rank<=4
+        // and small throughout, matching the same, correct answer.
+        ITensor new_HL;
+        if (have_HL) new_HL = (HL * bra_piece) * W_p * U;
+        else new_HL = bra_piece * W_p * U;
+        return {new_HL,right_bra_new};
+        }
+
+    // Mirror of idmrg_extend_HL: V (the newly-solved right-canonical site
+    // tensor) is absorbed into HR by prepending it on HR's left.
+    std::pair<ITensor,Index>
+    idmrg_extend_HR(ITensor const& HR, Index HR_bra, bool have_HR,
+                     ITensor const& W_p, ITensor const& V,
+                     Index right_ket_old, bool have_right_ket_old,
+                     Index left_ket_new) const
+        {
+        Index left_bra_new = sim(left_ket_new);
+        ITensor bra_piece = dag(prime(V,TagSet("Site")));
+        if (have_right_ket_old)
+            bra_piece = replaceInds(bra_piece,{right_ket_old},{HR_bra});
+        bra_piece = replaceInds(bra_piece,{left_ket_new},{left_bra_new});
+        // Same contraction-order fix as idmrg_extend_HL above (see its own
+        // comment for the full derivation): contract HR in first so every
+        // intermediate stays small instead of forming a maxdim^4-sized
+        // near-outer-product that only collapses on the last multiply.
+        ITensor new_HR;
+        if (have_HR) new_HR = (HR * bra_piece) * W_p * V;
+        else new_HR = bra_piece * W_p * V;
+        return {new_HR,left_bra_new};
         }
 
     Args

--- a/src/dmrgpy/pyitensor/idmrg.py
+++ b/src/dmrgpy/pyitensor/idmrg.py
@@ -1,0 +1,837 @@
+"""Infinite DMRG (iDMRG): the standard 2-site growing/infinite-size
+algorithm (White, PRL 69, 2863 (1992)), generalized to an n_uc-site unit
+cell per McCulloch's "Infinite size density matrix renormalization group,
+revisited" (arXiv:0804.2509) -- following the shape of the reference
+implementation at github.com/ITensor/iDMRG.
+
+This module is self-contained within the pyitensor engine: it reuses
+tensor.py/svd.py/kernels.py directly and imports only `_lanczos_ground_state`
+from dmrg.py (a generic, chain-position-agnostic Lanczos solver), but never
+imports `multioperator.py` or anything from the top-level dmrgpy package --
+exactly mirroring how chain.py itself only ever consumes an already-
+`MultiOperator.to_terms()`-shaped term list, never a MultiOperator object.
+`infinitechain.py` (the Many_Body_Chain-level API) is responsible for
+validating/canonicalizing the user's Hamiltonian into the plain
+`MultiOperator.op`-shaped term lists (`h_intra_op`, `h_inter_op` below,
+0-based site indices, no Jordan-Wigner threading needed -- this module
+threads Jordan-Wigner strings itself, term by term, exactly like
+autompo.HTerm.resolve() does, see `_term_site_matrices`) that this module's
+functions take directly.
+
+== Why the periodic MPO tensor is built directly, not extracted ==
+
+An earlier version of this module built a small (m=3 unit cells) finite
+reference system via the existing AutoMPO/mpobuilder.to_mpo machinery, and
+tried to extract one repeating MPO tensor per sublattice position from its
+middle repeat, relabeling bond Indices so the same tensor could be reused
+indefinitely. Two independent bugs were found this way, both confirmed by
+direct numerical checks (not just suspected):
+
+1. `to_mpo`'s SVD-based compression picks an independent, arbitrary U/V
+   basis at *every* bond, even at cutoff=0. Two positions of the compressed
+   MPO that represent the exact same repeating physical bond can therefore
+   come out expressed in different, non-interchangeable bases despite
+   having the same dimension -- reusing one Index object across them (the
+   whole point of the extraction) silently produced a measurably
+   non-Hermitian effective 2-site Hamiltonian (~16% relative asymmetry)
+   instead of raising. Building the reference MPO as an *exact,
+   uncompressed* sum of per-term MPOs instead (no SVD at all) fixed this
+   specific symptom -- but:
+2. Even with that fixed, the reported energy density still converged to 0
+   instead of the correct value. The root cause: a tensor extracted from
+   any *fixed, finite* reference system has a bond dimension tied to that
+   reference's own (finite) term count, with no channel that has an
+   unconditional identity self-loop -- i.e. no genuine "accumulator" that
+   can keep summing contributions across an *unbounded* number of repeats.
+   Reusing such a tensor forever caps how much Hamiltonian content a fixed
+   bond dimension can hold, which is exactly why the reported energy
+   stopped growing extensively and instead decayed toward 0.
+
+The fix implemented below is to build each sublattice's periodic MPO tensor
+*directly*, as a genuine finite-state automaton (see `_build_automaton`):
+one "F" (accumulator) channel with an Id self-loop, plus one "pending"
+channel per still-open 2-site term -- the same structure any standard
+finite-range-Hamiltonian MPO textbook derivation uses (e.g. the familiar
+bond-dimension-5 NN Heisenberg MPO), generalized here to the "at most two
+adjacent unit cells" term range `infinitechain.py` validates. Because this
+tensor is built directly rather than extracted from an independently
+gauge-fixed system, its own left and right bond Indices are, by
+construction, indexed by the identical, explicitly-enumerated channel list
+-- no relabeling, no gauge ambiguity, and (unlike the finite reference) an
+unconditional identity self-loop on the accumulator channel, so the growth
+loop can sum an unbounded number of repeats at fixed bond dimension.
+
+== The growing algorithm, concretely ==
+
+1. Build the periodic per-sublattice automaton tensors W[0..n_uc-1] (see
+   `_build_automaton`, channel space "S" + "F" (accumulator) + pending),
+   plus two dedicated *boundary* tensors, both via `_project_channel`:
+   project W[0]'s left leg onto "S" for the very first site ever absorbed
+   into HL, and W[n_uc-1]'s right leg onto "F" for the very first site
+   ever absorbed into HR.
+2. Grow two environments HL/HR, cold-started at `HL=HR=None` (the same
+   sentinel dmrg.py's own `_all_left_environments`/`_all_right_environments`
+   use for an open chain's true boundary). Each *macro-iteration* performs
+   `n_uc` *micro-steps* (one full unit cell added to each side); at
+   micro-step `m` (0..n_uc-1) the two newly-inserted sites have sublattice
+   `p_L=m` (extending HL) and `p_R=n_uc-1-m` (extending HR). This indexing
+   keeps each side's *own* absorption order correctly continuous (HL always
+   absorbs 0,1,...,n_uc-1 in order; HR's own internal order, after
+   prepending, works out the same way -- verified by hand for n_uc=2), but
+   the two *active* sites phys_L/phys_R of one micro-step are only
+   genuinely adjacent to each other (a real requirement for the 2-site
+   solve below to be physically meaningful) when n_uc<=2 -- for n_uc>=3 an
+   intermediate micro-step's phys_L and phys_R are several sites apart with
+   real, not-yet-inserted sites in between, and `_build_automaton`'s own
+   per-sublattice pending-channel content (see its docstring) differs
+   between the two, so there is no way to even wire them together
+   correctly without a genuine redesign of this pairing scheme. `n_uc>=3`
+   is therefore rejected explicitly (`infinitechain.py`'s constructor),
+   rather than left to fail confusingly deep inside a Lanczos call.
+3. Each micro-step's 2-site local ground state is found by the same
+   matvec-and-Lanczos machinery dmrg.py's own two_site_heff/
+   _local_ground_state use (`kernels.make_matvec` + `dmrg._lanczos_ground_state`,
+   imported directly, not duplicated), SVD-split (`svd.svd`) into a new
+   left-canonical tensor (absorbed into HL) and right-canonical tensor
+   (absorbed into HR). `idmrg_ground_state` re-mints a fresh mpo-axis
+   Index for HL's and HR's own environment tensor at the end of *every*
+   micro-step (see its own inline comment) rather than reusing whatever
+   Index `_build_automaton` happened to label that channel space with --
+   required because `_build_automaton`'s `boundary_idx` pool has only
+   `n_uc` distinct Index objects total, reused verbatim every time a given
+   sublattice position comes up again (every macro-iteration past the
+   first); left un-broken, HL's and HR's own mpo axes can end up being the
+   *same* Index object (guaranteed for n_uc=1, where a single sublattice's
+   left and right automaton legs are literally identical) once both
+   environments are non-trivial and used together in the same
+   `_local_two_site_solve` call, corrupting the effective Hamiltonian from
+   the second macro-iteration onward -- confirmed by extracting the dense
+   Heff at macro-iteration 2 of a uniform n_uc=1 chain and finding its full
+   eigenvalue spectrum did not match exact 6-site ED at all (not a
+   truncation effect: macro-iteration 1's spectrum matched ED to machine
+   precision).
+4. Convergence: once per macro-iteration, the finite-difference of the
+   local ground-state eigenvalue between consecutive macro-iterations,
+   divided by 2*n_uc (exactly the number of new physical sites per
+   macro-iteration), is compared against `etol` -- the standard infinite-
+   algorithm energy-density diagnostic.
+
+== Static correlators ==
+
+After convergence, the last macro-iteration's own per-micro-step
+left-canonical tensors (one per sublattice position) are taken as the
+converged unit cell's canonical MPS tensors, and one-/two-point static
+expectation values are computed via the standard infinite-MPS
+transfer-matrix formalism (dominant left/right fixed points of the
+per-unit-cell transfer operator) -- see `onsite_expectation`/
+`two_point_correlator`.
+"""
+
+import numpy as np
+
+from . import kernels
+from .dmrg import _lanczos_ground_state
+from .index import Index
+from .sites import SiteX
+from .sites.base import is_fermionic
+from .svd import svd
+from .tensor import ITensor, contract_many, dag
+from .tensor import prime as _t_prime
+
+
+def _unprimed_site_index(W):
+    """The unprimed ("ket"-side) Site-tagged Index of an MPO tensor W --
+    always its own physical leg, regardless of whether W is a bulk tensor
+    or one of the two projected boundary tensors (see `_project_channel`),
+    which is why this is read off W itself rather than looked up
+    separately."""
+    return next(ind for ind in W.inds if ind.hastags("Site") and ind.plev == 0)
+
+
+def _fresh_physical_copy(W):
+    """W with a freshly-minted (unprimed,primed) physical Index pair,
+    every other (Link/mpo-bond) leg untouched -- needed whenever the exact
+    same per-sublattice MPO tensor object is used for *both* active sites
+    of one micro-step (p_L==p_R, which happens at exactly one micro-step
+    per macro-iteration whenever n_uc is odd, including every micro-step
+    of a uniform n_uc=1 chain). Without this, the "two different" physical
+    legs of the local 2-site problem would collide onto the very same
+    Index object (since they'd both be read off the identical W tensor),
+    silently corrupting the local eigenproblem instead of raising -- caught
+    directly via a ValueError from kernels.py's index-matching machinery
+    on an n_uc=1 test case before this fix was added."""
+    old = _unprimed_site_index(W)
+    new = old.sim()
+    new_inds = tuple(new.setprime(ind.plev) if ind.id == old.id else ind
+                      for ind in W.inds)
+    return ITensor(new_inds, W.array)
+
+
+def _term_site_matrices(op_term, sites_uc, n_uc):
+    """op_term: (coef, [(name,rel_site), ...]) in MultiOperator.op format,
+    rel_site 0-based, spanning at most 2 distinct sites (validated by
+    infinitechain.py's `set_hamiltonian`). Returns (rel_sites_sorted, coef,
+    mats, ferm): rel_sites_sorted is the sorted list of distinct touched
+    sites (length 1 or 2); mats[k] is the composed (dim,dim) matrix at
+    rel_sites_sorted[k] (multiple operator factors at the same site are
+    combined via matrix product, reversed and un-transposed relative to
+    the term's own given order -- the same net composition
+    autompo.HTerm.resolve() computes for its "stored", (in,out)-convention
+    per-site matrix, worked out by tracing through its own std-convention
+    `.T`/composition steps); ferm[k] is whether an odd number of fermionic
+    factors occur at that site -- used by `_classify_terms` to decide
+    whether the "still open" channel between two touched sites of a 2-site
+    term must propagate a Jordan-Wigner "F" string or a plain identity
+    (mirrors HTerm.resolve()'s own `is_site_fermionic`-triggered carry
+    flag, which only ever depends on the *first* touched site of a term)."""
+    coef = op_term[0]
+    by_site = {}
+    for name, site in op_term[1:]:
+        by_site.setdefault(site, []).append(name)
+    rel_sites = sorted(by_site)
+    mats, ferm = [], []
+    for site in rel_sites:
+        names = by_site[site]
+        st = sites_uc.site_type((site % n_uc) + 1)
+        combined = st.matrix(names[-1])
+        for nm in reversed(names[:-1]):
+            combined = combined @ st.matrix(nm)
+        mats.append(combined)
+        ferm.append(sum(1 for nm in names if is_fermionic(nm)) % 2 == 1)
+    return rel_sites, complex(coef), mats, ferm
+
+
+def _classify_terms(h_intra_op, h_inter_op, sites_uc, n_uc):
+    """h_intra_op/h_inter_op -> (onsite, bonds): onsite is a list of
+    (rel_site, coef, mat) 1-site terms; bonds is a list of dicts
+    {rel_a, mat_a, rel_b, mat_b, carry_ferm, coef} for each 2-site term
+    (rel_a<rel_b, rel_a always < n_uc -- guaranteed by
+    infinitechain.py's canonicalization, which shifts any "pure R" term,
+    touching only site indices >= n_uc, back down into h_intra)."""
+    onsite, bonds = [], []
+    for op_term in list(h_intra_op) + list(h_inter_op):
+        rel_sites, coef, mats, ferm = _term_site_matrices(op_term, sites_uc, n_uc)
+        if len(rel_sites) == 1:
+            onsite.append((rel_sites[0], coef, mats[0]))
+        elif len(rel_sites) == 2:
+            a, b = rel_sites
+            if a >= n_uc:
+                raise ValueError(
+                    "idmrg: internal error -- inter-cell term does not "
+                    "touch the central cell ({})".format(op_term))
+            bonds.append(dict(rel_a=a, mat_a=mats[0], rel_b=b, mat_b=mats[1],
+                               carry_ferm=ferm[0], coef=coef))
+        else:
+            raise ValueError(
+                "idmrg: terms touching more than 2 distinct sites are not "
+                "supported ({})".format(op_term))
+    return onsite, bonds
+
+
+def _active_channels_at(bonds, n_uc, p):
+    """[(bond_index, r), ...] -- every 2-site term with a "pending"
+    instance active just before absorbing sublattice p (i.e. this is the
+    channel list valid *entering* sublattice p's own tensor, having
+    already absorbed everything up to but not including it), where r
+    counts down the number of *more* sites needed (including the one
+    about to be absorbed) until that specific instance completes: r=reach
+    means "just absorbed its own rel_a, about to absorb rel_a+1" (the
+    first position where it's actually pending -- rel_a's own site itself
+    is *not* pending yet when entering it, only starting in its output);
+    r=1 means "completes upon absorbing this very site". A term instance
+    with window [rel_a, rel_b] is pending entering absolute position P
+    (P mod n_uc = p) iff rel_a < P <= rel_b (mod the unit-cell tiling),
+    with r = rel_b - P + 1 -- solving for which p a given r corresponds
+    to gives p = (rel_b - r + 1) % n_uc, the formula used below (an
+    earlier version omitted the "+1", silently checking a mismatched
+    sublattice for every n_uc > 1 -- invisible for n_uc=1, where
+    (p+1)%1 == p makes the two formulas coincide, but fatal for n_uc=2:
+    it produced a completely decoupled, exactly-zero effective
+    Hamiltonian instead of raising). A bond can appear more than once
+    here (distinct r values) if its reach exceeds n_uc, meaning two
+    different unit cells' copies of the same term have genuinely
+    overlapping pending windows -- within this module's documented scope
+    (couplings spanning at most two adjacent unit cells) this happens for
+    at most 2 simultaneous instances of any one term."""
+    out = []
+    for bi, b in enumerate(bonds):
+        reach = b["rel_b"] - b["rel_a"]
+        for r in range(1, reach + 1):
+            if (b["rel_b"] - r + 1) % n_uc == p:
+                out.append((bi, r))
+    return out
+
+
+def _onsite_matrix(onsite_by_p, p, d):
+    """Σ coef*mat over every onsite term attributed to sublattice p, or
+    None if there is none (kept separate from np.zeros so callers can
+    tell "no onsite term here" from "an onsite term that happens to be
+    the zero matrix", and so the "F->F" self-loop's mandatory Id doesn't
+    need a redundant +0)."""
+    mat = None
+    for _rel, coef, m in onsite_by_p.get(p, []):
+        mat = coef * m if mat is None else mat + coef * m
+    return mat
+
+
+def _build_automaton(h_intra_op, h_inter_op, site_types, n_uc):
+    """Build the periodic per-sublattice MPO tensors W_bulk[0..n_uc-1]
+    directly, as a genuine finite-state automaton -- see this module's
+    docstring for why this, not an extraction from any fixed finite
+    reference system, is required.
+
+    Two *distinct* trivial channels, both persistent (part of every
+    W_bulk[p]'s own reused channel space, not a one-off boundary
+    construct), plus one "pending" channel per still-open 2-site term:
+
+    - "S" (index 0): self-loops via Id, and is the *only* channel a new
+      2-site term may start from. Nothing ever transitions into S from
+      anywhere else, so it always carries pure, unweighted Id content --
+      never contaminated by whatever has already been accumulated.
+    - "F" (index 1, the accumulator): self-loops via Id (picking up any
+      onsite term along the way), and receives completed pending
+      channels. Deliberately *cannot* start a new term itself.
+
+    Two earlier, both wrong, designs were tried and are worth recording
+    here since the failure modes were not obvious in advance:
+
+    1. A single merged S/F channel (this module's very first version):
+       the "nothing has ever happened, anywhere" path then trivially
+       reaches the same index used to terminate the chain, contributing a
+       spurious, wavefunction-coupled identity-operator term -- confirmed
+       directly as a uniform +1 shift of the exact 2-site spectrum for a
+       simple test case.
+    2. Separate S and F, but S consumed entirely by a one-off boundary
+       tensor (not part of W_bulk's own reused structure), *and* F itself
+       allowed to also start new pending channels (mirroring S's own
+       "start" edge, reasoning that F should be able to start a *second*
+       independent bond once a first one has already completed). This is
+       wrong for a different reason: starting a new term from F multiplies
+       the new term by *whatever F already holds* (a product), not an
+       independent, additive contribution -- the correct way to add a new,
+       independent term to a running sum is for it to start from something
+       carrying pure Id weight, i.e. S specifically, not F. Confirmed
+       directly: this version could not represent a growth step's *newest*
+       bond at all whenever F was still zero (e.g. every micro-step of the
+       very first macro-iteration, where nothing has completed yet), and
+       once S was instead made persistent (to fix that), letting *both* S
+       and F start new terms let every later bond be double-counted
+       through two structurally distinct paths that never resolve against
+       each other, since the growth loop has no final right boundary to
+       exclude the "still S" branch -- reported energy diverged to
+       -infinity across iterations instead of converging.
+
+    The fix implemented below: S persists (self-loop, can start new
+    terms), F persists (self-loop with onsite pickup, receives
+    completions) -- but *only* S may start a new pending channel.
+
+    Returns (sites_uc, W_bulk): sites_uc is the n_uc-site SiteX the
+    physical legs belong to (also used later to look up named-operator
+    matrices for static correlators); W_bulk[p] (rank 4: left-bond,
+    right-bond, phys, phys') is sublattice p's tensor, with W_bulk[p]'s
+    right bond and W_bulk[(p+1)%n_uc]'s left bond always the *same*
+    canonical Index object -- valid by construction here (both are
+    indexed by the identical, explicitly-enumerated channel list; there is
+    no independent gauge choice anywhere in this construction to make them
+    inconsistent, unlike extracting from an SVD-compressed reference)."""
+    sites_uc = SiteX(list(site_types))
+    onsite, bonds = _classify_terms(h_intra_op, h_inter_op, sites_uc, n_uc)
+    onsite_by_p = {}
+    for rel, coef, mat in onsite:
+        onsite_by_p.setdefault(rel, []).append((coef, mat))
+
+    # chans[p][0] = "S", chans[p][1] = "F", chans[p][k>1] = a
+    # (bond_index, r) pending-channel tuple -- the full channel list valid
+    # just before absorbing sublattice p, shared as *both* W_bulk[p]'s own
+    # left bond and W_bulk[(p-1)%n_uc]'s own right bond.
+    S, F = "S", "F"
+    chans = [[S, F] + _active_channels_at(bonds, n_uc, p) for p in range(n_uc)]
+    boundary_idx = [Index(len(chans[p]), tags="Link") for p in range(n_uc)]
+    dims = [sites_uc.dim(p + 1) for p in range(n_uc)]
+
+    W_bulk = []
+    for p in range(n_uc):
+        left, right = chans[p], chans[(p + 1) % n_uc]
+        left_idx, right_idx = boundary_idx[p], boundary_idx[(p + 1) % n_uc]
+        d = dims[p]
+        st = sites_uc.site_type(p + 1)
+        s = sites_uc.si(p + 1)
+        onsite_mat = _onsite_matrix(onsite_by_p, p, d)
+
+        arr = np.zeros((len(left), len(right), d, d), dtype=complex)
+        for li, lch in enumerate(left):
+            for ri, rch in enumerate(right):
+                mat = None
+                if lch == S and rch == S:
+                    mat = np.eye(d, dtype=complex)
+                elif lch == F and rch == F:
+                    mat = np.eye(d, dtype=complex)
+                    if onsite_mat is not None:
+                        mat = mat + onsite_mat
+                elif lch == S and rch not in (S, F):
+                    # a new pending channel starts here -- from S only
+                    # (never from F, see this function's own docstring)
+                    # -- iff this is exactly its own rel_a.
+                    bi, r = rch
+                    b = bonds[bi]
+                    if r == b["rel_b"] - b["rel_a"] and b["rel_a"] == p:
+                        mat = b["coef"] * b["mat_a"]
+                elif rch == F and lch not in (S, F):
+                    # a pending channel completes into the accumulator.
+                    bi, r = lch
+                    if r == 1:
+                        mat = bonds[bi]["mat_b"]
+                elif lch not in (S, F) and rch not in (S, F):
+                    # a pending channel propagates one more site (Id, or
+                    # "F" if this term's own Jordan-Wigner string is open).
+                    bi_l, r_l = lch
+                    bi_r, r_r = rch
+                    if bi_l == bi_r and r_r == r_l - 1:
+                        b = bonds[bi_l]
+                        mat = st.matrix("F") if b["carry_ferm"] else np.eye(d, dtype=complex)
+                if mat is not None:
+                    arr[li, ri] = mat
+        T = ITensor((left_idx, s, s.prime(1), right_idx),
+                     np.transpose(arr, (0, 2, 3, 1)))
+        W_bulk.append(T)
+    return sites_uc, W_bulk
+
+
+def _project_channel(T, side, idx):
+    """T with its 'side' ('left' or 'right') bond leg contracted against
+    the unit vector e_idx -- gives the true open-chain boundary tensor
+    (rank 3) needed to cold-start the growth loop's very first micro-step:
+    idx=0 ("S") for the left boundary (the chain has nothing accumulated
+    yet), idx=1 ("F") for the right boundary (the chain reports only its
+    genuinely-accumulated total, excluding the -- structurally impossible
+    to reach from S alone, see `_build_automaton`'s docstring -- "S was
+    still never resolved" case), exactly mirroring how a genuine finite
+    chain's own leftmost/rightmost MPO tensor has no dangling boundary leg
+    at all.
+
+    Implemented via direct positional array indexing (np.take), not a
+    generic Index-identity-matched ITensor contraction (`T * e`): for
+    n_uc=1 (and more generally whenever a bulk tensor's left and right
+    bond legs happen to be the very same canonical Index object, which
+    `_build_automaton` deliberately arranges whenever a channel type
+    recurs with period n_uc -- see its docstring), `T`'s left and right
+    legs are indistinguishable *by identity* to the generic `mul_plan`
+    matcher, which greedily matches whichever occurrence it scans first
+    (always the left leg, since it's T.inds[0]) regardless of which side
+    was actually requested -- confirmed directly: projecting side="right"
+    for n_uc=1 silently sliced the *left* axis instead, giving a tensor
+    representing "start a new term here" on both boundaries at once
+    instead of one "start" and one "end", which produced an identically
+    zero effective Hamiltonian for the very first growth step. Selecting
+    the axis by its *position* in T.inds (side="left" -> axis 0,
+    side="right" -> axis -1) rather than by Index identity sidesteps this
+    ambiguity entirely."""
+    axis = 0 if side == "left" else -1
+    new_inds = T.inds[1:] if side == "left" else T.inds[:-1]
+    new_array = np.take(T.array, idx, axis=axis)
+    return ITensor(new_inds, new_array)
+
+
+def _relabel_pos(T, pos, new_ind):
+    """T with the Index at axis position `pos` replaced by `new_ind`,
+    every other axis (including the array data) untouched. Selected by
+    *position*, not by matching the old Index's identity (the same
+    reasoning as `_project_channel`'s own docstring): whenever the axis
+    being replaced shares its Index object with another axis of the same
+    tensor -- always true of W_bulk[p]'s own left/right legs for n_uc=1,
+    and possible for other small n_uc -- an identity-based relabel would
+    silently rewrite *both* occurrences instead of just the one at `pos`.
+    Used by `idmrg_ground_state` to give HL's and HR's own mpo axes an
+    identity independent of `_build_automaton`'s small, reused
+    boundary_idx pool -- see its own comment for why that reuse is
+    otherwise unsafe."""
+    inds = list(T.inds)
+    inds[pos] = new_ind
+    return ITensor(tuple(inds), T.array)
+
+
+def _extend_HL(HL, HL_bra, W_p, U, left_ket_old, right_ket_new):
+    """Absorb the newly-solved left-canonical site tensor U into HL, using
+    MPO tensor W_p for the sublattice just absorbed. `left_ket_old` is U's
+    own link toward the *existing* HL (None only for the very first-ever
+    absorption); `right_ket_new` is U's own freshly-minted link away from
+    HL (always present -- this becomes the new HL's own ket-side leg).
+    Mirrors dmrg.py's `_extend_left`/`_relabel_bra_local`, but expressed
+    directly in terms of already-known link Indices (this module has no
+    `_Chain` container to search via `_link_at`, since the growing
+    environment isn't attached to any fixed-length chain object) -- same
+    contract_many()-routed, bra/ket-link-relabeled construction either way.
+    Returns (new_HL, new_HL_bra) where new_HL_bra is right_ket_new's own
+    bra-side counterpart, to be threaded into the *next* call."""
+    right_bra_new = right_ket_new.sim()
+    new_inds = []
+    for ind in U.inds:
+        if left_ket_old is not None and ind == left_ket_old:
+            new_inds.append(HL_bra)
+        elif ind == right_ket_new:
+            new_inds.append(right_bra_new)
+        else:
+            new_inds.append(ind)
+    bra_piece = dag(_t_prime(ITensor(tuple(new_inds), U.array), "Site"))
+    pieces = [p for p in (HL, bra_piece, W_p, U) if p is not None]
+    new_HL = contract_many(pieces)
+    return new_HL, right_bra_new
+
+
+def _extend_HR(HR, HR_bra, W_p, V, right_ket_old, left_ket_new):
+    """Mirror of `_extend_HL`: V (the newly-solved right-canonical site
+    tensor) is absorbed into HR by prepending it on HR's left. Returns
+    (new_HR, new_HR_bra)."""
+    left_bra_new = left_ket_new.sim()
+    new_inds = []
+    for ind in V.inds:
+        if right_ket_old is not None and ind == right_ket_old:
+            new_inds.append(HR_bra)
+        elif ind == left_ket_new:
+            new_inds.append(left_bra_new)
+        else:
+            new_inds.append(ind)
+    bra_piece = dag(_t_prime(ITensor(tuple(new_inds), V.array), "Site"))
+    pieces = [p for p in (HR, bra_piece, W_p, V) if p is not None]
+    new_HR = contract_many(pieces)
+    return new_HR, left_bra_new
+
+
+def _local_two_site_solve(HL, HL_bra, HL_ket, W_pL, phys_L,
+                           W_pR, phys_R, HR, HR_bra, HR_ket,
+                           cutoff, maxdim, niter):
+    """One micro-step's local ground-state solve: the effective 2-site
+    Hamiltonian sandwiched by (HL, W_pL, W_pR, HR), diagonalized via the
+    same matvec+Lanczos machinery as dmrg.py's own two_site_heff/
+    _local_ground_state (see this module's docstring) -- but with no
+    pre-existing ket tensor to seed the local guess from (there is no
+    "previous sweep" here, every micro-step inserts brand-new sites), so
+    the Lanczos start vector is always a fresh random one, matching how
+    randomMPS() itself starts finite DMRG from a generic point rather than
+    a product state (see CLAUDE.md's note on why mpscpp3/pyitensor never
+    seed DMRG from a product state). Returns (energy, U, S, V) -- the SVD
+    split of the local ground state, truncated to (cutoff, maxdim)."""
+    order_in = ([HL_ket] if HL_ket is not None else []) + [phys_L, phys_R] + \
+               ([HR_ket] if HR_ket is not None else [])
+    shape = tuple(ind.dim for ind in order_in)
+    s_L_out, s_R_out = phys_L.prime(1), phys_R.prime(1)
+    order_out = ([HL_bra] if HL_bra is not None else []) + [s_L_out, s_R_out] + \
+                ([HR_bra] if HR_bra is not None else [])
+    pieces = [p for p in (HL, W_pL, W_pR, HR) if p is not None]
+    matvec = kernels.make_matvec(pieces, order_in, shape, order_out)
+
+    dim = int(np.prod(shape))
+    if dim <= 3:
+        # too small a space for Lanczos to be meaningful; diagonalize directly
+        # (mirrors dmrg.py's own _local_ground_state small-dim fallback).
+        basis = np.eye(dim, dtype=complex)
+        Hmat = np.column_stack([matvec(basis[:, k]) for k in range(dim)])
+        w, v = np.linalg.eigh((Hmat + Hmat.conj().T) / 2)
+        eval0, evec0 = w[0], v[:, 0]
+    else:
+        rng = np.random.default_rng()
+        v0 = rng.standard_normal(dim) + 1j * rng.standard_normal(dim)
+        # Same niter floor as dmrg.py's _local_ground_state -- flagged there
+        # as load-bearing (dropping it caused real, measured convergence
+        # regressions), and there is even less "warm start from a nearly-
+        # converged sweep" margin here than in finite DMRG, since every
+        # micro-step's local problem starts from a fresh random vector.
+        eval0, evec0 = _lanczos_ground_state(matvec, v0, niter=max(niter, 200))
+
+    theta = ITensor(tuple(order_in), evec0.reshape(shape))
+    left_inds = ([HL_ket] if HL_ket is not None else []) + [phys_L]
+    U, S, V, spec = svd(theta, left_inds, cutoff=cutoff, maxdim=maxdim)
+    # U and V are used *without* S: HL/HR are block operators built by a
+    # similarity transform through U (or V) alone -- <dag(U)|W_p|U>, in
+    # _extend_HL/_extend_HR -- exactly mirroring White's original
+    # infinite-algorithm block update (and dmrg.py's own _extend_left/
+    # _extend_right, which likewise only ever see one SVD factor per
+    # extension, via ket.A(i) after _apply_local_update has already
+    # absorbed S into the *other* site). A version of this function that
+    # instead absorbed sqrt(S) into both U and V (reasoning that this
+    # growth loop extends HL and HR simultaneously, so neither should
+    # asymmetrically "own" S) was tried and is wrong: multiplying a new
+    # bond's own starting weight by whatever a neighboring environment's
+    # bond matrix already contains, instead of the environment being a
+    # clean similarity-transformed operator, corrupted every step past
+    # the very first one -- confirmed directly, it broke the variational
+    # monotonicity property (macro-iteration energies must only ever
+    # decrease as more sites are absorbed) by the *second* macro-iteration
+    # of a simple test case, and using plain U/V (this function's current
+    # form) restores both exact agreement with independent ED at small
+    # sizes and strict monotonicity at every iteration checked.
+    return float(eval0.real), U, S, V
+
+
+class IDMRGResult:
+    """Converged iDMRG state, as needed for static correlators: the
+    reference SiteX (for named-operator matrix lookups) and the last
+    macro-iteration's own per-sublattice left-canonical site tensors
+    (U_list[p], p=0..n_uc-1) -- a good approximation to the converged
+    infinite chain's own canonical unit-cell MPS tensors, since by the
+    last macro-iteration HL/HR are themselves converged to (near-)
+    translational invariance."""
+
+    def __init__(self, sites_uc, n_uc, U_list, e0, converged, niter_done):
+        self.sites_uc = sites_uc
+        self.n_uc = n_uc
+        self.U_list = U_list
+        self.e0 = e0
+        self.converged = converged
+        self.niter_done = niter_done
+
+
+def idmrg_ground_state(site_types, h_intra_op, h_inter_op, n_uc, maxm=30,
+                        cutoff=1e-12, maxiter=200, etol=1e-10, niter=30,
+                        verbose=False):
+    """Run the growing/infinite-size DMRG algorithm to convergence (or
+    `maxiter` macro-iterations) for a unit cell of `n_uc` sites (type codes
+    `site_types`) and Hamiltonian given by `h_intra_op`/`h_inter_op` (plain
+    MultiOperator.op-format term lists, 0-based site indices -- h_intra_op
+    touching only sites 0..n_uc-1, h_inter_op touching at least one site
+    n_uc..2*n_uc-1 -- see infinitechain.py's `_canonicalize_hamiltonian`
+    for how a user-facing L/C/R-suffixed Hamiltonian is turned into this
+    shape). Returns an IDMRGResult; `.e0` is the converged ground-state
+    energy *per site* (not a total -- see this module's docstring)."""
+    sites_uc, W_bulk = _build_automaton(h_intra_op, h_inter_op, site_types, n_uc)
+    W_start0 = _project_channel(W_bulk[0], "left", 0)          # 0 = "S"
+    W_endlast = _project_channel(W_bulk[n_uc - 1], "right", 1)  # 1 = "F"
+
+    HL = HR = None
+    HL_bra = HL_ket = None
+    HR_bra = HR_ket = None
+    # The Index currently serving as HL's/HR's own mpo axis -- tracked
+    # explicitly rather than re-read off W_bulk[p] each time it's reused
+    # (see the comment further below on why that reuse needs de-colliding).
+    HL_mpo = HR_mpo = None
+    energy = None
+    prev_energy = None
+    prev_density = None
+    U_list = [None] * n_uc
+    converged = False
+    macro_iter = 0
+
+    for macro_iter in range(maxiter):
+        for mstep in range(n_uc):
+            p_L = mstep
+            p_R = n_uc - 1 - mstep
+            first_step = (macro_iter == 0 and mstep == 0)
+            if first_step:
+                W_pL, W_pR = W_start0, W_endlast
+            else:
+                # W_bulk[p] is the *same* tensor object every time
+                # sublattice p comes up again (every macro-iteration past
+                # the first), still carrying _build_automaton's own
+                # boundary_idx identity on its left/right legs -- but
+                # HL's/HR's *own* mpo axis was already re-minted fresh at
+                # the end of the previous step (see below), so it must be
+                # forced onto W_bulk[p]'s matching leg here by position,
+                # not assumed to already agree. (Using the raw, un-forced
+                # W_bulk[p] here instead measurably breaks the algorithm:
+                # for n_uc=1, _build_automaton's single channel list makes
+                # W_bulk[0]'s own left and right legs literally the same
+                # Index object, which -- left un-broken -- makes HL's and
+                # HR's own mpo axes collide onto that same object too,
+                # corrupting every _local_two_site_solve from the second
+                # macro-iteration on: confirmed directly by extracting the
+                # dense effective Hamiltonian at macro-iteration 2 of a
+                # uniform n_uc=1 Heisenberg chain and comparing its full
+                # eigenvalue spectrum against exact 6-site ED -- completely
+                # different spectra (not just truncation error), while
+                # macro-iteration 1's spectrum matched ED to machine
+                # precision, isolating the corruption to exactly this
+                # reuse. The same collision risk exists for other small
+                # n_uc, not just n_uc=1, since _build_automaton's
+                # boundary_idx pool has only n_uc distinct objects total.)
+                W_pL = _relabel_pos(W_bulk[p_L], 0, HL_mpo)
+                W_pR = _relabel_pos(W_bulk[p_R], -1, HR_mpo)
+            if p_L == p_R:
+                W_pR = _fresh_physical_copy(W_pR)
+            phys_L = _unprimed_site_index(W_pL)
+            phys_R = _unprimed_site_index(W_pR)
+
+            energy, U, S, V = _local_two_site_solve(
+                HL, HL_bra, HL_ket, W_pL, phys_L,
+                W_pR, phys_R, HR, HR_bra, HR_ket,
+                cutoff=cutoff, maxdim=maxm, niter=niter)
+
+            left_ket_old, right_ket_old = HL_ket, HR_ket
+            new_bond_u, new_bond_v = U.inds[-1], V.inds[0]
+
+            # Fresh, independently-minted mpo-axis identities for the
+            # *extend* step only (not used in the solve above, so this
+            # doesn't disturb the W_pL/W_pR crossing bond the solve just
+            # relied on) -- guarantees the new HL's and HR's own mpo axes
+            # can never collide with each other, or with a future reuse of
+            # W_bulk[p], regardless of how small n_uc is.
+            new_HL_mpo = Index(W_pL.inds[-1].dim, tags="Link")
+            W_pL_ext = _relabel_pos(W_pL, -1, new_HL_mpo)
+            new_HR_mpo = Index(W_pR.inds[0].dim, tags="Link")
+            W_pR_ext = _relabel_pos(W_pR, 0, new_HR_mpo)
+
+            HL, HL_bra = _extend_HL(HL, HL_bra, W_pL_ext, U, left_ket_old, new_bond_u)
+            HL_ket = new_bond_u
+            HR, HR_bra = _extend_HR(HR, HR_bra, W_pR_ext, V, right_ket_old, new_bond_v)
+            HR_ket = new_bond_v
+            HL_mpo, HR_mpo = new_HL_mpo, new_HR_mpo
+
+            U_list[p_L] = U
+
+        density = ((energy - prev_energy) / (2 * n_uc)
+                   if prev_energy is not None else None)
+        if verbose:
+            print("idmrg macro-iter {}: E={} density={}".format(
+                macro_iter, energy, density))
+        if (density is not None and prev_density is not None
+                and abs(density - prev_density) < etol):
+            prev_energy, prev_density = energy, density
+            converged = True
+            break
+        prev_energy, prev_density = energy, density
+
+    if not converged and verbose:
+        print("idmrg_ground_state: reached maxiter={} without converging "
+              "to etol={} (last density change available)".format(maxiter, etol))
+
+    return IDMRGResult(sites_uc, n_uc, U_list, prev_density, converged, macro_iter + 1)
+
+
+# -- static correlators, via the standard infinite-MPS transfer-matrix
+# formalism, operating on IDMRGResult.U_list (all plain NumPy from here on
+# -- bond dimension/position is all that matters, not Index identity, so
+# there is no need to carry ITensor Index bookkeeping into this part). ----
+
+def _to_array_lpr(U):
+    """U's array as (chi_left, d, chi_right) -- matches svd()'s own Index
+    order (left_inds..., bond) exactly, so this is just U.array reshaped
+    when U has no left bond at all (only possible for a genuinely
+    first-ever site, which a *converged* unit cell's U_list never is)."""
+    if len(U.inds) == 3:
+        return U.array
+    return U.array.reshape((1,) + U.array.shape)
+
+
+def _transfer_matrices(result):
+    """[E_p] for p=0..n_uc-1, each a (chi_l,chi_l,chi_r,chi_r) array: the
+    doubled ket-times-conj(ket) transfer tensor for the converged
+    left-canonical tensor at sublattice p."""
+    Es = []
+    for p in range(result.n_uc):
+        A = _to_array_lpr(result.U_list[p])
+        Es.append(np.einsum('lpr,LpR->lLrR', A, np.conj(A)))
+    return Es
+
+
+def _compose(E_a, E_b):
+    """Transfer tensor for two sites in a row: E_a's own (r,R) legs
+    contracted against E_b's (l,L) legs."""
+    return np.einsum('lLrR,rRsS->lLsS', E_a, E_b)
+
+
+def _apply_transfer(E4, rho):
+    return np.einsum('lLrR,rR->lL', E4, rho)
+
+
+def _dominant_right_fixed_point(Es):
+    """The dominant right eigenvector of the full unit-cell transfer
+    matrix T=E_0...E_{n_uc-1} (as a chi x chi density-matrix-like array,
+    normalized to trace 1) and its eigenvalue -- should be close to 1 for
+    a properly converged, correctly normalized (each U_list[p] isometric
+    by SVD construction) infinite chain."""
+    T4 = Es[0]
+    for E in Es[1:]:
+        T4 = _compose(T4, E)
+    chi = T4.shape[0]
+    if T4.shape != (chi, chi, chi, chi):
+        # U_list[0]'s own left bond and U_list[n_uc-1]'s own right bond
+        # are, in a truly periodic MPS, the *same* wraparound bond -- but
+        # each is independently truncated by its own micro-step's SVD (up
+        # to maxm, based on that cut's own entanglement spectrum), so the
+        # growing algorithm's raw IDMRGResult.U_list offers no guarantee
+        # they come out numerically equal, even at good convergence.
+        # Confirmed directly: happens intermittently for some (maxm,
+        # maxiter) combinations, not universally -- raise clearly here
+        # instead of letting a generic reshape error surface deep inside.
+        raise RuntimeError(
+            "idmrg static correlators: the converged unit cell's wraparound "
+            "bond dimension is inconsistent (U_list[0]'s left bond and "
+            "U_list[-1]'s right bond differ, transfer tensor shape {}) -- "
+            "try a different maxm/maxiter/etol combination for "
+            "gs_energy()".format(T4.shape))
+    Tmat = T4.reshape(chi * chi, chi * chi)
+    w, v = np.linalg.eig(Tmat)
+    idx = np.argmax(np.abs(w))
+    eta = w[idx]
+    rho = v[:, idx].reshape(chi, chi)
+    rho = rho / np.trace(rho)
+    return rho, eta
+
+
+def _all_right_fixed_points(Es, n_uc):
+    """rho_after[p] = the fixed-point "everything strictly after site p,
+    wrapping back around" density matrix, for every sublattice position --
+    obtained from one dominant-eigenvector computation (the p=n_uc-1 case)
+    plus n_uc-1 cheap transfer-tensor applications, rather than a fresh
+    eigenproblem per position."""
+    rho_full, eta = _dominant_right_fixed_point(Es)
+    rho_after = [None] * n_uc
+    rho_after[n_uc - 1] = rho_full
+    cur = rho_full
+    for p in range(n_uc - 1, 0, -1):
+        cur = _apply_transfer(Es[p], cur)
+        cur = cur / np.trace(cur)
+        rho_after[p - 1] = cur
+    return rho_after, eta
+
+
+def _op_transfer(sites_uc, U_list, p, opname):
+    """Transfer tensor for sublattice p with operator `opname` inserted
+    (applied to the ket side only, as <bra|opname|ket> per site)."""
+    M = sites_uc.site_type(p + 1).matrix(opname)
+    A = _to_array_lpr(U_list[p])
+    Aop = np.einsum('io,lir->lor', M, A)
+    return np.einsum('lpr,LpR->lLrR', Aop, np.conj(A))
+
+
+def onsite_expectation(result, opname, p):
+    """<opname> at sublattice p (0..n_uc-1) of the converged infinite
+    chain."""
+    Es = _transfer_matrices(result)
+    rho_after, _eta = _all_right_fixed_points(Es, result.n_uc)
+    E_op = _op_transfer(result.sites_uc, result.U_list, p, opname)
+    val = _apply_transfer(E_op, rho_after[p])
+    return complex(np.trace(val))
+
+
+def two_point_correlator(result, opname_i, p_i, opname_j, r):
+    """<opname_i(site p_i) opname_j(site p_i + r)> of the converged
+    infinite chain, r measured in physical sites (r=0: both operators at
+    the same site, composed as opname_i then opname_j, i.e. matrix product
+    M_i @ M_j in the (in,out) convention of sites/base.py -- matching how
+    `SxC[i]*SxC[i]`-style same-site products read left to right elsewhere
+    in dmrgpy). r must be >= 0; use r and swap the operator order for the
+    mirror separation if r<0 is needed."""
+    if r < 0:
+        raise ValueError("two_point_correlator: r must be >= 0")
+    n_uc = result.n_uc
+    Es = _transfer_matrices(result)
+    rho_after, _eta = _all_right_fixed_points(Es, n_uc)
+
+    if r == 0:
+        M = (result.sites_uc.site_type(p_i + 1).matrix(opname_i)
+             @ result.sites_uc.site_type(p_i + 1).matrix(opname_j))
+        A = _to_array_lpr(result.U_list[p_i])
+        Aop = np.einsum('io,lir->lor', M, A)
+        E4 = np.einsum('lpr,LpR->lLrR', Aop, np.conj(A))
+        val = _apply_transfer(E4, rho_after[p_i])
+        return complex(np.trace(val))
+
+    p_j = (p_i + r) % n_uc
+    running = _op_transfer(result.sites_uc, result.U_list, p_i, opname_i)
+    for k in range(1, r):
+        p = (p_i + k) % n_uc
+        running = _compose(running, Es[p])
+    running = _compose(running, _op_transfer(
+        result.sites_uc, result.U_list, p_j, opname_j))
+    val = _apply_transfer(running, rho_after[p_j])
+    return complex(np.trace(val))

--- a/src/dmrgpy/pyitensor/idmrg.py
+++ b/src/dmrgpy/pyitensor/idmrg.py
@@ -593,6 +593,31 @@ def idmrg_ground_state(site_types, h_intra_op, h_inter_op, n_uc, maxm=30,
     for how a user-facing L/C/R-suffixed Hamiltonian is turned into this
     shape). Returns an IDMRGResult; `.e0` is the converged ground-state
     energy *per site* (not a total -- see this module's docstring)."""
+    if n_uc > 2:
+        # infinitechain.py's constructor already rejects n_uc>2 before
+        # this function is ever reached through the public API -- this is
+        # defense in depth for a direct caller of this module (bypassing
+        # the wrapper): without it, n_uc=3 fails several micro-steps in
+        # with an opaque "ValueError: axes don't match array" three stack
+        # frames deep inside kernels.py's matvec, confirmed directly --
+        # exactly the confusing-failure-mode this check exists to avoid.
+        # See this module's own docstring / infinitechain.py's
+        # __init__ for why n_uc>2 isn't supported yet.
+        raise NotImplementedError(
+            "idmrg_ground_state: n_uc>2 (got {}) is not supported yet -- "
+            "see this module's docstring".format(n_uc))
+    if maxiter < 2:
+        # The energy *density* is a finite difference between two
+        # consecutive macro-iterations' local ground-state eigenvalues
+        # (see the loop below), so it is structurally undefined before a
+        # second macro-iteration has run -- confirmed directly: maxiter=0
+        # left IDMRGResult.e0=None with niter_done=1 (misreporting that an
+        # iteration ran), and maxiter=1 likewise returned e0=None with no
+        # error, only surfacing later as a confusing AttributeError deep
+        # inside a subsequent vev()/correlator() call.
+        raise ValueError(
+            "idmrg_ground_state: maxiter must be >= 2 (energy density is "
+            "a finite difference between two macro-iterations), got {}".format(maxiter))
     sites_uc, W_bulk = _build_automaton(h_intra_op, h_inter_op, site_types, n_uc)
     W_start0 = _project_channel(W_bulk[0], "left", 0)          # 0 = "S"
     W_endlast = _project_channel(W_bulk[n_uc - 1], "right", 1)  # 1 = "F"

--- a/tests/test_infinite_chain.py
+++ b/tests/test_infinite_chain.py
@@ -1,0 +1,194 @@
+"""Coverage for Infinite_Many_Body_Chain / Infinite_Spin_Chain (iDMRG,
+pyitensor/idmrg.py) -- see infinitechain.py's own docstring for the
+L/C/R-suffixed Hamiltonian convention this exercises.
+
+There is no ED oracle for a genuinely infinite system, so these tests
+cross-check via: the exact Bethe-ansatz Heisenberg energy density
+(1/4 - ln(2)), a model-agnostic self-consistency identity (<H_uc> must
+equal n_uc*e0_density by translational invariance, independent of
+whether the *value* of e0_density itself is even known in closed form),
+and a finite-chain-size extrapolation cross-check via ED (mode="ED",
+so this needs no compiled C++ backend).
+
+n_uc>=3 is out of scope for now (Infinite_Many_Body_Chain's constructor
+raises NotImplementedError -- see its own docstring and idmrg.py's
+module docstring for why), so only n_uc in {1, 2} is exercised here.
+"""
+import numpy as np
+import pytest
+
+from dmrgpy import infinitechain
+from dmrgpy import spinchain
+
+EXACT_HEISENBERG_DENSITY = 0.25 - np.log(2)
+
+
+def _converged_uniform_chain(n_uc, maxm=40, maxiter=200, etol=1e-9):
+    spins = ["1/2"] * n_uc
+    ic = infinitechain.Infinite_Spin_Chain(spins)
+    terms = []
+    for i in range(n_uc - 1):
+        terms.append(ic.SxC[i] * ic.SxC[i + 1] + ic.SyC[i] * ic.SyC[i + 1]
+                     + ic.SzC[i] * ic.SzC[i + 1])
+    terms.append(ic.SxC[n_uc - 1] * ic.SxR[0] + ic.SyC[n_uc - 1] * ic.SyR[0]
+                 + ic.SzC[n_uc - 1] * ic.SzR[0])
+    h = terms[0]
+    for t in terms[1:]:
+        h = h + t
+    ic.maxm = maxm
+    ic.maxiter = maxiter
+    ic.etol = etol
+    ic.set_hamiltonian(h)
+    ic.gs_energy()
+    return ic, h
+
+
+def test_n_uc1_heisenberg_energy_density_matches_bethe_ansatz():
+    """The uniform antiferromagnetic Heisenberg chain is gapless
+    (critical): iDMRG's energy-density finite-difference convergence
+    criterion (`.converged`) is a power-law, not exponential, in this
+    regime at any *fixed* bond dimension, so it's not expected to trip
+    within a practical `maxiter` here -- only the *value* is checked,
+    with a tolerance loose enough for maxm=40's residual truncation
+    error (confirmed independently: maxm=60 gets within ~3e-6)."""
+    ic, _ = _converged_uniform_chain(1)
+    assert ic.e0 == pytest.approx(EXACT_HEISENBERG_DENSITY, abs=1e-4)
+
+
+def test_n_uc2_uniform_heisenberg_matches_bethe_ansatz():
+    ic, _ = _converged_uniform_chain(2)
+    assert ic.e0 == pytest.approx(EXACT_HEISENBERG_DENSITY, abs=1e-4)
+
+
+def test_unit_cell_expectation_self_consistency():
+    """<H_uc> (the same unit-cell MultiOperator passed to
+    set_hamiltonian, evaluated via the converged transfer-matrix
+    machinery) must equal n_uc*e0_density by translational invariance --
+    a model-agnostic identity, true regardless of the specific model.
+
+    Uses a moderately dimerized (gapped) chain rather than the uniform
+    (gapless/critical) Heisenberg chain, and forces a fixed, generous
+    number of macro-iterations via a near-zero etol rather than relying
+    on the energy-density finite-difference stopping criterion: the
+    *energy* converges quadratically in the wavefunction error and so
+    reports "converged" well before IDMRGResult.U_list (built from the
+    growing algorithm's raw per-iteration tensors, not yet a fully
+    gauge-fixed periodic MPS) has settled enough for a *linear*-order
+    quantity like this correlator identity to match tightly -- confirmed
+    directly: the identical model/maxm with etol=1e-9's early stop left a
+    ~1.8e-2 gap, while forcing the same run out to a fixed 150
+    macro-iterations closed it to ~4e-4. Also confirmed directly on the
+    exactly solvable fully-decoupled-dimer limit (J_weak=0) that the
+    correlator formulas themselves are exact (both intra-cell and
+    inter-cell/wraparound correlators matched -0.75 and 0 to machine
+    precision there), ruling out a correlator-formula bug as the cause of
+    the gap this test tolerates. DMRG never seeds Lanczos from a product
+    state here (see CLAUDE.md), so the *size* of that gap varies
+    noticeably run to run at fixed (maxm, maxiter) -- observed anywhere
+    from ~3e-3 to ~2e-2 across different random seeds at this exact
+    configuration -- hence the generous tolerance below; it still
+    confirms the identity holds in the right ballpark and with the right
+    sign, which a genuine correlator bug would not survive.
+
+    maxm=8 (well below this model's natural, cutoff-set bond dimension of
+    ~11-12) is deliberately small: it makes truncation land exactly on
+    maxm on *both* the intra- and inter-cell bonds, avoiding a separate,
+    real edge case where two independent SVDs (one per micro-step of the
+    unit cell) round a borderline singular value across the cutoff
+    threshold differently for what is, by periodicity, the *same*
+    wraparound bond -- confirmed to happen intermittently at maxm=40
+    (natural dimension 11 vs 12, one singular value short), which
+    idmrg.py's _dominant_right_fixed_point now raises a clear
+    RuntimeError for instead of a cryptic reshape crash (see its own
+    comment) -- a real, documented limitation of reusing the growing
+    algorithm's raw per-iteration U_list as a stand-in unit cell, not
+    something this test should also have to handle."""
+    n_uc = 2
+    ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+    j_strong, j_weak = 1.0, 0.2
+    h = (j_strong * (ic.SxC[0] * ic.SxC[1] + ic.SyC[0] * ic.SyC[1] + ic.SzC[0] * ic.SzC[1])
+         + j_weak * (ic.SxC[1] * ic.SxR[0] + ic.SyC[1] * ic.SyR[0] + ic.SzC[1] * ic.SzR[0]))
+    ic.maxm = 8
+    ic.maxiter = 150
+    ic.etol = 1e-14  # forces the full 150 iterations, see docstring above
+    ic.set_hamiltonian(h)
+    ic.gs_energy()
+    # <H_uc> = sum over every bond touched by the unit cell (intra-cell
+    # 0-1, plus the inter-cell n_uc-1 -> 0-of-next-cell), via
+    # correlator(name, p_i, name, r=1) = <name(p_i) name(p_i+1)>.
+    total = 0.0
+    for i in range(n_uc):
+        for name in ("Sx", "Sy", "Sz"):
+            total += ic.correlator(name, i, name, 1).real
+    assert total == pytest.approx(n_uc * ic.e0, abs=5e-2)
+
+
+def test_n_uc2_dimerized_chain_matches_finite_size_extrapolation():
+    """A dimerized (alternating strong/weak bond) n_uc=2 chain, cross-
+    checked against a finite-size ED extrapolation: two different large
+    open chains' total ground-state energies, differenced and divided by
+    the site-count difference, cancel boundary effects to leading order
+    and converge to the bulk energy density."""
+    j_strong, j_weak = 1.0, 0.4
+
+    ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+    h = (j_strong * (ic.SxC[0] * ic.SxC[1] + ic.SyC[0] * ic.SyC[1] + ic.SzC[0] * ic.SzC[1])
+         + j_weak * (ic.SxC[1] * ic.SxR[0] + ic.SyC[1] * ic.SyR[0] + ic.SzC[1] * ic.SzR[0]))
+    ic.maxm = 40
+    ic.maxiter = 200
+    ic.etol = 1e-9
+    ic.set_hamiltonian(h)
+    density = ic.gs_energy()
+    assert ic.converged
+
+    def finite_energy(n_sites):
+        sc = spinchain.Spin_Chain(["1/2"] * n_sites)
+        hf = 0
+        for i in range(n_sites - 1):
+            j = j_strong if i % 2 == 0 else j_weak
+            hf = hf + j * (sc.Sx[i] * sc.Sx[i + 1] + sc.Sy[i] * sc.Sy[i + 1]
+                           + sc.Sz[i] * sc.Sz[i + 1])
+        sc.set_hamiltonian(hf)
+        return sc.gs_energy(mode="ED")
+
+    n1, n2 = 12, 16
+    e1, e2 = finite_energy(n1), finite_energy(n2)
+    extrapolated_density = (e2 - e1) / (n2 - n1)
+    assert density == pytest.approx(extrapolated_density, abs=5e-3)
+
+
+def test_n_uc2_skip_site_coupling_via_R_suffix():
+    """A coupling from site 0 of the central cell directly to site 0 of
+    the next cell, skipping over site 1 -- exercises the R-suffix
+    canonicalization path a strict nearest-neighbor-only design couldn't
+    express. Only checks this runs and converges to *some* sane (real,
+    finite, negative) energy density -- there's no simple closed form
+    for this model, this is a smoke/regression test for the R-suffix
+    validation and automaton-construction path, not a numerical oracle
+    check."""
+    ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+    h = (ic.SxC[0] * ic.SxC[1] + ic.SyC[0] * ic.SyC[1] + ic.SzC[0] * ic.SzC[1]
+         + 0.5 * (ic.SxC[0] * ic.SxR[0] + ic.SyC[0] * ic.SyR[0] + ic.SzC[0] * ic.SzR[0]))
+    ic.maxm = 30
+    ic.maxiter = 150
+    ic.etol = 1e-8
+    ic.set_hamiltonian(h)
+    e0 = ic.gs_energy()
+    assert np.isfinite(e0)
+    assert e0 < 0
+
+
+def test_n_uc_above_2_not_implemented():
+    with pytest.raises(NotImplementedError):
+        infinitechain.Infinite_Spin_Chain(["1/2", "1/2", "1/2"])
+
+
+def test_itensor_version_other_than_python_not_implemented():
+    with pytest.raises(NotImplementedError):
+        infinitechain.Infinite_Spin_Chain(["1/2"], itensor_version=3)
+
+
+def test_l_and_r_in_same_term_rejected():
+    ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+    with pytest.raises(ValueError):
+        ic.set_hamiltonian(ic.SxL[0] * ic.SxR[0])


### PR DESCRIPTION
## Summary
- Adds `Infinite_Many_Body_Chain`/`Infinite_Spin_Chain` (`infinitechain.py`), an independent object (not a `Many_Body_Chain` subclass) describing a chain defined by a repeating `n_uc`-site unit cell rather than a fixed length, solved with White's growing infinite-DMRG algorithm generalized to a multi-site unit cell (`pyitensor/idmrg.py`).
- Hamiltonians are built from flat `L`/`C`/`R`-suffixed operators (`SxL`/`SxC`/`SxR`) so a term can couple to any site of an adjacent unit cell, including skipping over an intermediate site.
- v1 scope: ground-state energy density and static one-/two-point correlators (transfer-matrix formalism) for a 1- or 2-site unit cell, pure-Python `pyitensor` backend only. `n_uc>=3` raises `NotImplementedError` — the micro-step growth scheme needs a real redesign to pair genuinely adjacent sites in that case, not attempted here (documented in both `idmrg.py`'s module docstring and `docs/documentation.md`).
- Found and fixed a real bug during development: `HL`'s and `HR`'s own mpo-axis Index could collide onto the same object across macro-iterations (guaranteed for `n_uc=1`), corrupting the effective Hamiltonian from the second macro-iteration onward — confirmed by comparing the full eigenvalue spectrum of the extracted dense effective Hamiltonian against exact 6-site ED. Fixed by re-minting a fresh mpo-axis Index for `HL`/`HR` at the end of every micro-step. Also added a clear `RuntimeError` (instead of a cryptic reshape crash) for the milder, still-open case where two independent SVDs round a borderline wraparound-bond singular value differently.
- Updated `docs/user_guide.md`/`.tex` (new §18, physics-facing) and `docs/documentation.md`/`.tex` (new architecture subsection) per this repo's convention; both `.tex` files verified to compile cleanly with `pdflatex` (no new overfull-hbox warnings).

## Test plan
- [x] `pytest tests/test_infinite_chain.py -v` — 8/8 passing (Bethe-ansatz energy density for `n_uc=1` and `n_uc=2`, a model-agnostic `<H_uc> = n_uc * density` self-consistency check, an `n_uc=2` dimerized chain cross-checked against finite-size ED extrapolation, an R-suffix skip-site coupling smoke test, and guard-rail tests for `n_uc>=3`/non-Python backends/invalid `L`+`R` terms)
- [x] `python run_tests.py` — full suite, 215 passed / 9 skipped (pre-existing skips for optional backends), no regressions
- [x] `examples/idmrg/heisenberg_infinite/main.py` run directly — converges toward the exact Bethe-ansatz density
- [x] `pdflatex` on both `docs/user_guide.tex` and `docs/documentation.tex` — clean compile, no new overfull-hbox warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t