### PR TITLE
Port TEBD real-time evolution to the ITensor v3 (mpscpp3) backend

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1165,30 +1165,51 @@ Notable, deliberate implementation details (not bugs to "fix"):
   under a second for the same computation on `itensor_version=3`) that
   couldn't be root-caused in the time available — see git history around
   `mpscpp2/TDVP/` if picking this up again.
-- `tevol_method="TEBD"` (`pyitensor/tebd.py`'s `TEBDEvolver`,
-  `itensor_version="python"` only — no C++-backend port exists) runs the
-  standard 2nd-order-Trotter, even/odd-bond algorithm instead of TDVP:
-  every bond's evolution gate `exp(-i*tau*h_bond)` is the exact
-  exponential of the *bare* local 2-site Hamiltonian (`scipy.linalg.expm`
-  on a small dense matrix), built once from `bond_hamiltonians()` and
-  reused unchanged for every subsequent time step — no per-step
-  Krylov/Lanczos work at all, unlike TDVP's per-bond, per-step
-  environment-projected exponentiation. Only valid for a strictly
-  nearest-neighbor Hamiltonian (`bond_hamiltonians()` raises
-  `NotImplementedError` for any term spanning 3+ distinct sites; span is
-  computed from each term's *resolved* per-site matrices against the
-  identity, not from raw op-name lists, since both `MultiOperator`
-  placeholder-site bookkeeping and native-spinful-site Jordan-Wigner
-  string pairs can otherwise look like spurious long-range support — see
-  `tebd.py`'s `_true_span()`). `Chain.quench_tebd()`/
-  `evolve_and_measure_tebd()` mirror the TDVP counterparts one-for-one,
-  so `get_dynamical_correlator(submode="TD")` (a `quench_tebd()` call
-  under `timedependent.py`'s `evolution_dmrg_DC()`) and
-  `evolve_and_measure_dmrg()` both support `"TEBD"` the same way they
-  support `"TDVP"`. Individually validated against exact diagonalization
-  (both agree to ~3e-4) on small nearest-neighbor systems, including a
-  native-Hubbard chain, in `tests/test_time_evolution.py`; TEBD's cost
-  advantage there scales up dramatically since TDVP's per-step cost
+- `tevol_method="TEBD"` (`itensor_version="python"` via
+  `pyitensor/tebd.py`'s `TEBDEvolver`, or `itensor_version=3` via
+  `mpscpp3/tebd.h` -- a from-scratch C++ port, not a shared code path)
+  runs the standard 2nd-order-Trotter, even/odd-bond algorithm instead of
+  TDVP: every bond's evolution gate `exp(-i*tau*h_bond)` is the exact
+  exponential of the *bare* local 2-site Hamiltonian, built once from a
+  `bond_hamiltonians()` function and reused unchanged for every subsequent
+  time step — no per-step Krylov/Lanczos work at all, unlike TDVP's
+  per-bond, per-step environment-projected exponentiation. `"python"`
+  exponentiates a small dense matrix directly (`scipy.linalg.expm`);
+  `itensor_version=3` instead builds the gate as an `ITensor` via
+  ITensor's own `BondGate` primitive (`itensor/mps/bondgate.h`, its own
+  Taylor-series `exp`, order 100 -- no `expm()` port needed). Only valid
+  for a strictly nearest-neighbor Hamiltonian (`bond_hamiltonians()`
+  raises `NotImplementedError` in `"python"`, a catchable `ITError` in
+  `3`, for any term spanning 3+ distinct sites; span is computed from each
+  term's *resolved* per-site operator against the identity, not from raw
+  op-name lists, since both `MultiOperator` placeholder-site bookkeeping
+  and native-spinful-site Jordan-Wigner string pairs can otherwise look
+  like spurious long-range support — see `tebd.py`'s `_true_span()`).
+  `mpscpp3/tebd.h`'s own `bond_hamiltonians()` reimplements the identical
+  algorithm as `pyitensor/autompo.py`'s `HTerm.resolve()` (same
+  carried-parity Jordan-Wigner threading, same per-site factor composition
+  order) directly against ITensor v3's own site operators, composing
+  same-site factors via ITensor's `multSiteOps()` primitive rather than
+  going through `AutoMPO`/`toMPO()`: a probe against real ITensor v3
+  confirmed a single, unsummed `HTerm` does *not* compile to a
+  bond-dimension-1 MPO (a bare one-site term already comes out with
+  uniform bond dimension 2 on every link), so there is no cheap way to
+  "slice" a term's own local operator out of its compiled MPO the way
+  other bond-dimension-1-only extraction tricks in this file work.
+  `Chain::quench_tebd()`/`evolve_and_measure_tebd()` mirror the TDVP
+  counterparts one-for-one (down to the ground-state-energy-shift
+  convention `quench_tebd()`/`quench_tdvp()` share), so
+  `get_dynamical_correlator(submode="TD")` (a `quench_tebd()` call under
+  `timedependent.py`'s `evolution_dmrg_DC()`) and
+  `evolve_and_measure_dmrg()` both support `"TEBD"` on `itensor_version`
+  `3` or `"python"` the same way they support `"TDVP"`. Individually
+  validated against exact diagonalization (both agree to ~1e-4) on small
+  nearest-neighbor systems, including a native-Hubbard chain, in
+  `tests/test_time_evolution.py`; the two `"TEBD"` backends additionally
+  agree with *each other* to machine precision (~1e-14) on a fermionic
+  hopping+onsite cross-check, confirming the C++ port's Jordan-Wigner
+  threading and onsite-splitting match the Python reference exactly.
+  TEBD's cost advantage scales up dramatically since TDVP's per-step cost
   scales with the local Hilbert-space dimension squared (16 for a
   dimension-4 Hubbard site) while TEBD's gates are built once and reused
   every step — see

--- a/docs/documentation.tex
+++ b/docs/documentation.tex
@@ -1394,34 +1394,60 @@ Notable, deliberate implementation details (not bugs to ``fix''):
     \texttt{itensor\_version=3}) that couldn't be root-caused in the time
     available --- see git history around \texttt{mpscpp2/TDVP/} if
     picking this up again.
-  \item \texttt{tevol\_method="TEBD"} (\texttt{pyitensor/tebd.py}'s
-    \texttt{TEBDEvolver}, \texttt{itensor\_version="python"} only --- no
-    C++-backend port exists) runs the standard 2nd-order-Trotter,
-    even/odd-bond algorithm instead of TDVP: every bond's evolution gate
-    $\exp(-i\,\tau\,h_{\rm bond})$ is the exact exponential of the
-    \emph{bare} local 2-site Hamiltonian (\texttt{scipy.linalg.expm} on a
-    small dense matrix), built once from \texttt{bond\_hamiltonians()}
-    and reused unchanged for every subsequent time step --- no per-step
-    Krylov/Lanczos work at all, unlike TDVP's per-bond, per-step
-    environment-projected exponentiation. Only valid for a strictly
-    nearest-neighbor Hamiltonian (\texttt{bond\_hamiltonians()} raises
-    \texttt{NotImplementedError} for any term spanning 3+ distinct sites;
-    span is computed from each term's \emph{resolved} per-site matrices
-    against the identity, not from raw op-name lists, since both
-    \texttt{MultiOperator} placeholder-site bookkeeping and
-    native-spinful-site Jordan-Wigner string pairs can otherwise look
-    like spurious long-range support --- see \texttt{tebd.py}'s
-    \texttt{\_true\_span()}). \texttt{Chain.quench\_tebd()}/
+  \item \texttt{tevol\_method="TEBD"} (\texttt{itensor\_version="python"}
+    via \texttt{pyitensor/tebd.py}'s \texttt{TEBDEvolver}, or
+    \texttt{itensor\_version=3} via \texttt{mpscpp3/tebd.h} --- a
+    from-scratch C++ port, not a shared code path) runs the standard
+    2nd-order-Trotter, even/odd-bond algorithm instead of TDVP: every
+    bond's evolution gate $\exp(-i\,\tau\,h_{\rm bond})$ is the exact
+    exponential of the \emph{bare} local 2-site Hamiltonian, built once
+    from a \texttt{bond\_hamiltonians()} function and reused unchanged
+    for every subsequent time step --- no per-step Krylov/Lanczos work at
+    all, unlike TDVP's per-bond, per-step environment-projected
+    exponentiation. \texttt{"python"} exponentiates a small dense matrix
+    directly (\texttt{scipy.linalg.expm}); \texttt{itensor\_version=3}
+    instead builds the gate as an \texttt{ITensor} via ITensor's own
+    \texttt{BondGate} primitive (\texttt{itensor/mps/bondgate.h}, its own
+    Taylor-series \texttt{exp}, order 100 --- no \texttt{expm()} port
+    needed). Only valid for a strictly nearest-neighbor Hamiltonian
+    (\texttt{bond\_hamiltonians()} raises \texttt{NotImplementedError} in
+    \texttt{"python"}, a catchable \texttt{ITError} in \texttt{3}, for any
+    term spanning 3+ distinct sites; span is computed from each term's
+    \emph{resolved} per-site operator against the identity, not from raw
+    op-name lists, since both \texttt{MultiOperator} placeholder-site
+    bookkeeping and native-spinful-site Jordan-Wigner string pairs can
+    otherwise look like spurious long-range support --- see
+    \texttt{tebd.py}'s \texttt{\_true\_span()}).
+    \texttt{mpscpp3/tebd.h}'s own \texttt{bond\_hamiltonians()}
+    reimplements the identical algorithm as
+    \texttt{pyitensor/autompo.py}'s \texttt{HTerm.resolve()} (same
+    carried-parity Jordan-Wigner threading, same per-site factor
+    composition order) directly against ITensor v3's own site operators,
+    composing same-site factors via ITensor's \texttt{multSiteOps()}
+    primitive rather than going through \texttt{AutoMPO}/\texttt{toMPO()}:
+    a probe against real ITensor v3 confirmed a single, unsummed
+    \texttt{HTerm} does \emph{not} compile to a bond-dimension-1 MPO (a
+    bare one-site term already comes out with uniform bond dimension 2 on
+    every link), so there is no cheap way to ``slice'' a term's own local
+    operator out of its compiled MPO the way other bond-dimension-1-only
+    extraction tricks in this file work. \texttt{Chain.quench\_tebd()}/
     \texttt{evolve\_and\_measure\_tebd()} mirror the TDVP counterparts
-    one-for-one, so \texttt{get\_dynamical\_correlator(submode="TD")} (a
+    one-for-one (down to the ground-state-energy-shift convention
+    \texttt{quench\_tebd()}/\texttt{quench\_tdvp()} share), so
+    \texttt{get\_dynamical\_correlator(submode="TD")} (a
     \texttt{quench\_tebd()} call under \texttt{timedependent.py}'s
     \texttt{evolution\_dmrg\_DC()}) and
-    \texttt{evolve\_and\_measure\_dmrg()} both support \texttt{"TEBD"}
-    the same way they support \texttt{"TDVP"}. Individually validated
-    against exact diagonalization (both agree to $\sim3\times10^{-4}$)
-    on small nearest-neighbor systems, including a native-Hubbard chain,
-    in \texttt{tests/test\_time\_evolution.py}; TEBD's cost advantage
-    scales up dramatically since TDVP's per-step cost scales with the
+    \texttt{evolve\_and\_measure\_dmrg()} both support \texttt{"TEBD"} on
+    \texttt{itensor\_version} \texttt{3} or \texttt{"python"} the same way
+    they support \texttt{"TDVP"}. Individually validated against exact
+    diagonalization (both agree to $\sim10^{-4}$) on small
+    nearest-neighbor systems, including a native-Hubbard chain, in
+    \texttt{tests/test\_time\_evolution.py}; the two \texttt{"TEBD"}
+    backends additionally agree with \emph{each other} to machine
+    precision ($\sim10^{-14}$) on a fermionic hopping+onsite cross-check,
+    confirming the C++ port's Jordan-Wigner threading and onsite-splitting
+    match the Python reference exactly. TEBD's cost advantage scales up
+    dramatically since TDVP's per-step cost scales with the
     local Hilbert-space dimension squared (16 for a dimension-4 Hubbard
     site) while TEBD's gates are built once and reused every step ---
     see \texttt{examples/dynamical\_correlator/}\allowbreak

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1017,10 +1017,11 @@ measurement operator.
   dimension is small (e.g.\ a product-state quench) and one-site TDVP
   alone (which conserves bond dimension exactly) wouldn't be able to grow
   into the entanglement the subsequent evolution generates.
-- `"TEBD"` (`itensor_version="python"` only, and only for a strictly
+- `"TEBD"` (`itensor_version` `3` or `"python"`, and only for a strictly
   nearest-neighbor Hamiltonian — any term touching 3 or more distinct
-  sites raises `NotImplementedError`) — the standard 2nd-order-Trotter,
-  even/odd-bond ("brick-wall") algorithm: $e^{-iH\,dt}\approx
+  sites raises `NotImplementedError` (`"python"`) or a catchable
+  `RuntimeError` (`3`)) — the standard 2nd-order-Trotter, even/odd-bond
+  ("brick-wall") algorithm: $e^{-iH\,dt}\approx
   e^{-iH_{\rm odd}\,dt/2}\,e^{-iH_{\rm even}\,dt}\,e^{-iH_{\rm odd}\,dt/2}$,
   where $H_{\rm odd}$/$H_{\rm even}$ sum the bond Hamiltonians on
   odd-/even-indexed bonds (each internally commuting, since every bond in
@@ -1031,13 +1032,18 @@ measurement operator.
   2-site Hamiltonian, built once up front and reused unchanged for every
   time step — no per-step Krylov/Lanczos work at all — so `"TEBD"` is
   typically cheaper per step than TDVP whenever the Hamiltonian qualifies.
+  `itensor_version=3` builds the gate via ITensor's own `BondGate`
+  primitive (`mpscpp3/tebd.h`); `"python"` exponentiates the bare 2-site
+  matrix directly (`pyitensor/tebd.py`'s `TEBDEvolver`) — both backends
+  agree with each other to machine precision on a fermionic
+  hopping+onsite benchmark.
 - `"MPO"` — a hand-rolled 2nd-order Taylor expansion of $e^{-iH\,dt}$
   applied as an MPO each step; the only option on `itensor_version=2`
   (which has no TDVP or TEBD at all), and available (if slower/less
   accurate for a given bond dimension) everywhere else too.
 
 ```python
-sc.setup_python()          # TEBD only exists on the pure-Python backend
+sc.setup_cpp(version=3)    # or sc.setup_python()
 sc.tevol_method = "TEBD"
 ```
 

--- a/docs/user_guide.tex
+++ b/docs/user_guide.tex
@@ -1173,22 +1173,28 @@ options:
     dimension is small (e.g.\ a product-state quench) and one-site TDVP
     alone (which conserves bond dimension exactly) wouldn't be able to
     grow into the entanglement the subsequent evolution generates.
-  \item \texttt{"TEBD"} (\texttt{itensor\_version="python"} only, and
-    only for a strictly nearest-neighbor Hamiltonian --- any term
-    touching 3 or more distinct sites raises \texttt{NotImplementedError})
-    --- the standard 2nd-order-Trotter, even/odd-bond (``brick-wall'')
-    algorithm: $e^{-iH\,dt}\approx e^{-iH_{\rm odd}\,dt/2}\,
-    e^{-iH_{\rm even}\,dt}\,e^{-iH_{\rm odd}\,dt/2}$, where $H_{\rm odd}$/
-    $H_{\rm even}$ sum the bond Hamiltonians on odd-/even-indexed bonds
-    (each internally commuting, since every bond in one group acts on
-    disjoint sites). Onsite terms are split half-and-half onto each
-    site's neighboring bond(s) (full weight at a chain boundary). Unlike
-    the TDVP variants, every bond's evolution gate
-    $e^{-i\tau h_{\rm bond}}$ is the exact exponential of the \emph{bare}
-    local 2-site Hamiltonian, built once up front and reused unchanged
-    for every time step --- no per-step Krylov/Lanczos work at all --- so
-    \texttt{"TEBD"} is typically cheaper per step than TDVP whenever the
-    Hamiltonian qualifies.
+  \item \texttt{"TEBD"} (\texttt{itensor\_version} \texttt{3} or
+    \texttt{"python"}, and only for a strictly nearest-neighbor
+    Hamiltonian --- any term touching 3 or more distinct sites raises
+    \texttt{NotImplementedError} (\texttt{"python"}) or a catchable
+    \texttt{RuntimeError} (\texttt{3})) --- the standard 2nd-order-Trotter,
+    even/odd-bond (``brick-wall'') algorithm: $e^{-iH\,dt}\approx
+    e^{-iH_{\rm odd}\,dt/2}\, e^{-iH_{\rm even}\,dt}\,e^{-iH_{\rm
+    odd}\,dt/2}$, where $H_{\rm odd}$/ $H_{\rm even}$ sum the bond
+    Hamiltonians on odd-/even-indexed bonds (each internally commuting,
+    since every bond in one group acts on disjoint sites). Onsite terms
+    are split half-and-half onto each site's neighboring bond(s) (full
+    weight at a chain boundary). Unlike the TDVP variants, every bond's
+    evolution gate $e^{-i\tau h_{\rm bond}}$ is the exact exponential of
+    the \emph{bare} local 2-site Hamiltonian, built once up front and
+    reused unchanged for every time step --- no per-step Krylov/Lanczos
+    work at all --- so \texttt{"TEBD"} is typically cheaper per step than
+    TDVP whenever the Hamiltonian qualifies. \texttt{itensor\_version=3}
+    builds the gate via ITensor's own \texttt{BondGate} primitive
+    (\texttt{mpscpp3/tebd.h}); \texttt{"python"} exponentiates the bare
+    2-site matrix directly (\texttt{pyitensor/tebd.py}'s
+    \texttt{TEBDEvolver}) --- both backends agree with each other to
+    machine precision on a fermionic hopping+onsite benchmark.
   \item \texttt{"MPO"} --- a hand-rolled 2nd-order Taylor expansion of
     $e^{-iH\,dt}$ applied as an MPO each step; the only option on
     \texttt{itensor\_version=2} (which has no TDVP or TEBD at all), and
@@ -1204,7 +1210,7 @@ sc.tdvp_gse_cutoff = 1e-8
 \end{lstlisting}
 
 \begin{lstlisting}
-sc.setup_python()          # TEBD only exists on the pure-Python backend
+sc.setup_cpp(version=3)    # or sc.setup_python()
 sc.tevol_method = "TEBD"
 \end{lstlisting}
 

--- a/src/dmrgpy/manybodychain.py
+++ b/src/dmrgpy/manybodychain.py
@@ -76,18 +76,19 @@ class Many_Body_Chain():
           # evolve_and_measure_tdvp()), "TDVP_GSE" (one-site TDVP with
           # Krylov global subspace expansion, arXiv:2005.06104 -- same
           # itensor_version support as "TDVP"; see tdvp_gse_* below),
-          # "TEBD" (2nd-order-Trotter TEBD, pyitensor/tebd.py --
-          # itensor_version="python" only, and only for a strictly
-          # nearest-neighbor Hamiltonian; gates are built once from the
-          # bare bond Hamiltonians and reused every step, so it's cheaper
-          # per step than TDVP whenever it applies), or "MPO" (the legacy
-          # 2nd-order Taylor-expanded evoloperator() backup, the only
-          # option for itensor_version=2, since none of TDVP/TDVP_GSE/TEBD
-          # exist there -- a v2-API port of TDVP was attempted but
-          # reverted after a severe, unresolved performance regression at
-          # n>~10 sites, see git history around mpscpp2/TDVP/ if picking
-          # this up again). See timedependent.py's evolution_dmrg_DC()/
-          # evolve_and_measure_dmrg() for the actual dispatch.
+          # "TEBD" (2nd-order-Trotter TEBD, pyitensor/tebd.py or
+          # mpscpp3/tebd.h -- itensor_version in (3,"python"), and only
+          # for a strictly nearest-neighbor Hamiltonian; gates are built
+          # once from the bare bond Hamiltonians and reused every step,
+          # so it's cheaper per step than TDVP whenever it applies), or
+          # "MPO" (the legacy 2nd-order Taylor-expanded evoloperator()
+          # backup, the only option for itensor_version=2, since none of
+          # TDVP/TDVP_GSE/TEBD exist there -- a v2-API port of TDVP was
+          # attempted but reverted after a severe, unresolved performance
+          # regression at n>~10 sites, see git history around
+          # mpscpp2/TDVP/ if picking this up again). See
+          # timedependent.py's evolution_dmrg_DC()/evolve_and_measure_dmrg()
+          # for the actual dispatch.
       self.tdvp_gse_sweeps = 3 # "TDVP_GSE" only: number of leading TDVP
           # sweeps preceded by a global-subspace-expansion step; after
           # that, bond dimension is left to whatever GSE already grew it

--- a/src/dmrgpy/mps.py
+++ b/src/dmrgpy/mps.py
@@ -74,15 +74,34 @@ class MPS():
         # genuine opaque pybind11 objects with no Python-visible methods
         # at all (see mpscpp2/mpscpp3's bindings.cc), so hasattr() here
         # reliably tells the two cases apart.
+        #
+        # This unconditionally pays that cpp_handle.copy() on every call
+        # for itensor_version="python", not just from TDVP/TEBD -- but
+        # that copy is `list(self._tensors)` (mpscontainer.py's own
+        # _Chain.copy()), a shallow list of N Python object references
+        # (N = site count), not a deep duplication of any ITensor's
+        # actual (bond-dimension-scaled) data: every operation in that
+        # engine returns a *new* ITensor rather than mutating one in
+        # place (tensor.py's own convention), so sharing the individual
+        # tensor objects across the old and new tensor lists is exactly
+        # as safe as it is for MPO's identical copy() -- and O(N) is
+        # negligible next to any DMRG/TDVP/TEBD sweep's own O(bond_dim^3)
+        # cost. No call site needs auditing for performance on that
+        # basis; only for the correctness question above (does the
+        # handle need to stay independent of whatever produced it).
         out = _shallow_copy(self)
         out.name = name
         if self.cpp_handle is not None and hasattr(self.cpp_handle,"copy"):
             out.cpp_handle = self.cpp_handle.copy()
         return out
     def __deepcopy__(self,memo):
-        """Defer to copy(): see the note there for why a shallow copy is
-        already correct and a real deep copy would fail on cpp_handle (or
-        recurse needlessly into self.MBO)."""
+        """Defer to copy(): see the note there for why copy() itself
+        already does exactly the right thing per backend (a shallow copy
+        of self plus, for itensor_version="python" only, an explicit
+        cpp_handle.copy() to break tensor-list aliasing) -- a real
+        recursive deepcopy would also choke on the C++ backends'
+        cpp_handle (no pickle/deepcopy support) and recurse needlessly
+        into self.MBO."""
         return self.copy()
     def write(self,name=None,path=None):
         """No-op: the wavefunction already lives in self.cpp_handle,

--- a/src/dmrgpy/mpscpp3/bindings.cc
+++ b/src/dmrgpy/mpscpp3/bindings.cc
@@ -16,6 +16,7 @@ using namespace std;
 #include "check_task.h" // get_bool/get_str/get_int_value/... (get_sites.h needs these)
 #include "get_sites.h" // SpinX, incl. the in-memory std::vector<int> constructor
 #include "mo_terms.h" // OpFactor/MOTerm + build_ampo/build_mpo
+#include "tebd.h" // bond_hamiltonians/build_tebd_gates/tebd_step (Chain::quench_tebd/evolve_and_measure_tebd)
 #include "chain_session.h" // Chain: the session/handle model
 
 namespace py = pybind11;
@@ -426,6 +427,32 @@ PYBIND11_MODULE(_dmrgcpp, m)
                py::arg("krylov_order"),py::arg("gse_cutoff"),
                "One-site-TDVP-with-global-subspace-expansion counterpart of "
                "evolve_and_measure_tdvp(). Returns (correlator, final_wf)")
+        .def("quench_tebd",[](Chain& self, std::vector<PyTerm> const& terms_h,
+                          std::vector<PyTerm> const& terms_i,
+                          std::vector<PyTerm> const& terms_j,
+                          int nt, double dt) {
+                auto out = self.quench_tebd(terms_from_python(terms_h),
+                    terms_from_python(terms_i),terms_from_python(terms_j),
+                    nt,dt);
+                return py::make_tuple(out.correlator,out.final_wf);
+            }, py::arg("terms_h"),py::arg("terms_i"),py::arg("terms_j"),
+               py::arg("nt"),py::arg("dt"),
+               "2nd-order-Trotter TEBD counterpart of quench()/quench_tdvp(). "
+               "Only valid for a strictly nearest-neighbor terms_h (raises "
+               "for any term spanning 3+ distinct sites). "
+               "Returns (correlator, final_wf)")
+        .def("evolve_and_measure_tebd",
+            [](Chain& self, std::vector<PyTerm> const& terms_h,
+               std::vector<PyTerm> const& terms_op, MPS const& wf,
+               int nt, double dt) {
+                auto out = self.evolve_and_measure_tebd(terms_from_python(terms_h),
+                    terms_from_python(terms_op),wf,nt,dt);
+                return py::make_tuple(out.correlator,out.final_wf);
+            }, py::arg("terms_h"),py::arg("terms_op"),py::arg("wf"),
+               py::arg("nt"),py::arg("dt"),
+               "TEBD counterpart of evolve_and_measure()/evolve_and_measure_tdvp(). "
+               "Only valid for a strictly nearest-neighbor terms_h. "
+               "Returns (correlator, final_wf)")
         .def("tdvp_step",&Chain::tdvp_step,
              py::arg("H"),py::arg("wf"),py::arg("dt"),py::arg("num_center")=2,
              py::arg("niter")=50,

--- a/src/dmrgpy/mpscpp3/chain_session.h
+++ b/src/dmrgpy/mpscpp3/chain_session.h
@@ -1082,6 +1082,75 @@ class Chain
         return out;
         }
 
+    // TEBD counterparts of quench()/quench_tdvp() above: same physics and
+    // EGS-shift convention as quench_tdvp() (so results are directly
+    // comparable to it and to the MPO-Taylor backup), but each per-step
+    // evolution is a 2nd-order-Trotter TEBD step (tebd.h's
+    // build_tebd_gates()/tebd_step(), gates built once up front from the
+    // bare bond Hamiltonians and reused unchanged every step) instead of
+    // TDVP's per-step Krylov exponentiation of an effective Hamiltonian --
+    // only valid for a strictly nearest-neighbor terms_h
+    // (bond_hamiltonians() throws ITError otherwise; see tebd.h's own
+    // comment). Mirrors pyitensor/chain.py's Chain.quench_tebd() (the
+    // pure-Python backend's own TEBD, which this file's terms_h/dt
+    // conventions match exactly) -- kept as a near-duplicate of
+    // quench_tdvp() rather than sharing a driver loop with it, for the
+    // same reason quench_tdvp()/quench() themselves aren't unified: each
+    // per-step evolution primitive has its own setup (tdvp_step() takes
+    // an MPO, tebd_step() takes precomputed BondGates).
+    TimeEvolutionResult
+    quench_tebd(std::vector<MOTerm> const& terms_h,
+                std::vector<MOTerm> const& terms_i,
+                std::vector<MOTerm> const& terms_j,
+                int nt, double dt)
+        {
+        if (!have_wf0_) gs_energy();
+        auto H = build_mpo(sites_,terms_h,mpomaxm_);
+        auto args = Args("Cutoff",cutoff_,"MaxDim",maxm_);
+        double EGS = innerC(wf0_,H,wf0_).real()/innerC(wf0_,wf0_).real();
+        auto terms_shifted = terms_h;
+        MOTerm shift_term;
+        shift_term.coef = Cplx(-EGS,0.0);
+        shift_term.factors = {{"Id",1}};
+        terms_shifted.push_back(shift_term);
+        auto h_bonds = bond_hamiltonians(sites_,terms_shifted);
+        auto gates = build_tebd_gates(sites_,h_bonds,dt);
+        auto A1 = build_mpo(sites_,terms_i,mpomaxm_);
+        auto A2 = build_mpo(sites_,terms_j,mpomaxm_);
+        auto psi1 = apply_mpo(A1,wf0_,args);
+        auto psi2 = apply_mpo(A2,wf0_,args);
+        Cplx norm0 = std::sqrt(innerC(psi1,psi1));
+        TimeEvolutionResult out;
+        for (int it=0;it<nt;it++)
+            {
+            tebd_step(psi1,gates,cutoff_,maxm_);
+            psi1.normalize();
+            psi1 *= norm0;
+            out.correlator.push_back(innerC(psi2,psi1));
+            }
+        out.final_wf = psi1;
+        return out;
+        }
+
+    TimeEvolutionResult
+    evolve_and_measure_tebd(std::vector<MOTerm> const& terms_h,
+                             std::vector<MOTerm> const& terms_op,
+                             MPS const& wf, int nt, double dt)
+        {
+        auto h_bonds = bond_hamiltonians(sites_,terms_h);
+        auto gates = build_tebd_gates(sites_,h_bonds,dt);
+        auto A = build_mpo(sites_,terms_op,mpomaxm_);
+        auto psi = wf;
+        TimeEvolutionResult out;
+        for (int it=0;it<nt;it++)
+            {
+            tebd_step(psi,gates,cutoff_,maxm_);
+            out.correlator.push_back(innerC(psi,A,psi));
+            }
+        out.final_wf = psi;
+        return out;
+        }
+
     // One step exp(dt*H) of two-site TDVP (TDVP/tdvp.h), given an
     // already-built MPO H (e.g. from build_operator()) and MPS psi --
     // exposed publicly (moved here from a private helper of the same

--- a/src/dmrgpy/mpscpp3/tebd.h
+++ b/src/dmrgpy/mpscpp3/tebd.h
@@ -1,0 +1,211 @@
+// Real-time evolution via 2nd-order Trotter TEBD for strictly nearest-
+// neighbor Hamiltonians -- a C++ port of pyitensor/tebd.py's TEBDEvolver
+// onto ITensor v3's own BondGate (itensor/mps/bondgate.h, pulled in
+// transitively via itensor/mps/tevol.h) and svd() primitives. See
+// pyitensor/tebd.py's module docstring for the full algorithm/rationale
+// (bond Hamiltonians, half-dt-odd/full-dt-even/half-dt-odd Trotter
+// splitting, half-weight onsite-term splitting onto neighboring bonds,
+// why fermionic terms need no special-casing beyond correct per-site
+// operator resolution); this file only documents where the C++ port's
+// *method* of getting each term's per-site operator diverges from the
+// pure-Python reference.
+//
+// pyitensor/tebd.py resolves each MOTerm's per-site Jordan-Wigner-threaded
+// operator by hand (its own HTerm.resolve(), mirroring autompo.cc's
+// rewriteFermionic()). Here, that same algorithm is ported directly --
+// same carried-parity/JW-threading logic, same per-site factor
+// composition order -- rather than routed through ITensor's own
+// AutoMPO/toMPO() automaton: a probe against real ITensor v3 confirmed a
+// *single*, unsummed HTerm does NOT compile to a bond-dimension-1 MPO (a
+// bare one-site "Sz" term already comes out with uniform bond dimension 2
+// on every link, presumably automaton bookkeeping state rather than
+// physical content), so there is no cheap, generic way to "slice out" a
+// term's own local operator from its compiled MPO the way this file's
+// other extraction tricks (e.g. Chain::build_product_state()'s setElt()
+// idiom) work for genuinely bond-dimension-1 objects. Composing same-site
+// factors uses ITensor's own multSiteOps(A,B) ("apply B then A", i.e.
+// A@B) -- confirmed directly (multSiteOps(Cdag,C) == N on a Fermion
+// site) -- instead of hand-rolled prime-level bridging.
+bool inline
+is_fermionic_opname(std::string const& name)
+    {
+    return !name.empty() && name[0]=='C';
+    }
+
+// The per-site standard-convention operator (out=primed,in=unprimed) for
+// one MOTerm at one site, given the fermion parity carried in from sites
+// <site -- mirrors pyitensor/autompo.py's HTerm.resolve() body exactly.
+// Returns (operator, outgoing carry).
+std::pair<ITensor,bool>
+resolve_term_at_site(SiteSet const& sites, MOTerm const& term, int site, bool carry_in)
+    {
+    std::vector<std::string> names;
+    for (auto const& f : term.factors)
+        if (f.site==site) names.push_back(f.name);
+    if (names.empty())
+        return {sites.op(carry_in ? "F" : "Id", site), carry_in};
+    bool is_site_fermionic = false;
+    for (auto const& nm : names)
+        if (is_fermionic_opname(nm)) is_site_fermionic = !is_site_fermionic;
+    bool need_F = (carry_in != is_site_fermionic);
+    ITensor combined = sites.op(names[0],site);
+    for (size_t k=1; k<names.size(); ++k)
+        combined = multSiteOps(combined,sites.op(names[k],site));
+    if (need_F) combined = multSiteOps(combined,sites.op("F",site));
+    return {combined, carry_in != is_site_fermionic};
+    }
+
+// The 2-site bond Hamiltonians h_1..h_{n-1} (bond b couples sites b,b+1),
+// each an ITensor with indices s(b)',s(b),s(b+1)',s(b+1) (the standard
+// output-primed/input-unprimed convention op(sites,name,site) itself
+// uses, e.g. see ITensor's own tutorial/05_gates/gates.cc) -- ready to
+// hand to BondGate's tReal/tImag constructor unchanged.
+std::map<int,ITensor>
+bond_hamiltonians(SiteSet const& sites, std::vector<MOTerm> const& terms)
+    {
+    int n = sites.length();
+    if (n<2) throw ITError("bond_hamiltonians: TEBD needs at least 2 sites");
+    std::map<int,ITensor> H;
+    for (int b=1; b<n; ++b)
+        H[b] = (sites.op("Id",b)*sites.op("Id",b+1)) * 0.0;
+
+    for (auto const& term : terms)
+        {
+        std::vector<ITensor> mats(n+1); // 1-indexed, [0] unused
+        bool carry = false;
+        for (int i=1; i<=n; ++i)
+            {
+            auto resolved = resolve_term_at_site(sites,term,i,carry);
+            mats[i] = resolved.first;
+            carry = resolved.second;
+            }
+
+        // Touched span: where the resolved per-site operator differs
+        // from plain Id -- mirrors tebd.py's _true_span() (determining
+        // this from the *resolved* matrices, not the raw op-name list,
+        // is what makes it immune to both of _true_span()'s documented
+        // false-positive sources: MultiOperator.identity()'s placeholder
+        // "Id" factor, and paired F-string factors that algebraically
+        // cancel to Id).
+        int lo=-1, hi=-1;
+        for (int i=1; i<=n; ++i)
+            {
+            if (norm(mats[i]-sites.op("Id",i)) > 1E-10)
+                {
+                if (lo==-1) lo = i;
+                hi = i;
+                }
+            }
+
+        if (lo==-1)
+            {
+            // Untouched everywhere (a bare scalar*Identity term, e.g. a
+            // ground-state-energy shift folded in as coef*Id): dump the
+            // whole contribution on bond 1, exactly like tebd.py -- any
+            // other bond would do equally well (sum over bonds is what
+            // matters for Trotter correctness, not which bond carries a
+            // global-phase constant), bond 1 is just tebd.py's own
+            // convention, kept here for consistency.
+            H[1] += term.coef * (sites.op("Id",1)*sites.op("Id",2));
+            }
+        else if (lo==hi)
+            {
+            // Onsite term: split half-and-half onto both neighboring
+            // bonds (full weight at a chain boundary) -- TeNPy's
+            // NearestNeighborModel convention, same as tebd.py.
+            auto local = term.coef * mats[lo];
+            bool has_left = (lo>1), has_right = (lo<n);
+            double weight = (has_left && has_right) ? 0.5 : 1.0;
+            if (has_left) H[lo-1] += weight * (sites.op("Id",lo-1) * local);
+            if (has_right) H[lo] += weight * (local * sites.op("Id",lo+1));
+            }
+        else if (hi==lo+1)
+            {
+            H[lo] += term.coef * (mats[lo] * mats[hi]);
+            }
+        else
+            {
+            throw ITError("TEBD requires a nearest-neighbor Hamiltonian; "
+                "found a term with non-trivial support spanning sites "
+                +std::to_string(lo)+".."+std::to_string(hi));
+            }
+        }
+    return H;
+    }
+
+// Precomputed odd/even-bond gates for one fixed dt -- built once from the
+// (static, time-independent) bond Hamiltonians and reused unchanged for
+// every subsequent tebd_step() call, mirroring TEBDEvolver.__init__: the
+// odd bonds only ever need their half-dt gate, the even bonds only ever
+// need their full-dt gate (see tebd_step()'s own comment), so only those
+// are built. ITensor's BondGate computes exp(-i*tau*bondH) via its own
+// Taylor series (bondgate.h, order 100) -- no expm() port needed here.
+struct TebdGates
+    {
+    std::vector<int> odd, even;
+    std::map<int,BondGate> half; // odd bonds, dt/2
+    std::map<int,BondGate> full; // even bonds, dt
+    };
+
+TebdGates
+build_tebd_gates(SiteSet const& sites, std::map<int,ITensor> const& h_bonds, double dt)
+    {
+    int n = sites.length();
+    TebdGates g;
+    for (int b=1; b<n; b+=2) g.odd.push_back(b);
+    for (int b=2; b<n; b+=2) g.even.push_back(b);
+    for (int b : g.odd)
+        g.half.emplace(b,BondGate(sites,b,b+1,BondGate::tReal,dt/2.0,h_bonds.at(b)));
+    for (int b : g.even)
+        g.full.emplace(b,BondGate(sites,b,b+1,BondGate::tReal,dt,h_bonds.at(b)));
+    return g;
+    }
+
+// Contracts `gate` onto bond (b,b+1) and SVD-truncates. Canonicalizes
+// psi's orthogonality center to site b first (position(), the same
+// primitive every other bond-update in this file -- e.g. bond_entropy()
+// above -- uses), which is what makes the local SVD truncation-optimal
+// regardless of which bond was last touched. U is pre-seeded from psi's
+// own (pre-gate) tensor at site b, the same "seed the wanted left/right
+// split via a template ITensor" idiom bond_entropy() already uses above,
+// safe here because the gate's own noPrime() restores site b's physical
+// index to that very same Index object. psi.set() (unlike position()'s
+// own internal orthMPS()/svdBond() sweep helpers) does not update MPS's
+// own l_orth_lim_/r_orth_lim_ orthogonality-center bookkeeping, so it is
+// set explicitly here to (b,b+2) -- the (leftLim,rightLim) convention
+// position() itself uses for a center at site b+1 (confirmed by reading
+// MPS::position()'s own implementation) -- mirroring tebd.py's explicit
+// `psi.center = i+1` after the same U/S*V split. Skipping this left the
+// MPS's ortho-center metadata stuck wherever it was before this call,
+// confirmed directly: MPS::normalize() (called after every tebd_step() in
+// quench_tebd()) aborted with "MPS must have well-defined ortho center to
+// compute norm" without it. Mutates psi in place.
+void
+apply_bond_gate(MPS& psi, int b, BondGate const& gate, double cutoff, int maxdim)
+    {
+    auto args = Args("Cutoff",cutoff,"MaxDim",maxdim);
+    psi.position(b,args);
+    ITensor U = psi.A(b);
+    ITensor theta = noPrime(gate.gate() * (psi.A(b)*psi.A(b+1)));
+    ITensor S,V;
+    svd(theta,U,S,V,args);
+    psi.set(b,U);
+    psi.set(b+1,S*V);
+    psi.leftLim(b);
+    psi.rightLim(b+2);
+    }
+
+// One full step of size dt: exp(-i dt/2 H_odd) exp(-i dt H_even)
+// exp(-i dt/2 H_odd) -- H_odd/H_even being the sums over odd-indexed and
+// even-indexed bonds respectively, each internally commuting since every
+// bond in one group acts on disjoint sites -- mirrors TEBDEvolver.step().
+// Only ever applies the half-dt gate on odd bonds and the full-dt gate on
+// even bonds, matching what build_tebd_gates() above actually builds.
+// Mutates psi in place.
+void
+tebd_step(MPS& psi, TebdGates const& gates, double cutoff, int maxdim)
+    {
+    for (int b : gates.odd) apply_bond_gate(psi,b,gates.half.at(b),cutoff,maxdim);
+    for (int b : gates.even) apply_bond_gate(psi,b,gates.full.at(b),cutoff,maxdim);
+    for (int b : gates.odd) apply_bond_gate(psi,b,gates.half.at(b),cutoff,maxdim);
+    }

--- a/src/dmrgpy/mpscpp3/tebd.h
+++ b/src/dmrgpy/mpscpp3/tebd.h
@@ -86,11 +86,19 @@ bond_hamiltonians(SiteSet const& sites, std::vector<MOTerm> const& terms)
         // is what makes it immune to both of _true_span()'s documented
         // false-positive sources: MultiOperator.identity()'s placeholder
         // "Id" factor, and paired F-string factors that algebraically
-        // cancel to Id).
+        // cancel to Id). The threshold is matched to _true_span()'s own
+        // np.allclose(m,eye) default (atol=1e-8,rtol=1e-5, i.e. an
+        // effective tolerance of ~1e-8 to ~1e-5 depending on entry
+        // magnitude) rather than a tighter one: this is a Frobenius norm
+        // over the whole small (out,in) operator, not an element-wise
+        // check, but staying below Python's own loosest bound keeps a
+        // term that's borderline-touched from being classified
+        // differently (nearest-neighbor vs "reject as long-range")
+        // between the two backends.
         int lo=-1, hi=-1;
         for (int i=1; i<=n; ++i)
             {
-            if (norm(mats[i]-sites.op("Id",i)) > 1E-10)
+            if (norm(mats[i]-sites.op("Id",i)) > 1E-8)
                 {
                 if (lo==-1) lo = i;
                 hi = i;

--- a/src/dmrgpy/timedependent.py
+++ b/src/dmrgpy/timedependent.py
@@ -36,13 +36,17 @@ def evolution_dmrg_DC(self,name="XX",nt=10000,dt=0.1,restart=True,**kwargs):
     minutes at n=12, versus under a second for the same computation on
     v3/"python") that couldn't be root-caused in the time available.
 
-    self.tevol_method="TEBD" instead runs 2nd-order-Trotter TEBD
-    (pyitensor/tebd.py's TEBDEvolver -- gates built once from the bare
-    nearest-neighbor bond Hamiltonians, reused unchanged every step, no
-    per-step Krylov/Lanczos at all) -- itensor_version="python" only (no
-    C++-backend port exists), and only for a strictly nearest-neighbor
-    self.hamiltonian (TEBDEvolver raises NotImplementedError otherwise;
-    fall back to "TDVP" for longer-range models).
+    self.tevol_method="TEBD" instead runs 2nd-order-Trotter TEBD (gates
+    built once from the bare nearest-neighbor bond Hamiltonians, reused
+    unchanged every step, no per-step Krylov/Lanczos at all) --
+    itensor_version=3 or "python" only (itensor_version="python" via
+    pyitensor/tebd.py's TEBDEvolver, itensor_version=3 via
+    mpscpp3/tebd.h's bond_hamiltonians()/build_tebd_gates()/tebd_step(),
+    a C++ port onto ITensor's own BondGate primitive), and only for a
+    strictly nearest-neighbor self.hamiltonian (both backends raise --
+    NotImplementedError in Python, ITError in C++ -- for any term
+    spanning 3+ distinct sites; fall back to "TDVP" for longer-range
+    models).
 
     fit_td is hardcoded False in the MPO fallback, not read from
     self.fit_td: the removed file-based backend wrote it to tasks.in under
@@ -68,7 +72,7 @@ def evolution_dmrg_DC(self,name="XX",nt=10000,dt=0.1,restart=True,**kwargs):
         correlator,_wf = self._session.quench_tdvp(
                 self.hamiltonian.to_terms(),A.to_terms(),B.to_terms(),
                 int(nt),dt)
-    elif self.itensor_version=="python" and self.tevol_method=="TEBD":
+    elif self.itensor_version in (3,"python") and self.tevol_method=="TEBD":
         correlator,_wf = self._session.quench_tebd(
                 self.hamiltonian.to_terms(),A.to_terms(),B.to_terms(),
                 int(nt),dt)
@@ -137,7 +141,7 @@ def evolve_and_measure_dmrg(self,operator=None,nt=1000,h=None,
         correlator,_wf = self._session.evolve_and_measure_tdvp(
                 h.to_terms(),operator.to_terms(),wf.cpp_handle,
                 int(nt),dt)
-    elif self.itensor_version=="python" and self.tevol_method=="TEBD":
+    elif self.itensor_version in (3,"python") and self.tevol_method=="TEBD":
         correlator,_wf = self._session.evolve_and_measure_tebd(
                 h.to_terms(),operator.to_terms(),wf.cpp_handle,
                 int(nt),dt)

--- a/tests/test_time_evolution.py
+++ b/tests/test_time_evolution.py
@@ -118,6 +118,142 @@ def test_tebd_matches_ed_fermion_chain():
     assert np.array(y1) == pytest.approx(np.array(y), abs=1e-4)
 
 
+def test_tebd_v3_matches_ed_spin_chain():
+    """C++ (itensor_version=3) counterpart of test_tebd_matches_ed_spin_chain
+    above, exercising mpscpp3/tebd.h's Chain::evolve_and_measure_tebd()
+    instead of pyitensor/tebd.py's TEBDEvolver -- same setup, same
+    tolerance. Falls back to ED transparently (mode.py) if the v3
+    extension isn't compiled in this checkout, same as any other
+    itensor_version=3 test here."""
+    n = 4
+    spins = [2 for _ in range(n)]  # S=1/2
+    sc = spinchain.Spin_Chain(spins)
+    sc.setup_cpp(version=3)
+    sc.tevol_method = "TEBD"
+
+    h0 = 0
+    for i in range(n):
+        h0 = h0 + (-1) ** i * sc.Sz[i]
+    h1 = 0
+    for i in range(n - 1):
+        h1 = h1 + sc.Sx[i] * sc.Sx[i + 1] + sc.Sy[i] * sc.Sy[i + 1] + sc.Sz[i] * sc.Sz[i + 1]
+
+    sc.set_hamiltonian(h0)
+    wf = sc.get_gs()
+    wfED = sc.get_gs(mode="ED")
+    sc.set_hamiltonian(h1)
+
+    nt, dt = 50, 0.05
+    (_ts, sz) = timedependent.evolve_and_measure(sc, operator=sc.Sz[0], nt=nt, dt=dt, wf=wf)
+    (_tsED, szED) = timedependent.evolve_and_measure(
+            sc, operator=sc.Sz[0], nt=nt, dt=dt, wf=wfED, mode="ED")
+
+    assert np.array(sz).real == pytest.approx(np.array(szED).real, abs=1e-4)
+
+
+def test_tebd_v3_matches_python_fermion_chain():
+    """Cross-backend check for mpscpp3/tebd.h's bond_hamiltonians(): a
+    from-scratch C++ port of pyitensor/autompo.py's HTerm.resolve() (same
+    carried-parity Jordan-Wigner threading, composed via ITensor's own
+    multSiteOps() instead of dense matrix multiplication), so this
+    compares itensor_version=3 directly against itensor_version="python"
+    on a hopping+staggered-onsite Hamiltonian (exercising both the
+    2-site-bond and the onsite-split code paths together) rather than
+    against ED, which is already covered by test_tebd_matches_ed_fermion_chain.
+    Both backends should agree far tighter than the ED tolerance used
+    elsewhere in this file (confirmed ~1e-14 during development)."""
+    n = 5
+
+    def build(fc):
+        h0 = 0
+        h1 = 0
+        for i in range(n):
+            h0 = h0 + (-1) ** i * fc.N[i]
+        for i in range(n - 1):
+            h1 = h1 + fc.Cdag[i] * fc.C[i + 1] + fc.Cdag[i + 1] * fc.C[i]
+        h1 = h1 + 0.3 * sum(fc.N[i] for i in range(n))
+        return h0, h1
+
+    nt, dt = 40, 0.05
+
+    fc3 = fermionchain.Fermionic_Chain(n)
+    fc3.setup_cpp(version=3)
+    fc3.tevol_method = "TEBD"
+    h0_3, h1_3 = build(fc3)
+    fc3.set_hamiltonian(h0_3)
+    wf3 = fc3.get_gs()
+    fc3.set_hamiltonian(h1_3)
+    (_ts3, n2_v3) = timedependent.evolve_and_measure(fc3, operator=fc3.N[2], nt=nt, dt=dt, wf=wf3)
+
+    fcp = fermionchain.Fermionic_Chain(n)
+    fcp.setup_python()
+    fcp.tevol_method = "TEBD"
+    h0_p, h1_p = build(fcp)
+    fcp.set_hamiltonian(h0_p)
+    wfp = fcp.get_gs()
+    fcp.set_hamiltonian(h1_p)
+    (_tsp, n2_py) = timedependent.evolve_and_measure(fcp, operator=fcp.N[2], nt=nt, dt=dt, wf=wfp)
+
+    assert np.array(n2_v3).real == pytest.approx(np.array(n2_py).real, abs=1e-8)
+
+
+def test_tebd_v3_rejects_non_nearest_neighbor_hamiltonian():
+    """C++ counterpart of test_tebd_rejects_non_nearest_neighbor_hamiltonian:
+    mpscpp3/tebd.h's bond_hamiltonians() must raise a catchable RuntimeError
+    (an ITError translated by pybind11, not a process-killing abort() --
+    see chain_session.h's own extensive comment on why every recoverable
+    failure there uses `throw ITError(...)`, never `Error(...)`) for a
+    term spanning 3+ sites, exactly like the Python backend's
+    NotImplementedError."""
+    n = 4
+    fc = fermionchain.Fermionic_Chain(n)
+    fc.setup_cpp(version=3)
+    fc.tevol_method = "TEBD"
+
+    h = fc.Cdag[0] * fc.C[2]
+    h = h + h.get_dagger()
+    fc.set_hamiltonian(h)
+
+    with pytest.raises(RuntimeError):
+        timedependent.evolution_ABA(fc, nt=5, dt=0.05, mode="DMRG", A=fc.Cdag[0], B=fc.N[0])
+
+
+def test_tebd_v3_dynamical_correlator_matches_python_spin_chain():
+    """C++ counterpart of test_tebd_dynamical_correlator_matches_ed_spin_chain,
+    exercising Chain::quench_tebd() (the ground-state-energy-shift +
+    two-state-overlap path, distinct from evolve_and_measure_tebd() above)
+    -- compared against itensor_version="python" directly, matching
+    test_tebd_v3_matches_python_fermion_chain's rationale."""
+    n = 4
+    spins = [2 for _ in range(n)]
+
+    sc3 = spinchain.Spin_Chain(spins)
+    sc3.setup_cpp(version=3)
+    sc3.tevol_method = "TEBD"
+    h = 0
+    for i in range(n - 1):
+        h = h + sc3.Sx[i]*sc3.Sx[i+1] + sc3.Sy[i]*sc3.Sy[i+1] + sc3.Sz[i]*sc3.Sz[i+1]
+    sc3.set_hamiltonian(h)
+
+    scp = spinchain.Spin_Chain(spins)
+    scp.setup_python()
+    scp.tevol_method = "TEBD"
+    hp = 0
+    for i in range(n - 1):
+        hp = hp + scp.Sx[i]*scp.Sx[i+1] + scp.Sy[i]*scp.Sy[i+1] + scp.Sz[i]*scp.Sz[i+1]
+    scp.set_hamiltonian(hp)
+
+    nt, dt = 60, 0.05
+    sc3.get_gs()
+    scp.get_gs()
+    name3 = (sc3.Sz[0], sc3.Sz[0])
+    namep = (scp.Sz[0], scp.Sz[0])
+    (_ts3, cs3) = timedependent.evolution_DC(sc3, mode="DMRG", name=name3, nt=nt, dt=dt)
+    (_tsp, csp) = timedependent.evolution_DC(scp, mode="DMRG", name=namep, nt=nt, dt=dt)
+
+    assert np.array(cs3) == pytest.approx(np.array(csp), abs=1e-8)
+
+
 def test_tebd_rejects_non_nearest_neighbor_hamiltonian():
     """bond_hamiltonians() must fail loudly, not silently drop the
     long-range piece, when the Hamiltonian isn't strictly nearest-


### PR DESCRIPTION
## Summary
- Adds `Chain::quench_tebd()`/`evolve_and_measure_tebd()` to the ITensor v3 (`mpscpp3`) backend (`mpscpp3/tebd.h` + `chain_session.h` + `bindings.cc`), giving `itensor_version=3` the same `tevol_method="TEBD"` option the pure-Python (`pyitensor`) backend already has (#107).
- `bond_hamiltonians()` ports `pyitensor/autompo.py`'s `HTerm.resolve()` (same carried-parity Jordan-Wigner threading, same per-site factor composition order) directly against real ITensor v3 site operators, composing same-site factors via ITensor's own `multSiteOps()` primitive. A probe against real ITensor v3 showed a single, unsummed `HTerm` does **not** compile to a bond-dimension-1 MPO (a bare one-site term already comes out with uniform bond dimension 2 everywhere), ruling out the cheaper "extract the term's operator from a compiled single-term MPO" approach used by other bond-dimension-1-only tricks elsewhere in this file.
- Each bond's evolution gate is built via ITensor's own `BondGate` primitive (`itensor/mps/bondgate.h`) — no `expm()` port needed.
- Found and fixed a second, real bug along the way: gate application mutates the MPS's site tensors via `set()` but never updates its `l_orth_lim_`/`r_orth_lim_` orthogonality-center bookkeeping the way `position()`'s own sweep helpers do — mirrors `pyitensor`'s explicit `psi.center = i+1` after the same U/S·V split. Without it, `MPS::normalize()` (called after every step in `quench_tebd()`) aborted with "MPS must have well-defined ortho center".

## Test plan
- [x] `python3 -m pytest tests/test_time_evolution.py -v` — 12/12 passed, including 4 new `itensor_version=3` tests mirroring the existing pure-Python TEBD coverage (ED cross-check, cross-backend agreement, long-range rejection, dynamical-correlator quench path).
- [x] Full suite: `python3 run_tests.py` — 317 passed, 11 skipped (pre-existing, unrelated).
- [x] Manual validation: v3 TEBD vs ED on a spin chain (~8e-5, expected Trotter error); v3 TEBD vs pyitensor TEBD on a fermion hopping+onsite chain (~1e-14, essentially exact — confirms Jordan-Wigner threading and onsite-splitting match); `quench_tebd` (dynamical-correlator path) v3 vs pyitensor (~4e-13); a genuinely long-range term raises a catchable `RuntimeError` instead of aborting.
- [x] `docs/user_guide.{md,tex}` and `docs/documentation.{md,tex}` updated; both `.tex` files verified to compile cleanly with `pdflatex` (no errors, no new overfull-hbox warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nAcUcJBNGxPFumMcVA2Kx