### PR TITLE
installtk/addpythonpath: Handle the exception from missing permissions

### DIFF
--- a/installtk/addpythonpath.py
+++ b/installtk/addpythonpath.py
@@ -31,7 +31,7 @@ def addpath():
             if os.path.islink(target) or os.path.exists(target):
                 os.remove(target)
             os.symlink(source, target)
-        except PermissionError:
+        except (PermissionError, OSError):
             print("No permission to write to "+sp+".")
             print("Add this to your PYTHONPATH manually instead:")
             print("  "+mpath+"/../src")


### PR DESCRIPTION
In the addpath-function the exception thrown by os.symlink is OSError. This PR fixes the output for cases where user does not have permissions to write to the environment location (e.g. in common environments in Triton).