### PR TITLE
installtk/addpythonpath: catch OSError with accurate error message

### DIFF
--- a/installtk/addpythonpath.py
+++ b/installtk/addpythonpath.py
@@ -31,8 +31,8 @@ def addpath():
             if os.path.islink(target) or os.path.exists(target):
                 os.remove(target)
             os.symlink(source, target)
-        except PermissionError:
-            print("No permission to write to "+sp+".")
+        except OSError as e:
+            print("Could not link dmrgpy into "+sp+": "+str(e))
             print("Add this to your PYTHONPATH manually instead:")
             print("  "+mpath+"/../src")
             return


### PR DESCRIPTION
## Summary
- Alternative to #93: catches `OSError` (which already subsumes `PermissionError`, making the tuple in #93 redundant) so the symlink fallback also triggers on Triton where `os.symlink` doesn't always raise `PermissionError` specifically.
- Unlike #93, the fallback message now reports the actual exception (`"Could not link dmrgpy into <sp>: <e>"`) instead of unconditionally claiming "No permission to write to...", since `OSError` also covers unrelated causes (read-only filesystem, disk full, path too long, etc.) that the old fixed wording would misdiagnose.

## Test plan
- [x] Monkeypatched `os.symlink` to raise a generic `OSError` (errno 30, read-only filesystem, not a `PermissionError`) and confirmed `addpath()` now catches it and prints the real error message + manual `PYTHONPATH` fallback instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YQV5VGQuA5U8qPy2t737t