### PR TITLE
Accelerate atom.py: fix one2many() O(m^2) term accumulation

### DIFF
--- a/examples/fermion_models/atom_regression/main.py
+++ b/examples/fermion_models/atom_regression/main.py
@@ -1,0 +1,49 @@
+# Add the root path of the dmrgpy library
+import os ; import sys ; sys.path.append(os.getcwd()+'/../../../src')
+
+# Regression test for dmrgpy.atom.generate_atom() (a 5-orbital d-shell
+# spinful-fermion atom: hopping + Hund's coupling via S^2/L^2 + SOC +
+# external/exchange fields + a Lagrange-multiplier filling constraint).
+# Until now atomtk/ had no test or example coverage at all, so a change
+# there (e.g. reordering how the internal one2many() helper accumulates
+# MultiOperator terms) had nothing locking in correctness. Golden values
+# below were computed with mode="ED" on a small, hand-written (not
+# random, for reproducibility) hopping matrix.
+import numpy as np
+from dmrgpy.atom import generate_atom
+
+tol = 1e-6
+
+orbs = ["dz2", "dxz", "dyz", "dx2y2", "dxy"]
+tij = np.array([
+    [ 0.20,  0.10,  0.00,  0.00,  0.00],
+    [ 0.10, -0.10,  0.05,  0.00,  0.00],
+    [ 0.00,  0.05,  0.05,  0.00,  0.00],
+    [ 0.00,  0.00,  0.00,  0.15,  0.02],
+    [ 0.00,  0.00,  0.00,  0.02, -0.05],
+])
+
+fc = generate_atom(orbs=orbs, tij=tij, U=4., B=[0.05, 0., 0.1],
+                    Js=[0., 0.1, 0.], soc=0.2, J=0.5, Ne=5, lamb_Ne=200)
+
+e0 = fc.gs_energy(mode="ED")
+s2 = fc.vev(fc.ST2, mode="ED")
+l2 = fc.vev(fc.LT2, mode="ED")
+ntot = sum(fc.vev(Ni, mode="ED") for Ni in fc.N)
+
+e0_ref = -35.37282567472432
+s2_ref = 8.747265937476783
+l2_ref = 0.001100335706273672
+ntot_ref = 5.0 # enforced by the lamb_Ne filling constraint
+
+print("E0   = %.12f (ref %.12f)"%(e0.real, e0_ref))
+print("<S2> = %.12f (ref %.12f)"%(s2.real, s2_ref))
+print("<L2> = %.12f (ref %.12f)"%(l2.real, l2_ref))
+print("<N>  = %.12f (ref %.12f)"%(ntot.real, ntot_ref))
+
+assert abs(e0.real-e0_ref)<tol, "ground state energy drifted from golden value"
+assert abs(s2.real-s2_ref)<tol, "<S^2> drifted from golden value"
+assert abs(l2.real-l2_ref)<tol, "<L^2> drifted from golden value"
+assert abs(ntot.real-ntot_ref)<1e-3, "filling constraint not enforced"
+
+print("TEST PASSED")

--- a/src/dmrgpy/atomtk/atomicbasis.py
+++ b/src/dmrgpy/atomtk/atomicbasis.py
@@ -40,6 +40,7 @@ def get_T(orbs):
 
 
 from .. import fermionchain
+from .. import multioperator
 
 
 def generate_atom(orbs=None, # orbitals
@@ -111,19 +112,24 @@ def generate_atom(orbs=None, # orbitals
     def one2many(ml=None,ms=None):
         """Return the many body representation of the single particle
         operators ml in orbital basis and ms in spin basis"""
-        o = 0 # output
+        # Collect the individual contributions and sum them all at once
+        # with multioperator.msum() instead of "o = o + term" per
+        # iteration: each "+" on a MultiOperator copies/concatenates its
+        # whole term list, which turns this loop (up to n*n*4 iterations)
+        # into an accidental O(m^2) (see msum()'s own docstring).
+        terms = [] # individual contributions
         if ml is None: ml = np.identity(n) # identity matrix
         if ms is None: ms = np.identity(2) # identity matrix
         for io in range(n): # loop over spinful orbitals
+            cas = [fc.Cdagup[io],fc.Cdagdn[io]] # first operator, depends only on io
             for jo in range(n): # loop over spinful orbitals
-                cas = [fc.Cdagup[io],fc.Cdagdn[io]] # first operator
                 cbs = [fc.Cup[jo],fc.Cdn[jo]] # second operator
                 for si in range(2): # loop over spin
                     for sj in range(2): # loop over spin
                         coeff = ml[io,jo]*ms[si,sj] # orbital times spin
                         if abs(coeff)>1e-6: # if non-zero
-                            o = o + coeff*cas[si]*cbs[sj] # add this contribution
-        return o # return
+                            terms.append(coeff*cas[si]*cbs[sj]) # this contribution
+        return multioperator.msum(terms) # return
 
     # initialize Hamiltonian
     h = 0


### PR DESCRIPTION
## Summary
- `atomtk/atomicbasis.py::generate_atom()`'s local `one2many()` helper (used to build hopping, SOC, `S^2`/`L^2`, and field operators) accumulated its result with `o = o + term` inside a loop of up to `n^2*4` iterations. Every `MultiOperator.__add__` copies/concatenates its whole term list, so this was the exact O(m^2) anti-pattern `multioperator.msum()`'s own docstring calls out and was written to replace. Switched to collecting terms into a list and building the operator once via `msum()`; also hoisted the `io`-only-dependent `cas` list out of the inner `jo` loop.
- Verified the dense operator matrices (Hamiltonian, `S^2`, `L^2`, `Lx`) are bit-for-bit identical before/after on a representative case (`maxdiff=0.0`); `one2many()` itself is ~1.3x faster in isolation (chain construction and an unrelated subprocess-based `restart()`/`clean()` call dominate the rest of `generate_atom()`'s wall time and are out of scope here).
- Added `examples/fermion_models/atom_regression`, the first regression coverage for `atom.py`/`atomtk/` (previously exercised by zero tests or examples), locking in ED ground-state energy, `<S^2>`, `<L^2>`, and total filling against golden values on a deterministic hopping matrix.

## Test plan
- [x] New example passes: `cd examples/fermion_models/atom_regression && PYTHONPATH=<repo>/src python3 main.py` → `TEST PASSED`
- [x] Full `pytest tests/` run: 228 passed, 16 failed, 71 skipped — the 16 failures reproduce identically on the unmodified baseline (uncompiled ITensor C++ backend + a pre-existing unrelated `entropytk` bug), confirmed by re-running those exact failing files against the stashed baseline
- [x] Dense-matrix diff check (H, S^2, L^2, Lx) between baseline and fixed code: exact match

🤖 Generated with [Claude Code](https://claude.com/claude-code)