### PR TITLE
Cache TagSet("Site") in v3's apply_mpo() to speed up KPM and other MPO-heavy paths

### DIFF
--- a/examples/dynamical_correlator/dynamical_correlator_v2_VS_v3/main.py
+++ b/examples/dynamical_correlator/dynamical_correlator_v2_VS_v3/main.py
@@ -26,13 +26,19 @@ j = np.random.randint(n)
 j = i
 t1 = time.time()
 sc = getsc(2)
-(x2,y2) = sc.get_dynamical_correlator(mode="DMRG",i=i,j=j,name="ZZ")
+name = (sc.Sz[i],sc.Sz[j]) # name= takes a pair of MultiOperators, not a
+                            # bare "ZZ" string -- see kpmdmrg.py's
+                            # get_dynamical_correlator and
+                            # tests/test_dynamical_correlator.py for the
+                            # same convention
+(x2,y2) = sc.get_dynamical_correlator(mode="DMRG",name=name)
 t2 = time.time()
 print("Time with ITensor2",t2-t1)
 
 
 sc = getsc(3)
-(x3,y3) = sc.get_dynamical_correlator(mode="DMRG",i=i,j=j,name="ZZ")
+name = (sc.Sz[i],sc.Sz[j])
+(x3,y3) = sc.get_dynamical_correlator(mode="DMRG",name=name)
 t3 = time.time()
 print("Time with ITensor3",t3-t2)
 

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -2317,19 +2317,31 @@ class Chain
     // this class hands back or feeds into sum()/bicstab() has an unprimed
     // physical index" -- always holds, not just in the call sites that
     // happened to get exercised so far.
+    //
+    // TagSet("Site") re-parses its string argument every call (same cost
+    // already profiled and fixed for TagSet("a") in arnoldi_smallest_real
+    // below -- see that function's own comment); apply_mpo() is the
+    // single most-invoked helper in this file (every MPO application:
+    // KPM's Chebyshev recursion, time evolution, the generalized-
+    // eigenproblem solver, bicstab/CVM, custom_exp/evoloperator, ...), so
+    // a function-local static avoids re-parsing it on every one of those
+    // calls instead of just the iDMRG-specific functions the earlier pass
+    // covered.
     MPS
     apply_mpo(MPO const& K, MPS const& x, Args const& args) const
         {
+        static const TagSet site_tag("Site");
         auto out = applyMPO(K,x,args);
-        out.noPrime(TagSet("Site"));
+        out.noPrime(site_tag);
         return out;
         }
 
     MPS
     apply_mpo(MPO const& K, MPS const& x, MPS const& x0, Args const& args) const
         {
+        static const TagSet site_tag("Site");
         auto out = applyMPO(K,x,x0,args);
-        out.noPrime(TagSet("Site"));
+        out.noPrime(site_tag);
         return out;
         }
 


### PR DESCRIPTION
## Summary
- `mpscpp3/chain_session.h`'s `apply_mpo()` (both overloads) re-parsed `TagSet("Site")` from scratch on every call via `out.noPrime(TagSet("Site"))`. `apply_mpo()` is the single most-invoked MPO-application helper in the file: every Chebyshev moment of KPM's dynamical-correlator recursion (`kpm_moments_full`/`kpm_moments_accelerated`) calls it once or twice, and it also backs time evolution, the generalized-eigenproblem solver, and CVM's `bicstab` solver.
- The exact same class of overhead (`TagSet` construction re-parsing its string argument every call) was already profiled with `valgrind --tool=callgrind` and fixed elsewhere in this file (`arnoldi_smallest_real`, `idmrg_extend_HL`/`idmrg_extend_HR`, PR #87's follow-up) via a function-local `static const TagSet` — but that pass never touched `apply_mpo()` itself. This applies the identical, already-validated pattern there. Zero semantic change (same parsed tag value either way).
- Measured directly on the actual KPM hot loop: ~2-4% faster when bond dimension/moment cost is small enough that `applyMPO`'s own SVD work doesn't dominate the per-call fixed overhead; negligible when it does (unlike the iDMRG Arnoldi case's 6-8%, since that loop spends proportionally more time in cheap per-step ITensor operations relative to the parsing cost). v2 is unaffected — it predates the Tags system.
- Also fixed `examples/dynamical_correlator/dynamical_correlator_v2_VS_v3/main.py`, found broken while benchmarking this change: it used a stale `i=i,j=j,name="ZZ"` shorthand that `get_dynamical_correlator` no longer accepts (`name=` must be a pair of `MultiOperator`s), so it raised `RuntimeError: No active exception to reraise` on both backends. Replaced with `name=(sc.Sz[i],sc.Sz[j])`, the same convention `tests/test_dynamical_correlator.py` already uses.

## Test plan
- [x] `pytest tests/test_dynamical_correlator.py -k "kpm or cvm"` (parametrized over `itensor_version` incl. 3) passes before and after the change
- [x] Full suite: `pytest tests` — 268 passed, 9 skipped, unchanged from baseline
- [x] Benchmarked before/after with a standalone script exercising `get_dynamical_correlator(mode="DMRG", submode="KPM")` at multiple chain sizes/moment counts, built via the fast worktree-local `mpscpp3` rebuild trick (reuse `libitensor.a`, just `make pybind`)
- [x] Fixed example re-run end-to-end against both real compiled backends (mpscpp2 + mpscpp3, not the ED fallback), stable timings across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoZKWzhMo7qKoiP12gbcvv