### PR TITLE
Document all DMRG backends in README; fix stale v2-default claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ every build requirement -- OS, `make`, a C++ compiler, LAPACK/BLAS,
 checking a version string), and only once everything checks out does
 `installtk/install2.py` compile the vendored ITensor static library and
 the `pybind` Makefile target for whichever backend(s) `--itensor-version`
-selects (`2` = mpscpp2/ITensor v2, the default; `3` = mpscpp3/ITensor v3;
+selects (`2` = mpscpp2/ITensor v2; `3` = mpscpp3/ITensor v3, the default;
 `both` builds both, one after the other).`install2.py` picks the right
 `mpscppN` directory and C++ language standard per version (v2 needs only
 C++14; v3 needs C++17 with the concepts TS extension, `-fconcepts`, see
@@ -224,12 +224,17 @@ public methods on `Many_Body_Chain` accept a `mode="DMRG"|"ED"` kwarg so
 results can be cross-validated between solvers (see the
 bilinear-biquadratic example in `README.md`).
 
-- **DMRG, C++ (`itensor_version=2` (the default) or `itensor_version=3`)**:
+- **DMRG, C++ (`itensor_version=2` or `itensor_version=3` (the default))**:
   entirely in-process, see "In-process pybind11 extension" below. Both
   versions expose the identical `Chain` session API and public
   `Many_Body_Chain` surface — `itensor_version` only picks which compiled
   extension (`mpscpp2._dmrgcpp` vs `mpscpp3._dmrgcpp`, via
   `cppext.get_backend(version)`) backs `self._session`.
+  `cppext.DEFAULT_ITENSOR_VERSION` (currently `3`) is the single source of
+  truth for the default, threaded through `Many_Body_Chain.__init__`,
+  `setup_cpp()`, `get_backend()`/`available()`, and `install.py`'s own
+  `--itensor-version` default (`installtk/__init__.py`'s matching
+  constant) — change it there, not per call site.
   `Many_Body_Chain.setup_cpp(version=2)` switches an existing chain
   between them. There is no file-based/subprocess fallback for either —
   if the requested extension isn't compiled, `mode.py` routes to ED

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 This is a Python library to compute quasi-one-dimensional
 spin chains and fermionic systems using matrix product states
 with the density matrix renormalization group as implemented in ITensor
-(C++ and Julia versions). Most
+(C++ v2/v3, Julia, or a pure-Python/NumPy reimplementation that needs
+no compiler -- see "Choosing a backend" below). Most
 of the computations can be performed both with DMRG and exact
 diagonalization for small systems, which allows to benchmark the
 results.
@@ -125,7 +126,7 @@ You can find several tutorials [here](https://github.com/joselado/Advanced_Compu
 - Excitation energies
 - Excited wavefunctions
 - Arbitrary expectation values, including static correlation functions
-- Time evolution of arbitrary states
+- Time evolution of arbitrary states, with TDVP, TEBD or a Taylor-expanded evolution operator
 - MPS algebra: sum of MPS, application of operators, exponential and inverse
 - MPO algebra: sums, products, trace, trace of inverse for generic operators
 - Dynamical correlation functions computed with the Kernel polynomial method
@@ -505,19 +506,48 @@ print("GS energy with DMRG",fc.gs_energy(mode="DMRG")) # energy with DMRG
 ```
 
 
-# Choosing between the C++ and Julia backend #
-The library uses ITensor in the background. Currently dmrgpy allows to 
-choose between
-ITensor2 (C++), or ITensors (Julia). The default version executed is
-the the C++ v2 version, if you want to instead use the Julia version
-execute the method ".setup_julia()", for example
+# Choosing a backend #
+The library uses ITensor in the background, and exposes the same
+public API regardless of which backend actually runs the calculation.
+Available backends are
+
+- **ITensor v3 (C++)**, the default, compiled by `python install.py`.
+  An in-process pybind11 extension. Real-time evolution defaults to
+  TDVP (`tevol_method="TDVP"`), with TEBD (`tevol_method="TEBD"`) also
+  available.
+- **ITensor v2 (C++)**, compiled with `python install.py
+  --itensor-version=2` (or `--itensor-version=both` to build v2 and v3
+  together). Real-time evolution uses a Taylor-expanded
+  evolution-operator MPO instead (no TDVP/TEBD support).
+- **Pure Python** (`pyitensor`), a from-scratch NumPy/SciPy
+  reimplementation of the ITensor v3 API subset dmrgpy needs --
+  ground/excited-state DMRG, TDVP and TEBD time evolution, KPM dynamical
+  correlators, METTS, and more. Needs no C++ compiler or compiled
+  extension at all, at the cost of being slower than the compiled
+  backends.
+- **Julia (ITensors.jl)**, a live in-process Julia session, set up with
+  `python install_julia.py` instead of `install.py`.
+- **Exact diagonalization (ED)**, a pure Python/NumPy/SciPy fallback.
+  Used automatically for small systems, and automatically in place of
+  any C++/Julia backend that isn't available (e.g. its extension
+  wasn't compiled), so a script keeps running -- just slower -- even
+  without a full build.
+
+The default backend is ITensor v3 (C++). Switch an existing chain to
+another one with `.setup_cpp(version=2)`, `.setup_python()` or
+`.setup_julia()`, for example
 
 ```python
 from dmrgpy import spinchain
 spins = ["S=1/2" for i in range(30)] # spins in each site
 sc = spinchain.Spin_Chain(spins) # create spin chain object
-sc.setup_julia()
+sc.setup_cpp(version=2) # switch to ITensor v2 (C++)
+# sc.setup_python()     # or: pure Python, no compiler needed
+# sc.setup_julia()      # or: ITensors.jl (Julia)
 ```
 
-and all the subsequent computations will be performed with Julia.
+and all subsequent computations on `sc` will be performed with that
+backend. Most methods also accept a `mode="DMRG"|"ED"` kwarg to
+cross-check a single call against ED without switching the chain's
+backend, for example `sc.gs_energy(mode="ED")`.
 


### PR DESCRIPTION
## Summary
- README's "Choosing a backend" section only described C++ v2 vs Julia; expand it to cover ITensor v3, the pure-Python `pyitensor` backend, and the automatic ED fallback, matching what `manybodychain.py`/`cppext.py` actually support.
- Fix stale "ITensor v2 is the default" claims in README and CLAUDE.md — the default was changed to v3 back in `af779a9` ("Make ITensor v3 the default DMRG backend"), already reflected correctly in `docs/documentation.md`/`docs/user_guide.md`, but not in these two files.

## Test plan
- [x] Docs-only change; read through the new README section for consistency with `cppext.py`'s `DEFAULT_ITENSOR_VERSION` and `install.py`'s `--itensor-version` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nAcUcJBNGxPFumMcVA2Kx