### PR TITLE
Accelerate ED chain: sparse Kronecker products in one2many()

### DIFF
--- a/src/dmrgpy/edtk/one2many.py
+++ b/src/dmrgpy/edtk/one2many.py
@@ -1,15 +1,22 @@
 import numpy as np
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_matrix, kron as sp_kron
 
 def one2many(ids,op=None,i=-1):
-   """Function to transform to many body basis given identity operators"""
-   tmp = np.zeros((1,1),dtype=np.complex128) # initialize
-   tmp[0,0] = 1.0
+   """Function to transform to many body basis given identity operators.
+
+   Builds the embedding with sparse Kronecker products throughout
+   (instead of dense np.kron followed by a final sparse conversion):
+   the embedded operator is trivially sparse (identity on every site but
+   one), but a dense intermediate scales as O(dim**2) in time and memory
+   and dominates ED chain construction well before the dim>2000 point
+   where the eigensolver itself switches to ARPACK -- confirmed ~2000x
+   faster at ns=14 (dim=16384), with the dense path needing tens of GB
+   at ns=16 for a single intermediate matrix.
+   """
+   tmp = csc_matrix(np.array([[1.0]],dtype=np.complex128)) # initialize
    for j in range(len(ids)): # loop over sites
-       if i!=j: op2 = ids[j] # identity
-       else: op2 = op # operator
-       tmp = np.kron(tmp,op2) # tensor product
-   tmp = csc_matrix(tmp) # return operator
+       op2 = ids[j] if i!=j else op # identity or operator
+       tmp = sp_kron(tmp,csc_matrix(op2,dtype=np.complex128),format="csc")
    tmp.eliminate_zeros()
    return tmp
 


### PR DESCRIPTION
## Summary
- `edtk/one2many.py` (the operator-embedding primitive shared by `BosonChain`, `Parafermion_Chain`, `znchain`, and `pyspin.spin.Spin_Chain`'s ED backends) built each single-site operator via `np.kron` on **dense** identity matrices, converting to sparse only at the end. Cost/memory scaled `O(dim**2)` even though the result is trivially sparse (identity on every site but one) — this dominated ED chain construction well before the eigensolver's own `dim>2000` ARPACK cutoff, and was the real cap on usable ED chain size (tens of GB for one intermediate matrix at ns=16).
- Rewrote it to use `scipy.sparse.kron(..., format="csc")` throughout instead — identical signature/output, no call-site changes needed.
- Measured on `Bosonic_Chain.gs_energy(mode="ED")` (construction + solve): dim=4096 dropped from 13.06s to 0.12s (~110x). Isolated benchmark of the embedding step alone at ns=14 (dim=16384, spin-1/2): ~2000x faster.
- Note: `spinchain.Spin_Chain`'s ED path (`pychain/chain.py`) already builds operators directly in sparse basis-vector form and is unaffected by this change — this fix specifically targets `Bosonic_Chain`/`Parafermion_Chain`/`znchain`.

## Test plan
- [x] `pytest tests/test_spin_chain.py tests/test_boson_chain.py tests/test_parafermion_chain.py tests/test_benchmarks.py tests/test_internal_consistency.py` — all pass
- [x] Full suite `pytest tests` — 305 passed, 10 skipped (pre-existing), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3vAQih2WCR5XVemHSCUzb