### PR TITLE
Apply / overlap primitives for the converged iDMRG iMPS

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -342,6 +342,50 @@ happens instead of a cryptic `reshape` crash; a smaller `maxm` that
 actually binds (forcing both bonds to the same truncated dimension)
 avoids it, see `tests/test_infinite_chain.py`'s own comment on this.
 
+**Applying an MPO to the converged iMPS**: `idmrg.py` also implements
+`apply_mpo(result, W_bulk, cutoff, maxdim)` — the infinite-chain analogue
+of `mpsalgebra.applyMPO`, and the primitive a future iTEBD-style
+real/imaginary-time evolution feature would build on. `grow_by_mpo`
+Kronecker-merges `W_bulk`'s own per-site bonds with `U_list`'s (mirroring
+`mpsalgebra._apply_chain`'s per-site body, generalized to a periodic
+index range including the wraparound cut), giving raw, non-canonical
+tensors at bond dimension `chi_A*chi_W`; `_canonicalize_periodic` then
+re-canonicalizes/truncates them back down via the standard two-sided
+fixed-point infinite-MPS procedure (Orús & Vidal, PRB 78, 155117 (2008)):
+factor the dominant left/right transfer-matrix fixed points at every cut
+into square-root factors `X_p`/`Y_p` (`_psd_sqrt_factor`), SVD
+`M_p=X_p@Y_p` and truncate (reusing `svd.py`'s own `_truncate`), then
+build an *asymmetric* gauge (`G_left[p]=U_p^H X_p`, no `S` factor at all;
+`G_right[p]=Y_p V_p^H S_p^{-1}`, the *full* inverse) — asymmetric, rather
+than a textbook symmetric `S^{-1/2}` split on both sides, specifically so
+the result comes out plain left-canonical (matching `IDMRGResult.U_list`'s
+own convention) with no separate bond-weight layer to thread through,
+confirmed numerically before committing to the formula (a first,
+symmetric-split derivation looked plausible by analogy to Vidal's
+canonical form but reproduced Identity only to ~1, not a small residual).
+`_all_left_fixed_points` (the new, symmetric counterpart to the existing
+`_all_right_fixed_points`) needed one more fix beyond the obvious
+transpose-the-eigenproblem mirroring: its own per-cut renormalization
+(needed to avoid blow-up across repeated propagation, exactly like the
+existing right-fixed-point code) discards the *relative* scale between
+different cuts that `_canonicalize_periodic`'s left-gauge construction
+turns out to depend on (unlike the right-gauge one, which is provably
+scale-invariant) — tracked via an explicit accumulated-scale return value
+and undone before use. A second, independent bug (an index-order/
+transpose mismatch between `_apply_transfer_from_left`'s own (ket,bra)
+convention and the (bra,ket) convention the isometry derivation needs)
+was only found by deriving the exact identity the gauge must satisfy by
+hand and checking it numerically term-by-term — a genuine case where
+tests alone (which caught that *something* was wrong, via a hand-crafted
+internal left-canonicality check) weren't enough to *localize* the bug,
+only real algebra was. **Scope restriction**: `W_bulk` must be a
+*bounded* (non-extensive) periodic operator — the Hamiltonian's own
+`_build_periodic_mpo`-built automaton is deliberately the *other* kind
+(an unconditional accumulator self-loop that needs a genuine chain
+boundary to mean "sum", not "product") and is not a valid `apply_mpo`
+input; see `idmrg.py`'s own "Applying a (bounded) MPO to the converged
+iMPS" section docstring for the specific failure mode this would hit.
+
 ### 4.2 Operator representation: `MultiOperator`
 
 Hamiltonians and observables are built as `MultiOperator` objects

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -386,6 +386,61 @@ boundary to mean "sum", not "product") and is not a valid `apply_mpo`
 input; see `idmrg.py`'s own "Applying a (bounded) MPO to the converged
 iMPS" section docstring for the specific failure mode this would hit.
 
+**Overlap between two converged iMPS**: `idmrg.py` also implements
+`imps_overlap(result_a, result_b, normalize=True)` — the thermodynamic-
+limit analogue of a finite MPS inner product. Since a literal
+`<phi|psi>` over an infinite chain scales as `eta**N` over `N` unit
+cells (not a finite number unless `|eta|==1` exactly), the default
+return value is instead the *per-site fidelity*
+`eta_ab/sqrt(eta_aa*eta_bb)`, where `eta_ab` is the dominant eigenvalue
+of the *mixed* transfer matrix built from the two states' own tensors
+(`_transfer_matrices` generalized with a new optional `bra_list`
+parameter, defaulting to the self-overlap case every existing caller
+still uses) and `eta_aa`/`eta_bb` are each state's own self-overlap
+(via the existing `_dominant_right_fixed_point`, reused verbatim — valid
+since a self-overlap transfer tensor is always square). The mixed case
+needed a dedicated eigen-solve, `_dominant_eigenvalue_mixed`, rather
+than reusing `_dominant_right_fixed_point` directly: two independently
+converged/truncated iMPS need not share a bond dimension, so the
+composed mixed transfer tensor is `(chi_a,chi_b,chi_a,chi_b)`, square
+only in the `chi_a==chi_b` self-overlap special case
+`_dominant_right_fixed_point` itself assumes.
+
+**A second, real bug found while implementing `imps_overlap`** (needed a
+Hamiltonian with an onsite/field term to exercise a meaningfully
+non-trivial "orthogonal states" test case, which surfaced two bugs in
+`_build_periodic_mpo`'s onsite-term handling, both pre-dating and
+unrelated to `imps_overlap` itself): `_onsite_matrix`'s own unpacking
+loop expected 3-tuples (`rel_site, coef, mat`) but `_build_periodic_mpo`
+had already consumed `rel_site` as its `onsite_by_p` dict key, storing
+only `(coef, mat)` pairs — a `ValueError: not enough values to unpack`
+for *any* Hamiltonian with an onsite term (dead code before this, since
+every existing test used bond-only Hamiltonians). Fixing just that
+crash would have been unsafe: the underlying automaton wiring was also
+wrong. Onsite content was added on the accumulator's own `F,F`
+self-loop (`Id + onsite_mat`) rather than a direct `S,F` transition — no
+existing branch ever populates `S,F` at all, so (1) for a bond-less
+Hamiltonian, `W` stays block-diagonal between `{S}` and `{F,...}`
+forever, and the boundary-extracted `<S|W^N|F>` (exactly what
+`_project_channel`'s boundary tensors compute) is identically 0 for
+every `N` — confirmed directly: a pure-field `n_uc=1` chain converged to
+energy density 0 and `<Sz>~0` regardless of field strength, instead of
+the exact, closed-form `-|B|/2`/`sign(B)*0.5`; and (2) once a bond term
+*did* activate `F`, every further site absorbed while `F` was already
+hot re-added the onsite content on top of an already-summed running
+total (an exponential, multiplicative blow-up, not the intended linear
+sum) — confirmed directly: energy density reached `-1e23` by `B=0.3` and
+`-1e69` by `B=1.0` on an otherwise-normal dimerized `n_uc=2` chain, with
+`.converged` staying `False` throughout instead of a modest,
+field-dependent shift. The fix moves the onsite content onto the direct
+`S,F` transition (leaving `F,F` as plain `Id`) — the standard textbook
+automaton-MPO construction for summing an onsite term into a running
+total (the same upper-triangular-in-channel-index structure any
+finite-range Hamiltonian MPO derivation uses), verified both by a
+by-hand matrix-product induction argument and numerically (the same
+field tests above now reproduce the exact closed-form field-only result
+and a finite, converging energy density with a bond term present).
+
 ### 4.2 Operator representation: `MultiOperator`
 
 Hamiltonians and observables are built as `MultiOperator` objects

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -488,6 +488,69 @@ valid \texttt{apply\_mpo} input; see \texttt{idmrg.py}'s own ``Applying
 a (bounded) MPO to the converged iMPS'' section docstring for the
 specific failure mode this would hit.
 
+\textbf{Overlap between two converged iMPS}: \texttt{idmrg.py} also
+implements \texttt{imps\_overlap(result\_a, result\_b, normalize=True)}
+-- the thermodynamic-limit analogue of a finite MPS inner product. Since
+a literal $\langle\phi|\psi\rangle$ over an infinite chain scales as
+$\eta^N$ over $N$ unit cells (not a finite number unless $|\eta|=1$
+exactly), the default return value is instead the \emph{per-site
+fidelity} \texttt{eta\_ab/sqrt(eta\_aa*eta\_bb)}, where \texttt{eta\_ab}
+is the dominant eigenvalue of the \emph{mixed} transfer matrix built
+from the two states' own tensors (\texttt{\_transfer\_matrices}
+generalized with a new optional \texttt{bra\_list} parameter, defaulting
+to the self-overlap case every existing caller still uses) and
+\texttt{eta\_aa}/\texttt{eta\_bb} are each state's own self-overlap (via
+the existing \texttt{\_dominant\_right\_fixed\_point}, reused verbatim
+-- valid since a self-overlap transfer tensor is always square). The
+mixed case needed a dedicated eigen-solve,
+\texttt{\_dominant\_eigenvalue\_mixed}, rather than reusing
+\texttt{\_dominant\_right\_fixed\_point} directly: two independently
+converged/truncated iMPS need not share a bond dimension, so the
+composed mixed transfer tensor is
+\texttt{(chi\_a,chi\_b,chi\_a,chi\_b)}, square only in the
+\texttt{chi\_a==chi\_b} self-overlap special case
+\texttt{\_dominant\_right\_fixed\_point} itself assumes.
+
+\textbf{A second, real bug found while implementing \texttt{imps\_overlap}}
+(needed a Hamiltonian with an onsite/field term to exercise a
+meaningfully non-trivial ``orthogonal states'' test case, which
+surfaced two bugs in \texttt{\_build\_periodic\_mpo}'s onsite-term
+handling, both pre-dating and unrelated to \texttt{imps\_overlap}
+itself): \texttt{\_onsite\_matrix}'s own unpacking loop expected
+3-tuples (\texttt{rel\_site, coef, mat}) but \texttt{\_build\_periodic\_mpo}
+had already consumed \texttt{rel\_site} as its \texttt{onsite\_by\_p}
+dict key, storing only \texttt{(coef, mat)} pairs -- a
+\texttt{ValueError: not enough values to unpack} for \emph{any}
+Hamiltonian with an onsite term (dead code before this, since every
+existing test used bond-only Hamiltonians). Fixing just that crash
+would have been unsafe: the underlying automaton wiring was also wrong.
+Onsite content was added on the accumulator's own \texttt{F,F}
+self-loop (\texttt{Id + onsite\_mat}) rather than a direct
+\texttt{S,F} transition -- no existing branch ever populates
+\texttt{S,F} at all, so (1) for a bond-less Hamiltonian, \texttt{W}
+stays block-diagonal between $\{S\}$ and $\{F,\ldots\}$ forever, and the
+boundary-extracted $\langle S|W^N|F\rangle$ (exactly what
+\texttt{\_project\_channel}'s boundary tensors compute) is identically
+0 for every $N$ -- confirmed directly: a pure-field \texttt{n\_uc=1}
+chain converged to energy density 0 and $\langle S_z\rangle\sim0$
+regardless of field strength, instead of the exact, closed-form
+$-|B|/2$/$\mathrm{sign}(B)\cdot0.5$; and (2) once a bond term \emph{did}
+activate \texttt{F}, every further site absorbed while \texttt{F} was
+already hot re-added the onsite content on top of an already-summed
+running total (an exponential, multiplicative blow-up, not the intended
+linear sum) -- confirmed directly: energy density reached $-10^{23}$ by
+$B=0.3$ and $-10^{69}$ by $B=1.0$ on an otherwise-normal dimerized
+\texttt{n\_uc=2} chain, with \texttt{.converged} staying \texttt{False}
+throughout instead of a modest, field-dependent shift. The fix moves
+the onsite content onto the direct \texttt{S,F} transition (leaving
+\texttt{F,F} as plain \texttt{Id}) -- the standard textbook
+automaton-MPO construction for summing an onsite term into a running
+total (the same upper-triangular-in-channel-index structure any
+finite-range Hamiltonian MPO derivation uses), verified both by a
+by-hand matrix-product induction argument and numerically (the same
+field tests above now reproduce the exact closed-form field-only result
+and a finite, converging energy density with a bond term present).
+
 \subsection{Operator representation: \texttt{MultiOperator}}
 
 Hamiltonians and observables are built as \texttt{MultiOperator} objects

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -437,6 +437,57 @@ cryptic \texttt{reshape} crash; a smaller \texttt{maxm} that actually
 binds (forcing both bonds to the same truncated dimension) avoids it,
 see \texttt{tests/test\_infinite\_chain.py}'s own comment on this.
 
+\textbf{Applying an MPO to the converged iMPS}: \texttt{idmrg.py} also
+implements \texttt{apply\_mpo(result, W\_bulk, cutoff, maxdim)} -- the
+infinite-chain analogue of \texttt{mpsalgebra.applyMPO}, and the
+primitive a future iTEBD-style real/imaginary-time evolution feature
+would build on. \texttt{grow\_by\_mpo} Kronecker-merges \texttt{W\_bulk}'s
+own per-site bonds with \texttt{U\_list}'s (mirroring
+\texttt{mpsalgebra.\_apply\_chain}'s per-site body, generalized to a
+periodic index range including the wraparound cut), giving raw,
+non-canonical tensors at bond dimension \texttt{chi\_A*chi\_W};
+\texttt{\_canonicalize\_periodic} then re-canonicalizes/truncates them
+back down via the standard two-sided fixed-point infinite-MPS procedure
+(Or\'us \& Vidal, PRB 78, 155117 (2008)): factor the dominant left/right
+transfer-matrix fixed points at every cut into square-root factors
+\texttt{X\_p}/\texttt{Y\_p} (\texttt{\_psd\_sqrt\_factor}), SVD
+\texttt{M\_p=X\_p@Y\_p} and truncate (reusing \texttt{svd.py}'s own
+\texttt{\_truncate}), then build an \emph{asymmetric} gauge
+(\texttt{G\_left[p]=U\_p\^{}H X\_p}, no \texttt{S} factor at all;
+\texttt{G\_right[p]=Y\_p V\_p\^{}H S\_p\^{}\{-1\}}, the \emph{full}
+inverse) -- asymmetric, rather than a textbook symmetric
+\texttt{S\^{}\{-1/2\}} split on both sides, specifically so the result
+comes out plain left-canonical (matching \texttt{IDMRGResult.U\_list}'s
+own convention) with no separate bond-weight layer to thread through,
+confirmed numerically before committing to the formula (a first,
+symmetric-split derivation looked plausible by analogy to Vidal's
+canonical form but reproduced Identity only to $\sim$1, not a small
+residual). \texttt{\_all\_left\_fixed\_points} (the new, symmetric
+counterpart to the existing \texttt{\_all\_right\_fixed\_points}) needed
+one more fix beyond the obvious transpose-the-eigenproblem mirroring:
+its own per-cut renormalization (needed to avoid blow-up across repeated
+propagation, exactly like the existing right-fixed-point code) discards
+the \emph{relative} scale between different cuts that
+\texttt{\_canonicalize\_periodic}'s left-gauge construction turns out to
+depend on (unlike the right-gauge one, which is provably
+scale-invariant) -- tracked via an explicit accumulated-scale return
+value and undone before use. A second, independent bug (an index-order/
+transpose mismatch between \texttt{\_apply\_transfer\_from\_left}'s own
+(ket,bra) convention and the (bra,ket) convention the isometry
+derivation needs) was only found by deriving the exact identity the
+gauge must satisfy by hand and checking it numerically term-by-term --
+a genuine case where tests alone (which caught that \emph{something}
+was wrong, via a hand-crafted internal left-canonicality check) weren't
+enough to \emph{localize} the bug, only real algebra was. \textbf{Scope
+restriction}: \texttt{W\_bulk} must be a \emph{bounded} (non-extensive)
+periodic operator -- the Hamiltonian's own
+\texttt{\_build\_periodic\_mpo}-built automaton is deliberately the
+\emph{other} kind (an unconditional accumulator self-loop that needs a
+genuine chain boundary to mean ``sum'', not ``product'') and is not a
+valid \texttt{apply\_mpo} input; see \texttt{idmrg.py}'s own ``Applying
+a (bounded) MPO to the converged iMPS'' section docstring for the
+specific failure mode this would hit.
+
 \subsection{Operator representation: \texttt{MultiOperator}}
 
 Hamiltonians and observables are built as \texttt{MultiOperator} objects

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1541,6 +1541,8 @@ h = ic.SxC[0]*ic.SxR[0] + ic.SyC[0]*ic.SyR[0] + ic.SzC[0]*ic.SzR[0]  # NN Heisen
 ic.set_hamiltonian(h)
 ```
 
+A bare, single-site operator (e.g. `ic.SzC[0]`, no product) is also a valid term — a Zeeman-field-style onsite Hamiltonian, either on its own or added alongside bond terms.
+
 A two-site unit cell can express a dimerized (alternating-bond) chain, and a coupling can skip over an intermediate site by reaching straight from `C` to `R`:
 
 ```python
@@ -1591,3 +1593,15 @@ idmrg.onsite_expectation(new_state, "Sz", 0)               # <Sz> of the new sta
 **Scope restriction — bounded operators only.** `W_bulk` must represent a *bounded* (non-extensive) periodic operator: the same tensor reused at every unit cell, with no unconditional "keep accumulating forever" self-loop — single-site products (as above), gates tiled once per unit cell (an SVD-split 2-site gate embedded with identity everywhere else), symmetry operators, and the like. `pyitensor/idmrg.py`'s own Hamiltonian automaton (built internally by `_build_periodic_mpo` for `gs_energy()`) is deliberately the *other* kind — its accumulator channel needs a genuine chain boundary to correctly represent an extensive sum, so feeding it into `apply_mpo`'s boundary-less periodic contraction does not compute "H|psi>" (see `pyitensor/idmrg.py`'s own "Applying a (bounded) MPO to the converged iMPS" section docstring for the specific failure mode). This makes `apply_mpo` the natural building block for e.g. an iTEBD-style real/imaginary-time evolution step (repeatedly apply a local Trotter gate + truncate) — not yet implemented as a public feature, but `apply_mpo` is exactly the primitive it would use.
 
 `W_bulk`'s physical Indices must be the *same objects* as `result.sites_uc`'s own (`sites_uc.si(i+1)`), so a custom operator automaton must be built against `result.sites_uc` directly (as in the example above), not a freshly constructed `SiteX`. The truncation/regauging step's own numerical conditioning degrades the further the *raw* grown bond dimension (`chi_A * chi_W`, before any truncation) exceeds the state's real entanglement at that cut — keep `maxm`/`maxdim` modest relative to `chi_W` for the best-conditioned result.
+
+**Overlap/fidelity between two converged infinite MPS (advanced).** `pyitensor.idmrg.imps_overlap(result_a, result_b, normalize=True)` computes the per-unit-cell overlap between two `IDMRGResult`/`PeriodicMPS` objects — the infinite-chain notion of a finite MPS inner product `<phi|psi>`. A literal `<phi|psi>` over an infinite chain is not, in general, a finite number (it scales as `eta**N` over `N` unit cells, `N -> infinity`, where `eta` is the dominant eigenvalue of the mixed transfer matrix built from the two states' own tensors), so by default `imps_overlap` returns the always-finite *per-site fidelity* instead — magnitude 1 iff the two iMPS represent the same physical state (any gauge or normalization convention on the raw tensors), magnitude `<1` otherwise:
+
+```python
+from dmrgpy.pyitensor import idmrg
+
+idmrg.imps_overlap(ic._result, ic._result)          # 1 -- same state
+idmrg.imps_overlap(ic._result, new_state)            # cross-check apply_mpo didn't change the physical state
+idmrg.imps_overlap(ic._result, some_other_result)    # < 1 in magnitude for a genuinely different state
+```
+
+`result_a`/`result_b` must share the same `n_uc` and, at every sublattice position, the same local physical dimension — `imps_overlap` raises `ValueError` otherwise. The two states' bond dimensions need *not* match (e.g. comparing a ground state against an `apply_mpo` output truncated to a different `maxdim`). Pass `normalize=False` for the raw, un-normalized mixed-transfer eigenvalue instead — mainly a diagnostic, analogous to `apply_mpo`'s own returned `.eta`.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1569,3 +1569,25 @@ ic.correlator("Sz", 0, "Sz", r)    # <Sz(0) Sz(0+r)>, r measured in physical sit
 Because these are reconstructed *after* convergence from the last macro-iteration's own tensors (a good, but not exact, stand-in for a truly periodic MPS unit cell — the growing algorithm never explicitly re-canonicalizes into one), correlators converge more slowly than the energy density itself as a function of `maxiter` at fixed `maxm` — a model-agnostic self-consistency check that always holds exactly for a truly periodic unit cell, `<H_uc>` (the sum of every bond's correlator inside one unit cell) equals `n_uc * density`, is a useful way to judge whether `maxiter` is large enough for a given calculation.
 
 Excited states, dynamics, and entanglement/entropy are not implemented for infinite chains yet — only ground-state energy density and static correlators.
+
+**Applying an operator/gate to the converged chain (advanced).** `pyitensor.idmrg.apply_mpo(result, W_bulk, cutoff=..., maxdim=...)` is the infinite-chain analogue of the finite backends' `applyMPO`: it contracts a periodic MPO onto every site of the converged unit cell and re-canonicalizes/truncates the grown bond dimension back down via the standard two-sided fixed-point infinite-MPS canonicalization procedure, returning a new `pyitensor.idmrg.PeriodicMPS` that `onsite_expectation`/`two_point_correlator` accept exactly like an `IDMRGResult`. There is no `Infinite_Many_Body_Chain`-level wrapper yet, so it is reached by working with `pyitensor.idmrg` directly against `ic._result` (only meaningful for `itensor_version="python"`, same restriction as `vev`/`correlator`):
+
+```python
+from dmrgpy.pyitensor import idmrg
+from dmrgpy.pyitensor.index import Index
+from dmrgpy.pyitensor.tensor import ITensor
+
+sites_uc = ic._result.sites_uc
+d = sites_uc.dim(1)
+pauli_x = 2 * sites_uc.site_type(1).matrix("Sx")           # a chi_W=1 operator
+link_l, link_r = Index(1, tags="Link"), Index(1, tags="Link")
+s = sites_uc.si(1)
+W = [ITensor((link_l, s, s.prime(1), link_r), pauli_x.reshape(1, d, d, 1))]
+
+new_state = idmrg.apply_mpo(ic._result, W, cutoff=1e-12, maxdim=None)
+idmrg.onsite_expectation(new_state, "Sz", 0)               # <Sz> of the new state
+```
+
+**Scope restriction — bounded operators only.** `W_bulk` must represent a *bounded* (non-extensive) periodic operator: the same tensor reused at every unit cell, with no unconditional "keep accumulating forever" self-loop — single-site products (as above), gates tiled once per unit cell (an SVD-split 2-site gate embedded with identity everywhere else), symmetry operators, and the like. `pyitensor/idmrg.py`'s own Hamiltonian automaton (built internally by `_build_periodic_mpo` for `gs_energy()`) is deliberately the *other* kind — its accumulator channel needs a genuine chain boundary to correctly represent an extensive sum, so feeding it into `apply_mpo`'s boundary-less periodic contraction does not compute "H|psi>" (see `pyitensor/idmrg.py`'s own "Applying a (bounded) MPO to the converged iMPS" section docstring for the specific failure mode). This makes `apply_mpo` the natural building block for e.g. an iTEBD-style real/imaginary-time evolution step (repeatedly apply a local Trotter gate + truncate) — not yet implemented as a public feature, but `apply_mpo` is exactly the primitive it would use.
+
+`W_bulk`'s physical Indices must be the *same objects* as `result.sites_uc`'s own (`sites_uc.si(i+1)`), so a custom operator automaton must be built against `result.sites_uc` directly (as in the example above), not a freshly constructed `SiteX`. The truncation/regauging step's own numerical conditioning degrades the further the *raw* grown bond dimension (`chi_A * chi_W`, before any truncation) exceeds the state's real entanglement at that cut — keep `maxm`/`maxdim` modest relative to `chi_W` for the best-conditioned result.

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1800,6 +1800,10 @@ h = ic.SxC[0]*ic.SxR[0] + ic.SyC[0]*ic.SyR[0] + ic.SzC[0]*ic.SzR[0]  # NN Heisen
 ic.set_hamiltonian(h)
 \end{lstlisting}
 
+A bare, single-site operator (e.g.\ \texttt{ic.SzC[0]}, no product) is
+also a valid term -- a Zeeman-field-style onsite Hamiltonian, either on
+its own or added alongside bond terms.
+
 A two-site unit cell can express a dimerized (alternating-bond) chain,
 and a coupling can skip over an intermediate site by reaching straight
 from \texttt{C} to \texttt{R}:
@@ -1926,5 +1930,37 @@ conditioning degrades the further the \emph{raw} grown bond dimension
 (\texttt{chi\_A * chi\_W}, before any truncation) exceeds the state's
 real entanglement at that cut -- keep \texttt{maxm}/\texttt{maxdim}
 modest relative to \texttt{chi\_W} for the best-conditioned result.
+
+\textbf{Overlap/fidelity between two converged infinite MPS (advanced).}
+\texttt{pyitensor.idmrg.imps\_overlap(result\_a, result\_b,
+normalize=True)} computes the per-unit-cell overlap between two
+\texttt{IDMRGResult}/\texttt{PeriodicMPS} objects -- the infinite-chain
+notion of a finite MPS inner product $\langle\phi|\psi\rangle$. A literal
+$\langle\phi|\psi\rangle$ over an infinite chain is not, in general, a
+finite number (it scales as $\eta^N$ over $N$ unit cells, $N \to \infty$,
+where $\eta$ is the dominant eigenvalue of the mixed transfer matrix
+built from the two states' own tensors), so by default
+\texttt{imps\_overlap} returns the always-finite \emph{per-site fidelity}
+instead -- magnitude 1 iff the two iMPS represent the same physical state
+(any gauge or normalization convention on the raw tensors), magnitude
+$<1$ otherwise:
+
+\begin{lstlisting}
+from dmrgpy.pyitensor import idmrg
+
+idmrg.imps_overlap(ic._result, ic._result)          # 1 -- same state
+idmrg.imps_overlap(ic._result, new_state)            # cross-check apply_mpo didn't change the physical state
+idmrg.imps_overlap(ic._result, some_other_result)    # < 1 in magnitude for a genuinely different state
+\end{lstlisting}
+
+\texttt{result\_a}/\texttt{result\_b} must share the same
+\texttt{n\_uc} and, at every sublattice position, the same local
+physical dimension -- \texttt{imps\_overlap} raises \texttt{ValueError}
+otherwise. The two states' bond dimensions need \emph{not} match (e.g.\
+comparing a ground state against an \texttt{apply\_mpo} output truncated
+to a different \texttt{maxdim}). Pass \texttt{normalize=False} for the
+raw, un-normalized mixed-transfer eigenvalue instead -- mainly a
+diagnostic, analogous to \texttt{apply\_mpo}'s own returned
+\texttt{.eta}.
 
 \end{document}

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1867,4 +1867,64 @@ Excited states, dynamics, and entanglement/entropy are not implemented
 for infinite chains yet -- only ground-state energy density and static
 correlators.
 
+\textbf{Applying an operator/gate to the converged chain (advanced).}
+\texttt{pyitensor.idmrg.apply\_mpo(result, W\_bulk, cutoff=..., maxdim=...)}
+is the infinite-chain analogue of the finite backends' \texttt{applyMPO}:
+it contracts a periodic MPO onto every site of the converged unit cell
+and re-canonicalizes/truncates the grown bond dimension back down via
+the standard two-sided fixed-point infinite-MPS canonicalization
+procedure, returning a new \texttt{pyitensor.idmrg.PeriodicMPS} that
+\texttt{onsite\_expectation}/\texttt{two\_point\_correlator} accept
+exactly like an \texttt{IDMRGResult}. There is no
+\texttt{Infinite\_Many\_Body\_Chain}-level wrapper yet, so it is reached
+by working with \texttt{pyitensor.idmrg} directly against
+\texttt{ic.\_result} (only meaningful for
+\texttt{itensor\_version="python"}, same restriction as
+\texttt{vev}/\texttt{correlator}):
+
+\begin{lstlisting}
+from dmrgpy.pyitensor import idmrg
+from dmrgpy.pyitensor.index import Index
+from dmrgpy.pyitensor.tensor import ITensor
+
+sites_uc = ic._result.sites_uc
+d = sites_uc.dim(1)
+pauli_x = 2 * sites_uc.site_type(1).matrix("Sx")           # a chi_W=1 operator
+link_l, link_r = Index(1, tags="Link"), Index(1, tags="Link")
+s = sites_uc.si(1)
+W = [ITensor((link_l, s, s.prime(1), link_r), pauli_x.reshape(1, d, d, 1))]
+
+new_state = idmrg.apply_mpo(ic._result, W, cutoff=1e-12, maxdim=None)
+idmrg.onsite_expectation(new_state, "Sz", 0)               # <Sz> of the new state
+\end{lstlisting}
+
+\textbf{Scope restriction -- bounded operators only.} \texttt{W\_bulk}
+must represent a \emph{bounded} (non-extensive) periodic operator: the
+same tensor reused at every unit cell, with no unconditional ``keep
+accumulating forever'' self-loop -- single-site products (as above),
+gates tiled once per unit cell (an SVD-split 2-site gate embedded with
+identity everywhere else), symmetry operators, and the like.
+\texttt{pyitensor/idmrg.py}'s own Hamiltonian automaton (built internally
+by \texttt{\_build\_periodic\_mpo} for \texttt{gs\_energy()}) is
+deliberately the \emph{other} kind -- its accumulator channel needs a
+genuine chain boundary to correctly represent an extensive sum, so
+feeding it into \texttt{apply\_mpo}'s boundary-less periodic contraction
+does not compute ``H\textbar psi\textrangle'' (see
+\texttt{pyitensor/idmrg.py}'s own ``Applying a (bounded) MPO to the
+converged iMPS'' section docstring for the specific failure mode). This
+makes \texttt{apply\_mpo} the natural building block for e.g.\ an
+iTEBD-style real/imaginary-time evolution step (repeatedly apply a local
+Trotter gate + truncate) -- not yet implemented as a public feature, but
+\texttt{apply\_mpo} is exactly the primitive it would use.
+
+\texttt{W\_bulk}'s physical Indices must be the \emph{same objects} as
+\texttt{result.sites\_uc}'s own (\texttt{sites\_uc.si(i+1)}), so a custom
+operator automaton must be built against \texttt{result.sites\_uc}
+directly (as in the example above), not a freshly constructed
+\texttt{SiteX}. The truncation/regauging step's own numerical
+conditioning degrades the further the \emph{raw} grown bond dimension
+(\texttt{chi\_A * chi\_W}, before any truncation) exceeds the state's
+real entanglement at that cut -- keep \texttt{maxm}/\texttt{maxdim}
+modest relative to \texttt{chi\_W} for the best-conditioned result.
+
 \end{document}

--- a/examples/idmrg/apply_mpo_to_infinite_chain/main.py
+++ b/examples/idmrg/apply_mpo_to_infinite_chain/main.py
@@ -1,0 +1,108 @@
+# Applying a periodic (bounded) MPO to the converged infinite MPS --
+# pyitensor.idmrg.apply_mpo, the infinite-chain analogue of the finite
+# backends' applyMPO: contract a periodic MPO onto the converged unit
+# cell (grow_by_mpo), then re-canonicalize/truncate the grown bond
+# dimension back down (idmrg._canonicalize_periodic) via the standard
+# two-sided fixed-point infinite-MPS canonicalization procedure.
+#
+# SCOPE: apply_mpo only works for *bounded* (non-extensive) periodic
+# operators -- the same tensor reused at every unit cell, with no
+# unconditional "keep accumulating forever" self-loop -- see
+# pyitensor/idmrg.py's own "Applying a (bounded) MPO to the converged
+# iMPS" section docstring for why idmrg.py's own Hamiltonian automaton
+# (built by _build_periodic_mpo) is explicitly *not* a valid input here.
+#
+# Demonstrated below: (1) a chi_W=1 unitary single-site operator (Pauli-X
+# at every site of a uniform Heisenberg chain) -- flips <Sz> and leaves
+# <Sz(0)Sz(r)> unchanged, both exact, closed-form checks; (2) a genuinely
+# bond-dimension>1 local gate (an SVD-split 2-site unitary rotation,
+# tiled once per unit cell) -- exercises the actual bond-growth path,
+# and being unitary must preserve the norm (apply_mpo's own `eta`
+# diagnostic).
+
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+import numpy as np
+from scipy.linalg import expm
+from dmrgpy import infinitechain
+from dmrgpy.pyitensor import idmrg
+from dmrgpy.pyitensor.index import Index
+from dmrgpy.pyitensor.tensor import ITensor
+
+################################################################
+### (1) chi_W=1 unitary single-site operator: Pauli-X at every site ###
+################################################################
+ic = infinitechain.Infinite_Spin_Chain(["1/2"])
+h = ic.SxC[0] * ic.SxR[0] + ic.SyC[0] * ic.SyR[0] + ic.SzC[0] * ic.SzR[0]
+ic.set_hamiltonian(h)
+ic.maxm, ic.maxiter, ic.etol = 30, 60, 1e-9
+ic.gs_energy()
+
+sites_uc = ic._result.sites_uc
+d = sites_uc.dim(1)
+pauli_x = 2 * sites_uc.site_type(1).matrix("Sx")  # unitary for spin-1/2
+link_l, link_r = Index(1, tags="Link"), Index(1, tags="Link")
+s = sites_uc.si(1)
+W_pauli_x = [ITensor((link_l, s, s.prime(1), link_r), pauli_x.reshape(1, d, d, 1))]
+
+flipped = idmrg.apply_mpo(ic._result, W_pauli_x, cutoff=1e-12, maxdim=None)
+
+print("=== Pauli-X applied to every site of a uniform Heisenberg chain ===")
+print("norm diagnostic eta (unitary -> should be ~1):", flipped.eta)
+sz0 = idmrg.onsite_expectation(ic._result, "Sz", 0)
+sz0_flipped = idmrg.onsite_expectation(flipped, "Sz", 0)
+print("<Sz> before:", sz0, " after:", sz0_flipped, " (expect after = -before)")
+for r in range(1, 3):
+    c0 = idmrg.two_point_correlator(ic._result, "Sz", 0, "Sz", r)
+    c1 = idmrg.two_point_correlator(flipped, "Sz", 0, "Sz", r)
+    print("<Sz(0)Sz({})> before: {}  after: {}  (expect unchanged)".format(r, c0, c1))
+    assert abs(c1 - c0) < 1e-6
+
+assert abs(sz0_flipped - (-sz0)) < 1e-6
+assert abs(flipped.eta - 1.0) < 1e-6
+
+########################################################################
+### (2) chi_W>1 local gate: a 2-site unitary rotation, one per unit cell ###
+########################################################################
+ic2 = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+h2 = (ic2.SxC[0] * ic2.SxC[1] + ic2.SyC[0] * ic2.SyC[1] + ic2.SzC[0] * ic2.SzC[1]
+      + 0.4 * (ic2.SxC[1] * ic2.SxR[0] + ic2.SyC[1] * ic2.SyR[0] + ic2.SzC[1] * ic2.SzR[0]))
+ic2.set_hamiltonian(h2)
+# Deliberately modest maxm: apply_mpo's own truncation/regauging step
+# solves a numerically delicate two-sided-fixed-point problem whose
+# conditioning degrades the further the *raw* grown bond dimension
+# (chi_A*chi_W, before any truncation) exceeds the state's real
+# entanglement at that cut -- see idmrg.py's _canonicalize_periodic's own
+# comment. A larger maxm here still works, just needs a looser internal
+# tolerance to accommodate the resulting ill-conditioning.
+ic2.maxm, ic2.maxiter, ic2.etol = 4, 100, 1e-12
+ic2.gs_energy()
+
+sites_uc2 = ic2._result.sites_uc
+Sx, Sy, Sz = (sites_uc2.site_type(1).matrix(n) for n in ("Sx", "Sy", "Sz"))
+H2 = (np.kron(Sx, Sx) + np.kron(Sy, Sy) + np.kron(Sz, Sz)).real
+gate = expm(-1j * 0.37 * H2)  # d^2 x d^2 unitary 2-site rotation
+gate4 = np.transpose(gate.reshape(d, d, d, d), (2, 0, 3, 1))  # (s0,s0',s1,s1')
+U, S, Vh = np.linalg.svd(gate4.reshape(d * d, d * d), full_matrices=False)
+keep = int(np.sum(S > 1e-12))
+U, S, Vh = U[:, :keep], S[:keep], Vh[:keep, :]
+a_half = (U * S[None, :] ** 0.5).reshape(d, d, keep)
+b_half = (S[:, None] ** 0.5 * Vh).reshape(keep, d, d)
+
+s0, s1 = sites_uc2.si(1), sites_uc2.si(2)
+left_dummy, mid, right_dummy = Index(1, tags="Link"), Index(keep, tags="Link"), Index(1, tags="Link")
+W0 = ITensor((left_dummy, s0, s0.prime(1), mid), a_half.reshape(1, d, d, keep))
+W1 = ITensor((mid, s1, s1.prime(1), right_dummy), b_half.reshape(keep, d, d, 1))
+
+gated = idmrg.apply_mpo(ic2._result, [W0, W1], cutoff=1e-10, maxdim=None)
+
+print()
+print("=== 2-site unitary gate applied once per unit cell ===")
+print("original bond dims:", [u.array.shape for u in ic2._result.U_list])
+print("gated bond dims:   ", [u.array.shape for u in gated.U_list])
+print("norm diagnostic eta (unitary -> should be ~1):", gated.eta)
+assert abs(gated.eta - 1.0) < 1e-4
+
+print()
+print("apply_mpo example PASSED")

--- a/examples/idmrg/imps_overlap/main.py
+++ b/examples/idmrg/imps_overlap/main.py
@@ -1,0 +1,75 @@
+# Per-site overlap/fidelity between two converged infinite MPS --
+# pyitensor.idmrg.imps_overlap: the thermodynamic-limit generalization of
+# a finite MPS inner product <phi|psi>. A literal <phi|psi> over an
+# infinite chain is 0 or infinite (it scales as eta^N over N unit cells)
+# unless the dominant mixed-transfer-matrix eigenvalue eta has magnitude
+# exactly 1 -- so imps_overlap returns the *per-site fidelity*
+# eta_ab/sqrt(eta_aa*eta_bb) by default (normalize=True), which has
+# magnitude 1 iff the two iMPS represent the same physical state (any
+# gauge/normalization convention), and magnitude < 1 otherwise.
+#
+# Demonstrated below: (1) self-overlap and overlap with an identity-MPO'd
+# copy (idmrg.apply_mpo) are both exactly 1 -- a gauge-independent
+# cross-check that apply_mpo's own canonicalization didn't change the
+# physical state; (2) two independently-converged, oppositely-polarized
+# product states (a strong onsite field pinning <Sz> to +-0.5) are
+# orthogonal, |overlap| ~ 0.
+
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+from dmrgpy import infinitechain
+from dmrgpy.pyitensor import idmrg
+from dmrgpy.pyitensor.index import Index
+from dmrgpy.pyitensor.tensor import ITensor
+import numpy as np
+
+################################################################
+### (1) self-overlap and gauge-invariance under apply_mpo(Id) ###
+################################################################
+ic = infinitechain.Infinite_Spin_Chain(["1/2"])
+h = ic.SxC[0] * ic.SxR[0] + ic.SyC[0] * ic.SyR[0] + ic.SzC[0] * ic.SzR[0]
+ic.set_hamiltonian(h)
+ic.maxm, ic.maxiter, ic.etol = 30, 60, 1e-9
+ic.gs_energy()
+
+print("=== self-overlap of a converged Heisenberg ground state ===")
+ov_self = idmrg.imps_overlap(ic._result, ic._result)
+print("<psi|psi> per site:", ov_self, " (expect exactly 1)")
+assert abs(ov_self - 1.0) < 1e-6
+
+sites_uc = ic._result.sites_uc
+d = sites_uc.dim(1)
+link_l, link_r = Index(1, tags="Link"), Index(1, tags="Link")
+s = sites_uc.si(1)
+W_id = [ITensor((link_l, s, s.prime(1), link_r), np.eye(d, dtype=complex).reshape(1, d, d, 1))]
+same_state = idmrg.apply_mpo(ic._result, W_id, cutoff=1e-12, maxdim=None)
+
+print()
+print("=== overlap with an identity-MPO'd (re-gauged) copy ===")
+ov_gauge = idmrg.imps_overlap(ic._result, same_state)
+print("|<psi|apply_mpo(Id, psi)>| per site:", abs(ov_gauge), " (expect exactly 1)")
+assert abs(abs(ov_gauge) - 1.0) < 1e-6
+
+########################################################################
+### (2) two independently-converged, oppositely-polarized product states ###
+########################################################################
+ic_up = infinitechain.Infinite_Spin_Chain(["1/2"])
+ic_up.maxm, ic_up.maxiter, ic_up.etol = 4, 50, 1e-12
+ic_up.set_hamiltonian(-10.0 * ic_up.SzC[0])
+ic_up.gs_energy()
+
+ic_down = infinitechain.Infinite_Spin_Chain(["1/2"])
+ic_down.maxm, ic_down.maxiter, ic_down.etol = 4, 50, 1e-12
+ic_down.set_hamiltonian(10.0 * ic_down.SzC[0])
+ic_down.gs_energy()
+
+print()
+print("=== overlap between opposite-field-polarized product states ===")
+print("<Sz> up-chain:", ic_up.vev("Sz", 0), " down-chain:", ic_down.vev("Sz", 0))
+ov_orth = idmrg.imps_overlap(ic_up._result, ic_down._result)
+print("|<down|up>| per site:", abs(ov_orth), " (expect ~0, orthogonal states)")
+assert abs(ov_orth) < 1e-6
+
+print()
+print("imps_overlap example PASSED")

--- a/src/dmrgpy/pyitensor/idmrg.py
+++ b/src/dmrgpy/pyitensor/idmrg.py
@@ -134,8 +134,9 @@ from .dmrg import _lanczos_ground_state
 from .index import Index
 from .sites import SiteX
 from .sites.base import is_fermionic
-from .svd import svd
+from .svd import _truncate, svd
 from .tensor import ITensor, contract_many, dag
+from .tensor import noPrime as _t_noPrime
 from .tensor import prime as _t_prime
 
 
@@ -275,6 +276,17 @@ def _onsite_matrix(onsite_by_p, p, d):
 
 
 def _build_automaton(h_intra_op, h_inter_op, site_types, n_uc):
+    """sites_uc = SiteX(site_types), then _build_periodic_mpo(...) against
+    it -- split out so apply_mpo's own callers can build a *different*
+    (bounded, non-Hamiltonian) automaton sharing an *existing* IDMRGResult's
+    own sites_uc (required for the physical Indices to match by identity,
+    see _build_periodic_mpo's own docstring), rather than always minting a
+    fresh SiteX the way a Hamiltonian build always wants to."""
+    sites_uc = SiteX(list(site_types))
+    return sites_uc, _build_periodic_mpo(h_intra_op, h_inter_op, sites_uc, n_uc)
+
+
+def _build_periodic_mpo(h_intra_op, h_inter_op, sites_uc, n_uc):
     """Build the periodic per-sublattice MPO tensors W_bulk[0..n_uc-1]
     directly, as a genuine finite-state automaton -- see this module's
     docstring for why this, not an extraction from any fixed finite
@@ -325,16 +337,22 @@ def _build_automaton(h_intra_op, h_inter_op, site_types, n_uc):
     terms), F persists (self-loop with onsite pickup, receives
     completions) -- but *only* S may start a new pending channel.
 
-    Returns (sites_uc, W_bulk): sites_uc is the n_uc-site SiteX the
-    physical legs belong to (also used later to look up named-operator
-    matrices for static correlators); W_bulk[p] (rank 4: left-bond,
-    right-bond, phys, phys') is sublattice p's tensor, with W_bulk[p]'s
-    right bond and W_bulk[(p+1)%n_uc]'s left bond always the *same*
-    canonical Index object -- valid by construction here (both are
-    indexed by the identical, explicitly-enumerated channel list; there is
-    no independent gauge choice anywhere in this construction to make them
-    inconsistent, unlike extracting from an SVD-compressed reference)."""
-    sites_uc = SiteX(list(site_types))
+    `sites_uc` (an already-built SiteX -- see `_build_automaton`, the
+    Hamiltonian-facing wrapper that mints a fresh one; apply_mpo's own
+    bounded-operator callers instead pass an *existing* IDMRGResult's own
+    sites_uc, required so the physical Indices below match, by identity,
+    the converged U_list's own physical legs -- see idmrg.py's
+    apply_mpo/grow_by_mpo docstrings) is where physical-leg Indices and
+    per-site dimensions are looked up from, and h_intra_op/h_inter_op are
+    resolved against its own named-operator matrices.
+
+    Returns W_bulk: W_bulk[p] (rank 4: left-bond, right-bond, phys, phys')
+    is sublattice p's tensor, with W_bulk[p]'s right bond and
+    W_bulk[(p+1)%n_uc]'s left bond always the *same* canonical Index
+    object -- valid by construction here (both are indexed by the
+    identical, explicitly-enumerated channel list; there is no independent
+    gauge choice anywhere in this construction to make them inconsistent,
+    unlike extracting from an SVD-compressed reference)."""
     onsite, bonds = _classify_terms(h_intra_op, h_inter_op, sites_uc, n_uc)
     onsite_by_p = {}
     for rel, coef, mat in onsite:
@@ -394,7 +412,7 @@ def _build_automaton(h_intra_op, h_inter_op, site_types, n_uc):
         T = ITensor((left_idx, s, s.prime(1), right_idx),
                      np.transpose(arr, (0, 2, 3, 1)))
         W_bulk.append(T)
-    return sites_uc, W_bulk
+    return W_bulk
 
 
 def _project_channel(T, side, idx):
@@ -736,13 +754,16 @@ def _to_array_lpr(U):
     return U.array.reshape((1,) + U.array.shape)
 
 
-def _transfer_matrices(result):
+def _transfer_matrices(U_list, n_uc):
     """[E_p] for p=0..n_uc-1, each a (chi_l,chi_l,chi_r,chi_r) array: the
-    doubled ket-times-conj(ket) transfer tensor for the converged
-    left-canonical tensor at sublattice p."""
+    doubled ket-times-conj(ket) transfer tensor for the (left-canonical, or
+    -- for apply_mpo's use -- raw not-yet-canonical) tensor at sublattice p.
+    Takes a plain tensor list rather than an IDMRGResult so apply_mpo's own
+    canonicalization can reuse it on its own intermediate (not-yet-converged
+    IDMRGResult) tensors too."""
     Es = []
-    for p in range(result.n_uc):
-        A = _to_array_lpr(result.U_list[p])
+    for p in range(n_uc):
+        A = _to_array_lpr(U_list[p])
         Es.append(np.einsum('lpr,LpR->lLrR', A, np.conj(A)))
     return Es
 
@@ -821,7 +842,7 @@ def _op_transfer(sites_uc, U_list, p, opname):
 def onsite_expectation(result, opname, p):
     """<opname> at sublattice p (0..n_uc-1) of the converged infinite
     chain."""
-    Es = _transfer_matrices(result)
+    Es = _transfer_matrices(result.U_list, result.n_uc)
     rho_after, _eta = _all_right_fixed_points(Es, result.n_uc)
     E_op = _op_transfer(result.sites_uc, result.U_list, p, opname)
     val = _apply_transfer(E_op, rho_after[p])
@@ -839,7 +860,7 @@ def two_point_correlator(result, opname_i, p_i, opname_j, r):
     if r < 0:
         raise ValueError("two_point_correlator: r must be >= 0")
     n_uc = result.n_uc
-    Es = _transfer_matrices(result)
+    Es = _transfer_matrices(result.U_list, n_uc)
     rho_after, _eta = _all_right_fixed_points(Es, n_uc)
 
     if r == 0:
@@ -860,3 +881,388 @@ def two_point_correlator(result, opname_i, p_i, opname_j, r):
         result.sites_uc, result.U_list, p_j, opname_j))
     val = _apply_transfer(running, rho_after[p_j])
     return complex(np.trace(val))
+
+
+# == Applying a (bounded) MPO to the converged iMPS ================
+#
+# apply_mpo(result, W_bulk) is the infinite-chain analogue of
+# mpsalgebra.applyMPO(): contract a periodic MPO onto the converged unit
+# cell (grow_by_mpo), then re-canonicalize/truncate the grown bond
+# dimension back down (_canonicalize_periodic) via the standard two-sided
+# fixed-point procedure (Orus & Vidal, "Infinite time-evolving block
+# decimation algorithm beyond unitary evolution", PRB 78, 155117 (2008)) --
+# the same construction iTEBD uses after every non-unitary gate
+# application, generalized here from a single-site unit cell to n_uc sites.
+#
+# SCOPE: W_bulk must represent a *bounded* (non-extensive) periodic
+# operator -- the same tensor reused at every unit cell, with no
+# unconditional "keep accumulating forever" self-loop. `_build_periodic_mpo`
+# (the Hamiltonian's own automaton builder, used by idmrg_ground_state
+# above) is deliberately the *other* kind: its "F" channel has an
+# unconditional identity self-loop specifically so a *finite,
+# boundary-terminated* growing chain can sum an unbounded number of
+# repeats (see _build_periodic_mpo's own docstring). Feeding that
+# Hamiltonian automaton directly into apply_mpo below -- a boundary-less
+# periodic contraction -- does NOT compute "H|psi>": traced around a ring
+# with no boundary projection, the accumulator channel *multiplies* itself
+# every unit cell instead of *summing* (worked through by hand on a
+# trivial onsite-only automaton with no bond terms: going around N times
+# literally computes (Id+onsite)^N, not sum_i onsite_i). apply_mpo is
+# therefore scoped to genuinely bounded/local periodic operators --
+# single-site products, gates tiled once per unit cell, symmetry
+# operators, and the like -- built directly (see the docstrings below) or
+# via `_build_periodic_mpo` fed a Hamiltonian-shaped term list that is
+# genuinely finite-range *and* has no term wrapping past one adjacent
+# cell's own automaton reach; using the Hamiltonian's own full automaton
+# is out of scope for this function.
+
+
+def _primed_site_index(W):
+    """The primed ("out") Site-tagged Index of an MPO tensor W -- mirrors
+    idmrg_ground_state's own `_unprimed_site_index`, used by grow_by_mpo to
+    label the still-primed physical leg of a freshly MPO-grown tensor
+    before apply_mpo noPrime()s it back to a plain ket leg."""
+    return next(ind for ind in W.inds if ind.hastags("Site") and ind.plev == 1)
+
+
+def _local_grow(W_p, A_p):
+    """W_p applied to A_p at one unit-cell site: contract the shared
+    physical leg and Kronecker-merge (left(W),left(A)) and
+    (right(W),right(A)) into the two output bond axes -- done via plain
+    positional NumPy array manipulation (W_p's own axis order is always
+    (left,phys-in,phys-out,right), A_p's is always (left,phys,right), by
+    construction, see _build_periodic_mpo/_to_array_lpr) rather than
+    ITensor.__mul__'s Index-identity-based matching.
+
+    Index-identity matching would silently misbehave here whenever W_p's
+    own left and right legs happen to be the *same* Index object --
+    guaranteed for n_uc=1 (see _build_periodic_mpo's own docstring on its
+    boundary_idx pool having only n_uc distinct Index objects, reused
+    verbatim for a repeating channel type) -- exactly the same collision
+    idmrg_ground_state's own `_project_channel`/`_relabel_pos` already
+    have to sidestep positionally for identical reasons.
+
+    Returns a plain (chi_W_left*chi_A_left, d, chi_W_right*chi_A_right)
+    NumPy array -- the physical leg is W_p's own "out" (still primed)
+    convention, grow_by_mpo noPrime()s it once the full periodic chain is
+    assembled."""
+    w_arr = W_p.array
+    a_arr = _to_array_lpr(A_p)
+    Lw, d, _d2, Rw = w_arr.shape
+    La, _d3, Ra = a_arr.shape
+    prod = np.einsum('lsor,msn->lmorn', w_arr, a_arr)
+    return prod.reshape((Lw * La, d, Rw * Ra))
+
+
+def grow_by_mpo(W_bulk, U_list, n_uc):
+    """Contract MPO tensor W_bulk[p] against ket tensor U_list[p] at every
+    unit-cell site (via `_local_grow`), Kronecker-merging each of the
+    n_uc *cuts* (including the wraparound one, between site n_uc-1 and
+    site 0) into one freshly-minted combined Link Index -- the same
+    per-site "zip together, don't compress yet" construction
+    mpsalgebra.py's `_apply_chain` uses for a finite chain
+    (mpsalgebra.py:206-251), just over a periodic index range instead of a
+    chain with two open ends.
+
+    W_bulk[p]'s physical (unprimed) Index must be the *same* object as
+    U_list[p]'s own physical Index, so `_local_grow`'s contraction lands on
+    exactly that leg -- true whenever W_bulk was built by
+    `_build_periodic_mpo` against the *same* sites_uc U_list's own physical
+    legs came from (see apply_mpo's own docstring).
+
+    Returns B[0..n_uc-1]: rank-3 ITensors (left Link, phys -- still primed,
+    W's own "out" convention, see apply_mpo which noPrime()s it -- right
+    Link), *not yet* canonicalized/truncated (see `_canonicalize_periodic`)."""
+    if len(W_bulk) != n_uc or len(U_list) != n_uc:
+        raise ValueError(
+            "grow_by_mpo: expected {} unit-cell sites, got W_bulk={}, "
+            "U_list={}".format(n_uc, len(W_bulk), len(U_list)))
+    raw = [_local_grow(W_bulk[p], U_list[p]) for p in range(n_uc)]
+    combined_links = [Index(raw[p].shape[0], tags="Link") for p in range(n_uc)]
+    for p in range(n_uc):
+        right_dim = raw[p].shape[-1]
+        expected = combined_links[(p + 1) % n_uc].dim
+        if right_dim != expected:
+            raise RuntimeError(
+                "grow_by_mpo: cut dimension mismatch at site {} (right "
+                "dim {}, next site's left dim {}) -- W_bulk and U_list "
+                "must both be periodic with period n_uc={}".format(
+                    p, right_dim, expected, n_uc))
+    B = []
+    for p in range(n_uc):
+        phys_out = _primed_site_index(W_bulk[p])
+        left, right = combined_links[p], combined_links[(p + 1) % n_uc]
+        B.append(ITensor((left, phys_out, right), raw[p]))
+    return B
+
+
+def _apply_transfer_from_left(E4, rho):
+    """Mirror of `_apply_transfer`: contracts rho against E4's *left*
+    (l,L) legs instead of its right (r,R) ones -- used to propagate a
+    dominant *left* fixed point forward through a site, the mirror image
+    of how `_apply_transfer` propagates a right fixed point backward."""
+    return np.einsum('lL,lLrR->rR', rho, E4)
+
+
+def _dominant_left_fixed_point(Es):
+    """The dominant LEFT eigenvector of the full unit-cell transfer matrix
+    T=E_0...E_{n_uc-1} -- i.e. a vector rho_L with rho_L . T = eta * rho_L
+    (equivalently, the right eigenvector of T's own transpose) -- at the
+    *same* cut `_dominant_right_fixed_point` itself resolves (the
+    wraparound bond, "before site 0"/"after site n_uc-1"). Mirrors
+    `_dominant_right_fixed_point`'s own construction and
+    shape-consistency check exactly, with one added transpose."""
+    T4 = Es[0]
+    for E in Es[1:]:
+        T4 = _compose(T4, E)
+    chi = T4.shape[0]
+    if T4.shape != (chi, chi, chi, chi):
+        raise RuntimeError(
+            "idmrg apply_mpo: the periodic unit cell's wraparound bond "
+            "dimension is inconsistent (transfer tensor shape {}) -- same "
+            "failure mode _dominant_right_fixed_point already guards "
+            "against, see its own comment".format(T4.shape))
+    Tmat = T4.reshape(chi * chi, chi * chi)
+    w, v = np.linalg.eig(Tmat.T)
+    idx = np.argmax(np.abs(w))
+    eta = w[idx]
+    rho = v[:, idx].reshape(chi, chi)
+    rho = rho / np.trace(rho)
+    return rho, eta
+
+
+def _all_left_fixed_points(Es, n_uc):
+    """rho_before[p] = the fixed-point "everything strictly before site p,
+    wrapping back around" density matrix, for every sublattice position --
+    mirrors `_all_right_fixed_points`, propagating *forward* (rho_before[0]
+    is the dominant left fixed point itself; rho_before[p] for p>0 comes
+    from pushing it through sites 0..p-1) instead of backward.
+
+    Also returns `scales`: `_all_right_fixed_points`' own per-step
+    `cur = cur / np.trace(cur)` renormalization (needed there, and copied
+    here, purely to avoid numerical blow-up/decay across many propagation
+    steps) is harmless for `_all_right_fixed_points`' own callers -- the
+    correlator code only ever uses one rho_after[p] at a time, and
+    `_canonicalize_periodic`'s G_right[p] construction is provably
+    invariant to rho_R_before[p]'s own overall scale (the S_p factor it
+    divides by scales the same way, see `_canonicalize_periodic`'s own
+    comment). G_left[p], by contrast, is *linear* in rho_L_before[p]'s own
+    scale (no compensating S factor) -- so silently renormalizing away the
+    *relative* scale between different cuts' rho_before here would corrupt
+    `_canonicalize_periodic`'s left-canonicality by exactly that dropped
+    per-cut ratio. Confirmed directly: for n_uc=2, this was the actual bug
+    behind a 0.875/(1/0.875) Gram-matrix deviation at the two sites (their
+    product is exactly 1, i.e. a real, non-unitary rescale, not numerical
+    noise) that survived an unrelated (and, it turned out, inert -- see
+    that function's own comment) rho_R normalization fix; n_uc=1 has no
+    propagation step at all (scales=[1]) which is why it was never
+    affected. `scales[p]` is the accumulated product of exactly the trace
+    factors divided out through step p -- multiplying `rho_before[p]` by
+    `scales[p]` undoes the renormalization exactly (by linearity of the
+    transfer map, verified algebraically: if cur_normalized[p] =
+    cur_natural[p]/scales[p], propagating one more (linear) step and
+    renormalizing again preserves that relationship with
+    scales[p+1]=scales[p]*this step's own divided-out trace)."""
+    rho_full, eta = _dominant_left_fixed_point(Es)
+    rho_before = [None] * n_uc
+    rho_before[0] = rho_full
+    scales = [1.0] * n_uc
+    cur = rho_full
+    scale = 1.0
+    for p in range(0, n_uc - 1):
+        cur = _apply_transfer_from_left(Es[p], cur)
+        step_trace = np.trace(cur)
+        cur = cur / step_trace
+        scale = scale * step_trace
+        scales[p + 1] = scale
+        rho_before[p + 1] = cur
+    return rho_before, eta, scales
+
+
+def _psd_sqrt_factor(rho, rel_floor=1e-12):
+    """X (k x N, k <= N) such that rho ~= X^H X (Hermitized square root
+    via eigh, dropping eigenvalues at or below `rel_floor` times the
+    largest one -- this covers both clipping small-negative numerical
+    noise, since 0 <= rel_floor*max, and dropping small-but-positive ones)
+    -- factors the dominant left/right transfer-matrix fixed points ahead
+    of `_canonicalize_periodic`'s SVD-based truncation/regauging step. Not
+    `svd.py`'s `eigh_truncate`: that also truncates to a caller-chosen
+    cutoff/maxdim (the *final* truncation `_canonicalize_periodic` must
+    only apply once, jointly, from the SVD of X @ Y, not here) and only
+    returns eigenvectors, not a full sqrt factor.
+
+    Dropping near-zero eigenvalues here (not just clipping negative ones)
+    is required, not cosmetic: a raw environment fixed point can be
+    enormously ill-conditioned (confirmed directly on a genuinely
+    bond-growing apply_mpo case -- eigenvalues spanning ~1e-11 to ~1,
+    condition number ~1e10) whenever the *raw* grown bond dimension (an
+    artifact of grow_by_mpo's Kronecker product, before any truncation)
+    vastly exceeds the state's actual entanglement at that cut. Keeping
+    those near-singular directions in a *square*, full-rank X/Y produces
+    an M_p = X_p @ Y_p whose own SVD is numerically garbage in exactly
+    those directions -- confirmed directly: without this floor, a genuine
+    (non-uniform-bond-dimension) grow-then-truncate case left one site's
+    Gram matrix off from Identity by O(100), not a small residual, while
+    the same run's *other* site (whose own environment was well-
+    conditioned) was fine -- narrowing the cause to exactly this."""
+    herm = (rho + rho.conj().T) / 2
+    evals, evecs = np.linalg.eigh(herm)
+    floor = rel_floor * evals[-1] if evals.size and evals[-1] > 0 else 0.0
+    keep = evals > max(floor, 0.0)
+    return np.sqrt(evals[keep])[:, None] * evecs[:, keep].conj().T
+
+
+def _canonicalize_periodic(B_list, n_uc, cutoff, maxdim):
+    """The standard two-sided fixed-point infinite-MPS canonicalization/
+    compression procedure (see this module's "Applying a (bounded) MPO"
+    section docstring above for the reference). B_list: raw (generally
+    non-canonical) periodic tensors, already noPrime()d, one per
+    unit-cell site, n_uc cuts total (including the wraparound).
+
+    At each cut p, factor the dominant left/right fixed points
+    rho_L_before[p] = X_p^H X_p, rho_R_before[p] = Y_p Y_p^H
+    (`_psd_sqrt_factor`), SVD M_p = X_p @ Y_p = U_p S_p V_p^H, truncate
+    (`svd.py`'s `_truncate`), and build the *asymmetric* gauge
+    G_left[p] = U_p^H X_p (no S factor at all), G_right[p] =
+    Y_p V_p^H S_p^-1 (the *full* inverse, not a square root) -- inserting
+    G_right[p] @ G_left[p] at cut p still resolves (up to the truncation
+    just performed) the identity there (S cancels: U^H X Y V^H S^-1 =
+    U^H (U S V^H) V^H S^-1 = S S^-1 = Identity_keep on the kept subspace,
+    same argument as a symmetric S^-1/2 split, just redistributed), but
+    -- unlike a symmetric S^-1/2 split, which produces Vidal Gamma tensors
+    still needing a separate bond-weight Lambda=S layer threaded between
+    them -- putting the *entire* S^-1 on one side directly produces the
+    plain left-canonical form this module's IDMRGResult.U_list already
+    uses (each tensor alone isometric, no separate bond-weight layer),
+    with no further Lambda-absorption step needed. (Confirmed numerically
+    on the identity-MPO round-trip case before committing to this
+    formula: the symmetric-S^-1/2-plus-separate-Lambda-absorption
+    construction a first derivation produced looked plausible by analogy
+    to Vidal's canonical form but was measurably wrong -- gram matrix
+    deviation from Identity ~1, not a small residual; this asymmetric
+    form reproduces Identity to ~1e-14.)
+
+    Returns (U_list_new, eta): U_list_new is left-canonical (verified
+    internally, raising if it isn't within tolerance -- a real bug would
+    otherwise silently corrupt every downstream correlator computation on
+    the result); eta is the new state's own self-overlap transfer
+    eigenvalue (a norm diagnostic -- apply_mpo does not renormalize, so
+    this is not necessarily close to 1)."""
+    Es = _transfer_matrices(B_list, n_uc)
+    rho_after, eta_R = _all_right_fixed_points(Es, n_uc)
+    rho_R_before = [rho_after[(p - 1) % n_uc] for p in range(n_uc)]
+    rho_L_before, eta_L, scales = _all_left_fixed_points(Es, n_uc)
+
+    if abs(eta_L - eta_R) > 1e-6 * max(1.0, abs(eta_R)):
+        raise RuntimeError(
+            "idmrg apply_mpo: dominant left/right transfer eigenvalues "
+            "disagree (eta_L={}, eta_R={}) -- same transfer matrix, only "
+            "the eigenvector side differs, so a mismatch signals a "
+            "genuine inconsistency (e.g. a near-degenerate transfer "
+            "spectrum) rather than benign numerical noise".format(eta_L, eta_R))
+
+    # Undo _all_left_fixed_points' own per-cut renormalization -- see that
+    # function's own comment for why G_left[p] (unlike G_right[p]) is not
+    # invariant to it, and why this is the fix (not, as an earlier,
+    # confirmed-inert attempt assumed, a mismatch between rho_L and rho_R).
+    #
+    # Also transpose: _apply_transfer_from_left(E4, rho)[r,R] pairs its
+    # *first* input index with E4's 'l' leg (the *unconjugated*/ket copy)
+    # and its second with 'L' (the conjugated/bra copy) -- see
+    # _transfer_matrices' own E4 = einsum('lpr,LpR->lLrR', A, conj(A)).
+    # That makes _all_left_fixed_points' own rho_before a (ket,bra)-ordered
+    # matrix, the *transpose* of the usual (bra,ket) density-matrix
+    # convention the isometry identity below needs (the same convention
+    # rho_R_before/rho_after already use, consumed correctly as-is).
+    # Confirmed directly, the hard way: an isometry-target identity derived
+    # by hand (G_right[p]^H @ rho_L_before[p] @ G_right[p] == Identity_keep,
+    # with rho_L_before[p] appearing via
+    # sum_{b,b'} rho_L_before[0][b,b'] conj(B[b,..]) B[b',..] == rho_L_before[1])
+    # checked out in the identity/algebra but the *numeric* Gram matrix of
+    # the resulting tensor was still off by O(10-1000) (not the earlier
+    # bugs' signatures, and unaffected by cutoff/maxdim/psd-factor-rank
+    # choices) until this transpose was added -- isolated by computing
+    # that same bracketed sum directly and finding it equal to
+    # conj(rho_L_before[1]) (== rho_L_before[1].T for a Hermitian matrix),
+    # not rho_L_before[1] itself.
+    rho_L_before = [(rho_L_before[p] * scales[p]).T for p in range(n_uc)]
+
+    G_left, G_right = [None] * n_uc, [None] * n_uc
+    for p in range(n_uc):
+        X_p = _psd_sqrt_factor(rho_L_before[p])
+        Y_p = _psd_sqrt_factor(rho_R_before[p]).conj().T
+        M_p = X_p @ Y_p
+        U_p, S_p, Vh_p = np.linalg.svd(M_p, full_matrices=False)
+        keep, _discarded = _truncate(S_p, cutoff, maxdim, mindim=1)
+        U_p, S_p, Vh_p = U_p[:, :keep], S_p[:keep], Vh_p[:keep, :]
+        G_left[p] = U_p.conj().T @ X_p
+        G_right[p] = (Y_p @ Vh_p.conj().T) * (1.0 / S_p)[None, :]
+
+    U_list_new = []
+    for p in range(n_uc):
+        arr = np.einsum('ab,bpc,cd->apd', G_left[p], B_list[p].array,
+                         G_right[(p + 1) % n_uc])
+        left = Index(arr.shape[0], tags="Link")
+        right = Index(arr.shape[2], tags="Link")
+        phys = next(ind for ind in B_list[p].inds if ind.hastags("Site"))
+        U_list_new.append(ITensor((left, phys, right), arr))
+
+    for p in range(n_uc):
+        arr = U_list_new[p].array
+        gram = np.einsum('apc,apd->cd', arr.conj(), arr)
+        ident = np.eye(gram.shape[0])
+        # 1e-4, not machine precision: X_p/Y_p's own conditioning degrades
+        # with how far the *raw* grown bond dimension (chi_A*chi_W, before
+        # any truncation) exceeds the state's real entanglement at that
+        # cut -- confirmed directly on a deliberately extreme stress case
+        # (an already near-maxdim-saturated 16-dim bond grown by a
+        # bond-4 gate with maxdim=None, so almost nothing is discarded):
+        # a genuine, essentially unavoidable ~1e-10 condition number left
+        # a ~1e-5 to 1e-3 residual depending on cutoff/maxdim, even though
+        # the exact same construction reproduces Identity to ~1e-13 on
+        # every less pathological case tried (n_uc in (1,2), identity and
+        # unitary chi_W=1 MPOs, and this same gate at a smaller starting
+        # bond dimension). 1e-4 is loose enough to absorb that, while
+        # still being orders of magnitude below every *actual* bug this
+        # check caught during development (deviations of 1, 50-1000s, or
+        # more -- see this function's own docstring history).
+        if not np.allclose(gram, ident, atol=1e-4):
+            raise RuntimeError(
+                "idmrg apply_mpo: canonicalization produced a non-left-"
+                "canonical tensor at sublattice {} (max deviation from "
+                "Identity: {}) -- indicates a bug in the gauge-fixing "
+                "construction, not a benign numerical issue".format(
+                    p, np.max(np.abs(gram - ident))))
+
+    return U_list_new, eta_R
+
+
+class PeriodicMPS:
+    """A periodic iMPS with no ground-state-specific bookkeeping -- same
+    shape as IDMRGResult (sites_uc, n_uc, U_list) minus e0/converged/
+    niter_done, which have no meaning for apply_mpo's output.
+    onsite_expectation/two_point_correlator only ever read
+    .sites_uc/.n_uc/.U_list off their `result` argument, so they accept a
+    PeriodicMPS directly, no changes needed there. `eta` is apply_mpo's own
+    diagnostic (see `_canonicalize_periodic`'s docstring)."""
+
+    def __init__(self, sites_uc, n_uc, U_list, eta):
+        self.sites_uc = sites_uc
+        self.n_uc = n_uc
+        self.U_list = U_list
+        self.eta = eta
+
+
+def apply_mpo(result, W_bulk, cutoff=1e-12, maxdim=None):
+    """Apply a periodic MPO to the converged iMPS `result` (an IDMRGResult
+    or PeriodicMPS), returning a new PeriodicMPS representing W|psi> up to
+    (cutoff, maxdim) truncation -- the infinite-chain analogue of
+    `mpsalgebra.applyMPO`. See this module's "Applying a (bounded) MPO to
+    the converged iMPS" section docstring above for the *scope*
+    restriction on W_bulk (bounded/local periodic operators only -- not
+    the Hamiltonian's own unbounded automaton) and the algorithm
+    (`grow_by_mpo` + `_canonicalize_periodic`)."""
+    B = grow_by_mpo(W_bulk, result.U_list, result.n_uc)
+    B = [_t_noPrime(b, "Site") for b in B]
+    U_list_new, eta = _canonicalize_periodic(B, result.n_uc, cutoff, maxdim)
+    return PeriodicMPS(result.sites_uc, result.n_uc, U_list_new, eta)

--- a/src/dmrgpy/pyitensor/idmrg.py
+++ b/src/dmrgpy/pyitensor/idmrg.py
@@ -268,9 +268,19 @@ def _onsite_matrix(onsite_by_p, p, d):
     None if there is none (kept separate from np.zeros so callers can
     tell "no onsite term here" from "an onsite term that happens to be
     the zero matrix", and so the "F->F" self-loop's mandatory Id doesn't
-    need a redundant +0)."""
+    need a redundant +0).
+
+    `onsite_by_p[p]` holds (coef, mat) pairs -- `rel_site` (`_classify_terms`'
+    own 3rd list entry) is already consumed as this dict's own key by
+    `_build_periodic_mpo`, not carried into each stored tuple. A previous
+    version of this loop unpacked 3 values here (`for _rel, coef, m in ...`)
+    -- a leftover from `_classify_terms`' own (rel_site, coef, mat) shape
+    that was never updated to match -- which raised `ValueError: not enough
+    values to unpack` for *any* Hamiltonian containing an onsite term (bond-
+    only Hamiltonians never populate onsite_by_p, so every existing test
+    happened to avoid this path); confirmed directly and fixed here."""
     mat = None
-    for _rel, coef, m in onsite_by_p.get(p, []):
+    for coef, m in onsite_by_p.get(p, []):
         mat = coef * m if mat is None else mat + coef * m
     return mat
 
@@ -299,10 +309,63 @@ def _build_periodic_mpo(h_intra_op, h_inter_op, sites_uc, n_uc):
     - "S" (index 0): self-loops via Id, and is the *only* channel a new
       2-site term may start from. Nothing ever transitions into S from
       anywhere else, so it always carries pure, unweighted Id content --
-      never contaminated by whatever has already been accumulated.
-    - "F" (index 1, the accumulator): self-loops via Id (picking up any
-      onsite term along the way), and receives completed pending
-      channels. Deliberately *cannot* start a new term itself.
+      never contaminated by whatever has already been accumulated. Also
+      the *only* channel a site's own onsite term may start from, via a
+      direct S->F transition (see the "S,F" case below) -- an onsite term
+      is, in automaton terms, a "bond" that starts and completes on the
+      very same site.
+    - "F" (index 1, the accumulator): self-loops via plain Id (nothing
+      added -- see below for why), and receives completed pending
+      channels *and* direct onsite completions from S. Deliberately
+      *cannot* start a new term itself.
+
+    A site's own onsite term must live on the direct "S,F" transition, NOT
+    added onto "F,F"'s own self-loop (an earlier, wrong version of this
+    function did exactly that -- `mat = Id; if onsite_mat is not None: mat
+    += onsite_mat` on the F,F entry). Two independent things go wrong with
+    putting it there instead of on S,F:
+
+    1. No branch below ever actually sets the "S,F" entry (every existing
+       branch requires `rch`/`lch` to be a pending-channel tuple, never
+       bare "S" or "F"), so with F,F holding the onsite content, W stays
+       *block-diagonal* between {S} and {F,pending...} for any Hamiltonian
+       with no bond terms at all (confirmed directly: S,F and F,S both
+       stay exactly 0 in that case) -- and a matrix power/product of a
+       block-diagonal matrix stays block-diagonal forever, so <S|W^N|F>
+       (exactly what the growing algorithm's boundary projections extract,
+       see `_project_channel`) is identically 0 for every N, silently
+       dropping every onsite term entirely. Confirmed directly: a bare
+       field Hamiltonian (`-B*SzC[0]`, n_uc=1, no bond term) converged to
+       energy density 0 and <Sz>~0 regardless of B, instead of the exact
+       B/2 (fully polarized, since a field-only Hamiltonian is exactly
+       solvable).
+    2. Once at least one bond term *does* eventually activate F (a
+       completed pending channel), every *further* site absorbed while F
+       is already hot picks up "Id+onsite_mat" again on top of whatever HL
+       already represents -- but HL's own recursive `_extend_HL` already
+       carries the *entire* accumulated-so-far MPO-chain product as a live
+       tensor leg (not a collapsed scalar), so this re-adds that site's
+       onsite content into an already-summed F channel instead of summing
+       it in exactly once via its own site's S->F transition -- an
+       exponential (multiplicative-in-effect) blow-up, not a linear
+       (additive) one. Confirmed directly: an n_uc=2 XXZ chain with a
+       small field (`-0.1*(SzC[0]+SzC[1])` added to an otherwise-normal
+       bond Hamiltonian) reported energy densities of -1.3e7, then -1.4e23
+       at B=0.3, -3.6e37 at B=0.5, -1.3e69 at B=1.0 -- diverging, not
+       converging, with `.converged` staying False throughout -- instead
+       of a finite, B-dependent shift of the B=0 energy density. The fix
+       (S,F direct transition carrying onsite_mat, plain Id with no
+       addition on F,F) is exactly the standard textbook automaton-MPO
+       construction for summing an onsite term into a running total (the
+       same upper-triangular-in-channel-index structure any finite-range
+       Hamiltonian MPO derivation uses, e.g. the familiar bond-dimension-5
+       NN Heisenberg-plus-field MPO's own field entry) -- verified by hand
+       for the matrix-product identity this construction relies on
+       (an upper-triangular [[Id,h],[0,Id]]-per-site chain product's own
+       top-right entry sums exactly sum_i h_i, by induction on chain
+       length) and confirmed numerically: the same field test above now
+       reproduces the field=0 energy density plus the expected
+       field-induced shift, converging cleanly for every B tried.
 
     Two earlier, both wrong, designs were tried and are worth recording
     here since the failure modes were not obvious in advance:
@@ -384,8 +447,13 @@ def _build_periodic_mpo(h_intra_op, h_inter_op, sites_uc, n_uc):
                     mat = np.eye(d, dtype=complex)
                 elif lch == F and rch == F:
                     mat = np.eye(d, dtype=complex)
+                elif lch == S and rch == F:
+                    # this site's own onsite term: starts and completes in
+                    # one step, direct from S into the accumulator (see
+                    # this function's own docstring for why this, not
+                    # adding onsite_mat onto the F,F self-loop, is correct).
                     if onsite_mat is not None:
-                        mat = mat + onsite_mat
+                        mat = onsite_mat
                 elif lch == S and rch not in (S, F):
                     # a new pending channel starts here -- from S only
                     # (never from F, see this function's own docstring)
@@ -754,17 +822,30 @@ def _to_array_lpr(U):
     return U.array.reshape((1,) + U.array.shape)
 
 
-def _transfer_matrices(U_list, n_uc):
-    """[E_p] for p=0..n_uc-1, each a (chi_l,chi_l,chi_r,chi_r) array: the
-    doubled ket-times-conj(ket) transfer tensor for the (left-canonical, or
-    -- for apply_mpo's use -- raw not-yet-canonical) tensor at sublattice p.
-    Takes a plain tensor list rather than an IDMRGResult so apply_mpo's own
-    canonicalization can reuse it on its own intermediate (not-yet-converged
-    IDMRGResult) tensors too."""
+def _transfer_matrices(U_list, n_uc, bra_list=None):
+    """[E_p] for p=0..n_uc-1, each a (chi_l,chi_l,chi_r,chi_r) array (or
+    (chi_l_ket,chi_l_bra,chi_r_ket,chi_r_bra) when `bra_list` differs from
+    `U_list` -- see below): the doubled ket-times-conj(bra) transfer tensor
+    for the tensor at sublattice p. Takes a plain tensor list rather than an
+    IDMRGResult so apply_mpo's own canonicalization can reuse it on its own
+    intermediate (not-yet-converged IDMRGResult) tensors too.
+
+    `bra_list=None` (the default, used by every caller except
+    `imps_overlap`) means the ordinary *self*-overlap transfer tensor,
+    ket-times-conj(same tensor) -- what onsite_expectation/
+    two_point_correlator/_canonicalize_periodic all need. Passing a
+    *different* periodic tensor list computes the *mixed* transfer tensor
+    between two distinct states instead -- what `imps_overlap` needs to
+    compute <bra|ket> between two independently converged iMPS, which may
+    not even share a bond dimension (hence the four-way (l_ket,l_bra,r_ket,
+    r_bra) shape above, only square in the self-overlap case)."""
+    if bra_list is None:
+        bra_list = U_list
     Es = []
     for p in range(n_uc):
         A = _to_array_lpr(U_list[p])
-        Es.append(np.einsum('lpr,LpR->lLrR', A, np.conj(A)))
+        Bc = _to_array_lpr(bra_list[p])
+        Es.append(np.einsum('lpr,LpR->lLrR', A, np.conj(Bc)))
     return Es
 
 
@@ -881,6 +962,97 @@ def two_point_correlator(result, opname_i, p_i, opname_j, r):
         result.sites_uc, result.U_list, p_j, opname_j))
     val = _apply_transfer(running, rho_after[p_j])
     return complex(np.trace(val))
+
+
+def _dominant_eigenvalue_mixed(Es):
+    """Dominant eigenvalue of the full unit-cell *mixed* transfer matrix
+    T=E_0...E_{n_uc-1}, generalizing `_dominant_right_fixed_point`'s own
+    eigen-solve to the case where the ket and bra tensor lists don't share
+    a single common bond dimension -- exactly the case `imps_overlap` needs
+    (the two states being overlapped may have been converged/truncated to
+    different maxm). Unlike `_dominant_right_fixed_point`, this does not
+    require T4's four legs to all share one size, only that the *ket*'s own
+    wraparound bond (legs 0 and 2) and the *bra*'s own wraparound bond (legs
+    1 and 3) are each individually self-consistent -- the two need not
+    match each other. Returns only the eigenvalue: `imps_overlap` has no
+    use for the fixed-point vector itself, unlike the correlator machinery
+    that consumes `_dominant_right_fixed_point`'s own rho."""
+    T4 = Es[0]
+    for E in Es[1:]:
+        T4 = _compose(T4, E)
+    chi_ket, chi_bra = T4.shape[0], T4.shape[1]
+    if T4.shape != (chi_ket, chi_bra, chi_ket, chi_bra):
+        raise RuntimeError(
+            "idmrg imps_overlap: a state's own wraparound bond dimension "
+            "is inconsistent (mixed transfer tensor shape {}) -- same "
+            "failure mode _dominant_right_fixed_point already guards "
+            "against for a single state, see its own comment".format(T4.shape))
+    Tmat = T4.reshape(chi_ket * chi_bra, chi_ket * chi_bra)
+    w = np.linalg.eigvals(Tmat)
+    return w[np.argmax(np.abs(w))]
+
+
+def imps_overlap(result_a, result_b, normalize=True):
+    """Per-unit-cell overlap <result_b|result_a> between two converged
+    infinite MPS (`result_a`/`result_b`: IDMRGResult and/or PeriodicMPS, any
+    combination -- both are accepted anywhere that only reads
+    .sites_uc/.n_uc/.U_list, matching onsite_expectation/
+    two_point_correlator's own duck typing).
+
+    A literal <psi_b|psi_a> over an infinite chain is not, in general, a
+    finite number: it factorizes into one power of the dominant *mixed*
+    transfer-matrix eigenvalue eta_ab (see `_dominant_eigenvalue_mixed`)
+    per unit cell, so <psi_b|psi_a> ~ eta_ab^N is 0 or infinite as N (the
+    number of unit cells) -> infinity, unless |eta_ab|==1 exactly. The
+    physically meaningful, always-finite quantity is instead the *per-site
+    fidelity*
+
+        eta_ab / sqrt(eta_aa * eta_bb)
+
+    where eta_aa/eta_bb are `result_a`/`result_b`'s own self-overlap
+    eigenvalues (exactly 1 for a properly left-canonical U_list -- which is
+    what both idmrg_ground_state and apply_mpo always return -- but
+    computed here rather than assumed, so this also works on a hand-built
+    or un-normalized PeriodicMPS). This per-site fidelity has magnitude 1
+    iff `result_a` and `result_b` represent the same physical state (any
+    gauge, any normalization convention on the raw tensors), and magnitude
+    < 1 otherwise -- a transfer-matrix Cauchy-Schwarz bound that holds
+    because every U_list tensor produced by this module is isometric/
+    left-canonical. This is the standard iMPS notion of state overlap
+    (e.g. used for fidelity susceptibility across a phase transition, or to
+    check that `apply_mpo` with an identity-equivalent operator reproduced
+    the original state up to gauge -- see test_imps_overlap_* in
+    tests/test_infinite_chain.py). Pass normalize=False for the raw,
+    un-normalized eta_ab instead -- mainly a diagnostic, analogous to
+    apply_mpo's own returned `eta` (which is exactly this function's
+    would-be eta_aa, applied to apply_mpo's output against itself).
+
+    Requires both states to share the same n_uc and, at every sublattice
+    position, the same local physical dimension (same Hilbert space) --
+    raises ValueError otherwise. Bond dimensions need not match between the
+    two states (this is exactly why the mixed-transfer eigen-solve below
+    uses `_dominant_eigenvalue_mixed`, not `_dominant_right_fixed_point`,
+    which assumes a single self-consistent chi)."""
+    n_uc = result_a.n_uc
+    if result_b.n_uc != n_uc:
+        raise ValueError(
+            "imps_overlap: unit-cell size mismatch (result_a.n_uc={}, "
+            "result_b.n_uc={})".format(n_uc, result_b.n_uc))
+    dims_a = [_to_array_lpr(result_a.U_list[p]).shape[1] for p in range(n_uc)]
+    dims_b = [_to_array_lpr(result_b.U_list[p]).shape[1] for p in range(n_uc)]
+    if dims_a != dims_b:
+        raise ValueError(
+            "imps_overlap: physical dimension mismatch per sublattice "
+            "(result_a={}, result_b={})".format(dims_a, dims_b))
+
+    Es_ab = _transfer_matrices(result_a.U_list, n_uc, bra_list=result_b.U_list)
+    eta_ab = _dominant_eigenvalue_mixed(Es_ab)
+    if not normalize:
+        return complex(eta_ab)
+
+    _, eta_aa = _dominant_right_fixed_point(_transfer_matrices(result_a.U_list, n_uc))
+    _, eta_bb = _dominant_right_fixed_point(_transfer_matrices(result_b.U_list, n_uc))
+    return complex(eta_ab) / np.sqrt(complex(eta_aa) * complex(eta_bb))
 
 
 # == Applying a (bounded) MPO to the converged iMPS ================

--- a/tests/test_infinite_chain.py
+++ b/tests/test_infinite_chain.py
@@ -25,6 +25,9 @@ import pytest
 from dmrgpy import cppext
 from dmrgpy import infinitechain
 from dmrgpy import spinchain
+from dmrgpy.pyitensor import idmrg
+from dmrgpy.pyitensor.index import Index
+from dmrgpy.pyitensor.tensor import ITensor
 
 EXACT_HEISENBERG_DENSITY = 0.25 - np.log(2)
 
@@ -251,3 +254,145 @@ def test_l_and_r_in_same_term_rejected():
     ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
     with pytest.raises(ValueError):
         ic.set_hamiltonian(ic.SxL[0] * ic.SxR[0])
+
+
+# -- idmrg.apply_mpo: applying a periodic (bounded) MPO to the converged
+# iMPS -- see idmrg.py's own "Applying a (bounded) MPO to the converged
+# iMPS" section docstring for the algorithm and its scope restriction
+# (bounded/local operators only, not idmrg.py's own extensive Hamiltonian
+# automaton). These go through pyitensor.idmrg directly (not
+# infinitechain.py, which has no public wrapper for this yet) --
+# tests/test_metts_vev.py and others already establish that reaching into
+# dmrgpy.pyitensor submodules directly from a test is a normal pattern
+# here, not a workaround.
+
+def _identity_mpo(sites_uc, n_uc):
+    """chi_W=1 automaton: Id at every site, sharing sites_uc's own physical
+    Indices (required, see grow_by_mpo's docstring)."""
+    W = []
+    for p in range(n_uc):
+        d = sites_uc.dim(p + 1)
+        s = sites_uc.si(p + 1)
+        link_l = Index(1, tags="Link")
+        link_r = Index(1, tags="Link")
+        arr = np.eye(d, dtype=complex).reshape(1, d, d, 1)
+        W.append(ITensor((link_l, s, s.prime(1), link_r), arr))
+    # wraparound: every site's own fresh links are fine independently
+    # (chi_W=1 throughout, so there is nothing to actually connect).
+    return W
+
+
+def _single_site_operator_mpo(sites_uc, n_uc, opname, p_active):
+    """chi_W=1 automaton: `opname`'s matrix at sublattice p_active, Id
+    everywhere else -- the simplest genuinely non-trivial bounded MPO."""
+    W = []
+    for p in range(n_uc):
+        d = sites_uc.dim(p + 1)
+        s = sites_uc.si(p + 1)
+        mat = sites_uc.site_type(p + 1).matrix(opname) if p == p_active else np.eye(d, dtype=complex)
+        link_l = Index(1, tags="Link")
+        link_r = Index(1, tags="Link")
+        W.append(ITensor((link_l, s, s.prime(1), link_r), mat.reshape(1, d, d, 1)))
+    return W
+
+
+@pytest.mark.parametrize("n_uc", [1, 2])
+def test_apply_mpo_identity_is_noop(n_uc):
+    """Applying the identity MPO must reproduce every existing observable
+    to numerical precision -- isolates the canonicalization machinery
+    (grow_by_mpo + _canonicalize_periodic) from any MPO-construction
+    question, since chi_W=1 Id trivially can't grow the bond dimension."""
+    ic, _ = _converged_uniform_chain(n_uc, maxm=20)
+    W = _identity_mpo(ic._result.sites_uc, n_uc)
+    new_result = idmrg.apply_mpo(ic._result, W, cutoff=1e-12, maxdim=None)
+    assert new_result.eta == pytest.approx(1.0, abs=1e-8)
+    for p in range(n_uc):
+        orig = idmrg.onsite_expectation(ic._result, "Sz", p)
+        new = idmrg.onsite_expectation(new_result, "Sz", p)
+        assert new == pytest.approx(orig, abs=1e-8)
+        for r in range(3):
+            orig_c = idmrg.two_point_correlator(ic._result, "Sz", p, "Sz", r)
+            new_c = idmrg.two_point_correlator(new_result, "Sz", p, "Sz", r)
+            assert new_c == pytest.approx(orig_c, abs=1e-8)
+
+
+def test_apply_mpo_pauli_x_flips_sz():
+    """Pauli-X (2*Sx for spin-1/2) at every site is unitary and chi_W=1 --
+    applying it must flip <Sz> -> -<Sz> exactly and leave <Sz(0)Sz(r)>
+    unchanged exactly (two flipped operators multiply back to the
+    original sign), a strong, closed-form check unrelated to any
+    numerical oracle."""
+    ic, _ = _converged_uniform_chain(1, maxm=20)
+    sites_uc = ic._result.sites_uc
+    d = sites_uc.dim(1)
+    pauli_x = 2 * sites_uc.site_type(1).matrix("Sx")
+    assert np.allclose(pauli_x @ pauli_x.conj().T, np.eye(d), atol=1e-10)
+    link_l, link_r = Index(1, tags="Link"), Index(1, tags="Link")
+    s = sites_uc.si(1)
+    W = [ITensor((link_l, s, s.prime(1), link_r), pauli_x.reshape(1, d, d, 1))]
+
+    new_result = idmrg.apply_mpo(ic._result, W, cutoff=1e-12, maxdim=None)
+    assert new_result.eta == pytest.approx(1.0, abs=1e-8)
+
+    orig_sz = idmrg.onsite_expectation(ic._result, "Sz", 0)
+    new_sz = idmrg.onsite_expectation(new_result, "Sz", 0)
+    assert new_sz == pytest.approx(-orig_sz, abs=1e-8)
+    for r in range(1, 3):
+        orig_c = idmrg.two_point_correlator(ic._result, "Sz", 0, "Sz", r)
+        new_c = idmrg.two_point_correlator(new_result, "Sz", 0, "Sz", r)
+        assert new_c == pytest.approx(orig_c, abs=1e-8)
+
+
+def test_apply_mpo_two_site_gate_preserves_norm():
+    """A genuinely bond-dimension>1 local gate (an SVD-split 2-site
+    unitary rotation, tiled once per unit cell on the intra-cell bond
+    only -- identity on the inter-cell bond, so this is a bounded/local
+    operator, not idmrg.py's own extensive Hamiltonian automaton) --
+    exercises the actual bond-growth path (grow_by_mpo produces a raw,
+    non-canonical bond) unlike the chi_W=1 tests above, which barely
+    touch _canonicalize_periodic's fixed-point machinery. Being unitary,
+    it must preserve the norm (apply_mpo's own `eta` diagnostic ~1);
+    _canonicalize_periodic's internal left-canonicality check (raises
+    RuntimeError if it fails) is the other half of this test, implicitly
+    exercised by apply_mpo not raising."""
+    from scipy.linalg import expm
+
+    n_uc = 2
+    ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+    h = (ic.SxC[0] * ic.SxC[1] + ic.SyC[0] * ic.SyC[1] + ic.SzC[0] * ic.SzC[1]
+         + 0.4 * (ic.SxC[1] * ic.SxR[0] + ic.SyC[1] * ic.SyR[0] + ic.SzC[1] * ic.SzR[0]))
+    ic.maxm = 4
+    ic.maxiter = 100
+    ic.etol = 1e-12
+    ic.set_hamiltonian(h)
+    ic.gs_energy()
+
+    sites_uc = ic._result.sites_uc
+    d = sites_uc.dim(1)
+    Sx = sites_uc.site_type(1).matrix("Sx")
+    Sy = sites_uc.site_type(1).matrix("Sy")
+    Sz = sites_uc.site_type(1).matrix("Sz")
+    H2 = (np.kron(Sx, Sx) + np.kron(Sy, Sy) + np.kron(Sz, Sz)).real
+    gate = expm(-1j * 0.37 * H2)  # d^2 x d^2 unitary 2-site rotation
+    gate4 = np.transpose(gate.reshape(d, d, d, d), (2, 0, 3, 1))  # (s0,s0',s1,s1')
+    U, S, Vh = np.linalg.svd(gate4.reshape(d * d, d * d), full_matrices=False)
+    keep = int(np.sum(S > 1e-12))
+    U, S, Vh = U[:, :keep], S[:keep], Vh[:keep, :]
+    a_half = (U * S[None, :] ** 0.5).reshape(d, d, keep)
+    b_half = (S[:, None] ** 0.5 * Vh).reshape(keep, d, d)
+
+    s0, s1 = sites_uc.si(1), sites_uc.si(2)
+    left_dummy, mid, right_dummy = (Index(1, tags="Link"), Index(keep, tags="Link"),
+                                     Index(1, tags="Link"))
+    W0 = ITensor((left_dummy, s0, s0.prime(1), mid), a_half.reshape(1, d, d, keep))
+    W1 = ITensor((mid, s1, s1.prime(1), right_dummy), b_half.reshape(keep, d, d, 1))
+
+    new_result = idmrg.apply_mpo(ic._result, [W0, W1], cutoff=1e-10, maxdim=None)
+    assert new_result.eta == pytest.approx(1.0, abs=1e-6)
+
+
+def test_grow_by_mpo_rejects_mismatched_length():
+    ic, _ = _converged_uniform_chain(2, maxm=8)
+    W = _identity_mpo(ic._result.sites_uc, 2)
+    with pytest.raises(ValueError):
+        idmrg.grow_by_mpo(W[:1], ic._result.U_list, 2)

--- a/tests/test_infinite_chain.py
+++ b/tests/test_infinite_chain.py
@@ -396,3 +396,141 @@ def test_grow_by_mpo_rejects_mismatched_length():
     W = _identity_mpo(ic._result.sites_uc, 2)
     with pytest.raises(ValueError):
         idmrg.grow_by_mpo(W[:1], ic._result.U_list, 2)
+
+
+# -- idmrg.imps_overlap: per-site overlap/fidelity between two converged
+# infinite MPS -- see idmrg.py's own docstring for the mixed-transfer-matrix
+# construction and the physical meaning of the normalized (per-site
+# fidelity) vs raw (normalize=False) return value.
+
+@pytest.mark.parametrize("n_uc", [1, 2])
+def test_imps_overlap_self_is_one(n_uc):
+    """<psi|psi> per site must be exactly 1 (up to numerical precision),
+    both normalized (the default) and raw (normalize=False, since a
+    converged IDMRGResult.U_list is already left-canonical, so its own
+    self-overlap transfer eigenvalue is already 1 without needing the
+    normalization division)."""
+    ic, _ = _converged_uniform_chain(n_uc, maxm=20)
+    ov = idmrg.imps_overlap(ic._result, ic._result)
+    assert ov == pytest.approx(1.0, abs=1e-8)
+    ov_raw = idmrg.imps_overlap(ic._result, ic._result, normalize=False)
+    assert ov_raw == pytest.approx(1.0, abs=1e-8)
+
+
+@pytest.mark.parametrize("n_uc", [1, 2])
+def test_imps_overlap_identity_mpo_preserves_state(n_uc):
+    """Applying the identity MPO must reproduce the same physical state up
+    to gauge -- |imps_overlap| between the original and the identity-MPO'd
+    copy must be exactly 1, a gauge-independent cross-check complementing
+    test_apply_mpo_identity_is_noop's own per-observable comparison."""
+    ic, _ = _converged_uniform_chain(n_uc, maxm=20)
+    W = _identity_mpo(ic._result.sites_uc, n_uc)
+    new_result = idmrg.apply_mpo(ic._result, W, cutoff=1e-12, maxdim=None)
+    ov = idmrg.imps_overlap(ic._result, new_result)
+    assert abs(ov) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_imps_overlap_orthogonal_polarized_states_near_zero():
+    """Two independently-converged n_uc=1 chains with a strong onsite field
+    pinned to opposite Sz polarization converge to (near-exact) product
+    states |up> and |down>, which are exactly orthogonal -- |imps_overlap|
+    must be ~0, regardless of the fact that the two chains were never
+    built or grown together. This exercises the same onsite-field
+    machinery whose real bug (see _build_periodic_mpo's own docstring) was
+    found and fixed while writing this test."""
+    ic_up = infinitechain.Infinite_Spin_Chain(["1/2"])
+    ic_up.maxm, ic_up.maxiter, ic_up.etol = 4, 50, 1e-12
+    ic_up.set_hamiltonian(-10.0 * ic_up.SzC[0])
+    ic_up.gs_energy()
+
+    ic_down = infinitechain.Infinite_Spin_Chain(["1/2"])
+    ic_down.maxm, ic_down.maxiter, ic_down.etol = 4, 50, 1e-12
+    ic_down.set_hamiltonian(10.0 * ic_down.SzC[0])
+    ic_down.gs_energy()
+
+    ov = idmrg.imps_overlap(ic_up._result, ic_down._result)
+    assert abs(ov) == pytest.approx(0.0, abs=1e-8)
+
+
+def test_imps_overlap_rejects_n_uc_mismatch():
+    ic1, _ = _converged_uniform_chain(1, maxm=8)
+    ic2, _ = _converged_uniform_chain(2, maxm=8)
+    with pytest.raises(ValueError):
+        idmrg.imps_overlap(ic1._result, ic2._result)
+
+
+def test_imps_overlap_rejects_dimension_mismatch():
+    """Different local Hilbert-space dimensions per sublattice (spin-1/2
+    vs spin-1) is a meaningless overlap -- must raise, not silently
+    contract mismatched-size physical legs."""
+    ic_half = infinitechain.Infinite_Spin_Chain(["1/2"])
+    ic_half.maxm, ic_half.maxiter, ic_half.etol = 4, 20, 1e-8
+    ic_half.set_hamiltonian(ic_half.SxC[0] * ic_half.SxR[0]
+                             + ic_half.SyC[0] * ic_half.SyR[0]
+                             + ic_half.SzC[0] * ic_half.SzR[0])
+    ic_half.gs_energy()
+
+    ic_one = infinitechain.Infinite_Spin_Chain(["1"])
+    ic_one.maxm, ic_one.maxiter, ic_one.etol = 4, 20, 1e-8
+    ic_one.set_hamiltonian(ic_one.SxC[0] * ic_one.SxR[0]
+                            + ic_one.SyC[0] * ic_one.SyR[0]
+                            + ic_one.SzC[0] * ic_one.SzR[0])
+    ic_one.gs_energy()
+
+    with pytest.raises(ValueError):
+        idmrg.imps_overlap(ic_half._result, ic_one._result)
+
+
+# -- Regression tests for a real bug found while writing the imps_overlap
+# tests above: _build_periodic_mpo wired a Hamiltonian's onsite terms onto
+# the automaton's F,F self-loop instead of a direct S,F transition -- see
+# that function's own docstring for the full derivation. This silently
+# dropped onsite terms entirely for any bond-less Hamiltonian, and caused
+# an exponential energy blow-up once at least one bond term was also
+# present (both confirmed directly before the fix).
+
+def test_onsite_field_matches_exact_solution():
+    """A pure onsite (Zeeman-field) Hamiltonian with no bond term at all is
+    exactly solvable (a decoupled product state at every site): the ground
+    state aligns <Sz> with sign(B) (to minimize H=-B*Sz), so e0 must be
+    -|B|/2 and <Sz> must be sign(B)*0.5 exactly, for either field
+    direction. Before the fix, e0 stayed exactly 0 and <Sz> ~ 0 for every
+    field strength tried, since W stayed block-diagonal between S and F
+    with no bond term ever able to activate F -- confirmed directly."""
+    for B in (5.0, -5.0, 2.0):
+        ic = infinitechain.Infinite_Spin_Chain(["1/2"])
+        ic.maxm, ic.maxiter, ic.etol = 4, 50, 1e-12
+        ic.set_hamiltonian(-B * ic.SzC[0])
+        e0 = ic.gs_energy()
+        assert e0 == pytest.approx(-abs(B) / 2, abs=1e-6)
+        sz = ic.vev("Sz", 0)
+        assert sz.real == pytest.approx(0.5 if B > 0 else -0.5, abs=1e-6)
+
+
+def test_onsite_field_with_bonds_does_not_diverge():
+    """A small field added to an otherwise-normal (bond-coupled,
+    dimerized) n_uc=2 chain must converge to a finite energy density --
+    before the fix, once the bond term activated the automaton's F
+    channel, every further absorbed site re-added the field content on top
+    of the already-accumulated total (multiplicative, not additive):
+    confirmed directly, energy density reached -1e23 at B=0.3 and -1e69 at
+    B=1.0, with `.converged` staying False throughout. This dimerized
+    model is gapped, so a field well below its gap should leave the energy
+    density unchanged from B=0 (confirmed reproducible to ~1e-13 run over
+    run at this exact configuration) -- a much stronger check than merely
+    "finite"."""
+    def density_at(B):
+        ic = infinitechain.Infinite_Spin_Chain(["1/2", "1/2"])
+        h = (ic.SxC[0] * ic.SxC[1] + ic.SyC[0] * ic.SyC[1] + ic.SzC[0] * ic.SzC[1]
+             + 0.5 * (ic.SxC[1] * ic.SxR[0] + ic.SyC[1] * ic.SyR[0] + ic.SzC[1] * ic.SzR[0])
+             - B * (ic.SzC[0] + ic.SzC[1]))
+        ic.maxm, ic.maxiter, ic.etol = 20, 100, 1e-11
+        ic.set_hamiltonian(h)
+        e0 = ic.gs_energy()
+        assert ic.converged
+        return e0
+
+    d0 = density_at(0.0)
+    d1 = density_at(0.2)
+    assert np.isfinite(d1) and abs(d1) < 10  # rules out the 1e23-scale blow-up
+    assert d1 == pytest.approx(d0, abs=1e-6)


### PR DESCRIPTION
## Summary
- Adds `pyitensor.idmrg.apply_mpo(result, W_bulk, cutoff, maxdim)`, the infinite-chain analogue of `mpsalgebra.applyMPO`: `grow_by_mpo` contracts a periodic MPO onto every site of the converged unit cell (Kronecker-merging bonds at each cut, including the wraparound), then `_canonicalize_periodic` re-canonicalizes/truncates the grown bond dimension back down via the standard two-sided fixed-point infinite-MPS canonicalization procedure (Orús & Vidal, PRB 78, 155117 (2008)), returning a new `PeriodicMPS` that `onsite_expectation`/`two_point_correlator` accept directly.
- **Scope restriction, documented at length**: `W_bulk` must be a *bounded* (non-extensive) periodic operator — `idmrg.py`'s own Hamiltonian automaton (built by the now-split-out `_build_periodic_mpo`) has an unconditional accumulator self-loop that needs a genuine chain boundary to mean "sum", not "product", so it is explicitly not a valid `apply_mpo` input. This makes `apply_mpo` the natural primitive a future iTEBD-style real/imaginary-time evolution feature would build on (not implemented here).
- Adds `pyitensor.idmrg.imps_overlap(result_a, result_b, normalize=True)`: the thermodynamic-limit analogue of a finite MPS inner product. Since a literal `<phi|psi>` over an infinite chain scales as `eta**N` over `N` unit cells (not finite unless `|eta|==1` exactly), the default return is the always-finite *per-site fidelity* `eta_ab/sqrt(eta_aa*eta_bb)` — magnitude 1 iff the two states are the same physical state (any gauge/normalization), `<1` otherwise. Handles states with different bond dimensions (a new `_dominant_eigenvalue_mixed`, since the composed mixed transfer tensor need not be square, unlike the existing self-overlap-only `_dominant_right_fixed_point`).
- No public `Infinite_Many_Body_Chain` wrapper yet for either primitive — reached via `pyitensor.idmrg` directly against `ic._result`, matching the existing pattern for other advanced/internal pieces of this module.
- Updated `docs/user_guide.{md,tex}` and `docs/documentation.{md,tex}` (both `.tex` files verified to compile cleanly with `pdflatex`, no errors, no overfull-hbox warnings).
- Added `examples/idmrg/apply_mpo_to_infinite_chain/main.py` and `examples/idmrg/imps_overlap/main.py`.
- New tests in `tests/test_infinite_chain.py`: identity-MPO round-trip (n_uc∈{1,2}), a unitary Pauli-X spin-flip (exact closed-form check), a bond-growing 2-site gate (norm-preservation + internal left-canonicality), a `grow_by_mpo` input-validation check, plus `imps_overlap` self-overlap/gauge-invariance/orthogonal-states/mismatch-validation tests.

## Notes on getting the algebra right (apply_mpo)
Two independent bugs were found and fixed via direct numerical derivation (not just test failures) before the canonicalization was correct for `n_uc=2` and genuine bond growth:
1. `_all_left_fixed_points`' own per-cut renormalization (needed to avoid blow-up across propagation, mirroring the existing right-fixed-point code) was discarding a *relative* scale between cuts that the left-gauge construction depends on (the right-gauge one is provably scale-invariant, so this was invisible for `n_uc=1`) — fixed by returning and re-applying the accumulated per-cut scale factors.
2. A second, independent index-order/transpose mismatch between `_apply_transfer_from_left`'s own (ket,bra) convention and the (bra,ket) convention the gauge-fixing isometry identity needs — found by deriving that identity by hand and checking it numerically term-by-term, since the internal left-canonicality self-check could only confirm *something* was wrong, not localize it.

Both are covered by the regression tests listed above (in particular the identity round-trip at n_uc=2 and the bond-growing gate test).

## A real, pre-existing bug found while testing imps_overlap
Writing a meaningful "orthogonal states" test needed a Hamiltonian with an onsite/field term, which surfaced two bugs in `_build_periodic_mpo`'s onsite-term handling, unrelated to `imps_overlap` itself:
1. `_onsite_matrix` unpacked 3-tuples but `_build_periodic_mpo` stored `(coef, mat)` 2-tuples — a `ValueError` for *any* Hamiltonian with an onsite term (dead code before this, since every existing test used bond-only Hamiltonians).
2. More seriously, onsite content was wired onto the automaton's `F,F` self-loop instead of a direct `S,F` transition — no branch ever populated `S,F`, so (a) a bond-less Hamiltonian silently dropped its field term entirely (energy density stuck at exactly 0, confirmed directly against the exact closed-form solution), and (b) once a bond term activated `F`, every later site re-added the onsite content *multiplicatively* instead of additively — confirmed directly: energy density diverged to `-1e69` by `B=1.0` on an otherwise-normal chain, with `.converged` staying `False` throughout. Fixed by moving the onsite content to the `S,F` transition (the standard textbook automaton-MPO construction), verified against the exact field-only solution and reproducibility (~1e-13) of the bond+field energy density.

## Test plan
- [x] `python run_tests.py` — 233 passed, 9 skipped, 0 failed
- [x] `examples/idmrg/apply_mpo_to_infinite_chain/main.py` and `examples/idmrg/imps_overlap/main.py` run manually — assertions pass
- [x] Pre-existing `examples/idmrg/heisenberg_infinite*/main.py` re-run manually — unaffected by the `_transfer_matrices`/`_build_automaton` signature refactors
- [x] `docs/documentation.tex` and `docs/user_guide.tex` compile cleanly with `pdflatex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t
